### PR TITLE
Add Swagger docs with new API routes

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -17,3 +17,11 @@ npm run dev
 ```
 
 This starts the server with nodemon enabled.
+
+## API Documentation
+
+After starting the server, Swagger UI is available at:
+
+```
+http://localhost:3000/api-docs
+```

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "express": "^4.18.4",
     "dotenv": "^16.3.1",
-    "mongoose": "^7.6.1"
+    "mongoose": "^7.6.1",
+    "swagger-ui-express": "^4.6.3",
+    "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/server/src/controllers/leaveController.js
+++ b/server/src/controllers/leaveController.js
@@ -1,0 +1,16 @@
+import Leave from '../models/Leave.js';
+
+export async function listLeaves(req, res) {
+  const leaves = await Leave.find().populate('employee');
+  res.json(leaves);
+}
+
+export async function createLeave(req, res) {
+  try {
+    const leave = new Leave(req.body);
+    await leave.save();
+    res.status(201).json(leave);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -1,0 +1,16 @@
+import Schedule from '../models/Schedule.js';
+
+export async function listSchedules(req, res) {
+  const schedules = await Schedule.find().populate('employee');
+  res.json(schedules);
+}
+
+export async function createSchedule(req, res) {
+  try {
+    const schedule = new Schedule(req.body);
+    await schedule.save();
+    res.status(201).json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,6 +3,10 @@ import dotenv from 'dotenv';
 import { connectDB } from './config/db.js';
 import employeeRoutes from './routes/employeeRoutes.js';
 import attendanceRoutes from './routes/attendanceRoutes.js';
+import leaveRoutes from './routes/leaveRoutes.js';
+import scheduleRoutes from './routes/scheduleRoutes.js';
+import swaggerUi from 'swagger-ui-express';
+import swaggerDocument from './swagger.js';
 
 dotenv.config();
 
@@ -17,6 +21,9 @@ app.get('/api/health', (req, res) => {
 
 app.use('/api/employees', employeeRoutes);
 app.use('/api/attendance', attendanceRoutes);
+app.use('/api/leaves', leaveRoutes);
+app.use('/api/schedules', scheduleRoutes);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 connectDB(process.env.MONGODB_URI || 'mongodb://localhost/hr');
 

--- a/server/src/models/Leave.js
+++ b/server/src/models/Leave.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const leaveSchema = new mongoose.Schema({
+  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
+  startDate: { type: Date, required: true },
+  endDate: { type: Date, required: true },
+  type: { type: String, enum: ['vacation', 'sick', 'unpaid'], default: 'vacation' },
+  status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' }
+}, { timestamps: true });
+
+export default mongoose.model('Leave', leaveSchema);

--- a/server/src/models/Schedule.js
+++ b/server/src/models/Schedule.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const scheduleSchema = new mongoose.Schema({
+  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
+  date: { type: Date, required: true },
+  shift: { type: String, enum: ['morning', 'evening', 'night'], default: 'morning' }
+}, { timestamps: true });
+
+export default mongoose.model('Schedule', scheduleSchema);

--- a/server/src/routes/leaveRoutes.js
+++ b/server/src/routes/leaveRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listLeaves, createLeave } from '../controllers/leaveController.js';
+
+const router = Router();
+
+router.get('/', listLeaves);
+router.post('/', createLeave);
+
+export default router;

--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listSchedules, createSchedule } from '../controllers/scheduleController.js';
+
+const router = Router();
+
+router.get('/', listSchedules);
+router.post('/', createSchedule);
+
+export default router;

--- a/server/src/swagger.js
+++ b/server/src/swagger.js
@@ -1,0 +1,213 @@
+export default {
+  openapi: '3.0.0',
+  info: {
+    title: 'HR System API',
+    version: '1.0.0'
+  },
+  paths: {
+    '/api/employees': {
+      get: {
+        summary: 'List employees',
+        responses: {
+          '200': {
+            description: 'A list of employees',
+            content: {
+              'application/json': {
+                example: [{
+                  _id: '650000000000000000000000',
+                  name: 'John Doe',
+                  email: 'john@example.com',
+                  role: 'employee'
+                }]
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create employee',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              example: {
+                name: 'Jane Doe',
+                email: 'jane@example.com',
+                role: 'employee'
+              }
+            }
+          }
+        },
+        responses: {
+          '201': {
+            description: 'Created employee',
+            content: {
+              'application/json': {
+                example: {
+                  _id: '650000000000000000000001',
+                  name: 'Jane Doe',
+                  email: 'jane@example.com',
+                  role: 'employee'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/attendance': {
+      get: {
+        summary: 'List attendance records',
+        responses: {
+          '200': {
+            description: 'A list of attendance records',
+            content: {
+              'application/json': {
+                example: [{
+                  _id: '660000000000000000000000',
+                  employee: '650000000000000000000000',
+                  action: 'clockIn',
+                  timestamp: '2024-01-01T08:00:00Z'
+                }]
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create attendance record',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              example: {
+                employee: '650000000000000000000000',
+                action: 'clockIn'
+              }
+            }
+          }
+        },
+        responses: {
+          '201': {
+            description: 'Created record',
+            content: {
+              'application/json': {
+                example: {
+                  _id: '660000000000000000000001',
+                  employee: '650000000000000000000000',
+                  action: 'clockIn',
+                  timestamp: '2024-01-01T08:00:00Z'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/leaves': {
+      get: {
+        summary: 'List leaves',
+        responses: {
+          '200': {
+            description: 'A list of leave requests',
+            content: {
+              'application/json': {
+                example: [{
+                  _id: '670000000000000000000000',
+                  employee: '650000000000000000000000',
+                  startDate: '2024-02-01',
+                  endDate: '2024-02-05',
+                  type: 'vacation',
+                  status: 'pending'
+                }]
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create leave',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              example: {
+                employee: '650000000000000000000000',
+                startDate: '2024-02-01',
+                endDate: '2024-02-05',
+                type: 'vacation'
+              }
+            }
+          }
+        },
+        responses: {
+          '201': {
+            description: 'Created leave',
+            content: {
+              'application/json': {
+                example: {
+                  _id: '670000000000000000000001',
+                  employee: '650000000000000000000000',
+                  startDate: '2024-02-01',
+                  endDate: '2024-02-05',
+                  type: 'vacation',
+                  status: 'pending'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/schedules': {
+      get: {
+        summary: 'List schedules',
+        responses: {
+          '200': {
+            description: 'A list of schedules',
+            content: {
+              'application/json': {
+                example: [{
+                  _id: '680000000000000000000000',
+                  employee: '650000000000000000000000',
+                  date: '2024-03-01',
+                  shift: 'morning'
+                }]
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create schedule',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              example: {
+                employee: '650000000000000000000000',
+                date: '2024-03-01',
+                shift: 'morning'
+              }
+            }
+          }
+        },
+        responses: {
+          '201': {
+            description: 'Created schedule',
+            content: {
+              'application/json': {
+                example: {
+                  _id: '680000000000000000000001',
+                  employee: '650000000000000000000000',
+                  date: '2024-03-01',
+                  shift: 'morning'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add Swagger setup and docs
- create Leave and Schedule models with controllers and routes
- expose new endpoints and swagger UI in server
- link API documentation in README

## Testing
- `npm test` *(fails: vitest not found)*