### PR TITLE
Add basic Vitest setup and router test

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,10 @@
         "unplugin-auto-import": "^19.1.2",
         "unplugin-vue-components": "^28.4.1",
         "vite": "^6.2.4",
-        "vite-plugin-vue-devtools": "^7.7.2"
+        "vite-plugin-vue-devtools": "^7.7.2",
+        "vitest": "^1.5.0",
+        "@vue/test-utils": "^2.4.3",
+        "jsdom": "^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "element": "^0.1.4",
@@ -21,6 +22,9 @@
     "unplugin-auto-import": "^19.1.2",
     "unplugin-vue-components": "^28.4.1",
     "vite": "^6.2.4",
-    "vite-plugin-vue-devtools": "^7.7.2"
+    "vite-plugin-vue-devtools": "^7.7.2",
+    "vitest": "^1.5.0",
+    "@vue/test-utils": "^2.4.3",
+    "jsdom": "^24.0.0"
   }
 }

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import router from '../src/router/index.js'
+
+describe('router', () => {
+  it('loads routes without error', () => {
+    expect(() => router.getRoutes()).not.toThrow()
+  })
+})

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,4 +15,7 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  test: {
+    environment: 'jsdom'
+  }
 })


### PR DESCRIPTION
## Summary
- add Vitest, jsdom, and @vue/test-utils dev dependencies
- configure testing environment in vite.config.js
- provide basic router spec
- expose `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*