### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          cd client
+          npm install
+      - name: Run tests
+        run: |
+          cd client
+          npm test
+  server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          cd server
+          npm install
+      - name: Run tests
+        run: |
+          cd server
+          npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to install and test `client/` and `server/`

## Testing
- `npm test` in `server` *(fails: missing script)*
- `npm test --silent` in `client` *(fails: vitest not found)*