### PR TITLE
Add JWT auth with user model

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -107,17 +107,16 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   // 簡易示範: 後台 requiresAuth
   if (to.meta.requiresAuth) {
-    const isAuthenticated = localStorage.getItem('isAuthenticated') === 'true'
-    if (!isAuthenticated) {
+    const token = localStorage.getItem('token')
+    if (!token) {
       return next({ name: 'Login' })
     }
   }
 
   // 若要檢查前台也需登入
   if (to.meta.frontRequiresAuth) {
-    // 例如: 檢查 localStorage 是否有 role
-    const frontRole = localStorage.getItem('role')
-    if (!frontRole) {
+    const token = localStorage.getItem('token')
+    if (!token) {
       return next({ name: 'FrontLogin' })
     }
   }
@@ -125,9 +124,7 @@ router.beforeEach((to, from, next) => {
   // 若有角色限制 meta.roles
   if (to.meta.roles) {
     const userRole = localStorage.getItem('role') || 'employee'
-    // 若不包含於 roles array，就跳 403 or 其他處理
     if (!to.meta.roles.includes(userRole)) {
-      // 這裡可 next('/403') 或者 next('/front/attendance') etc.
       return next('/403')
     }
   }

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -37,11 +37,20 @@
   
   const loginFormRef = ref(null)
   
-  const onLogin = () => {
-    // 這邊可以加上帳密判斷邏輯
-    // 如果帳號密碼正確，則紀錄登入狀態
-    localStorage.setItem('isAuthenticated', 'true')
-    router.push({ name: 'Settings' }) // 登入後直接導向設定頁
+  const onLogin = async () => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(loginForm.value)
+    })
+    if (res.ok) {
+      const data = await res.json()
+      localStorage.setItem('token', data.token)
+      localStorage.setItem('role', data.user.role)
+      router.push({ name: 'Settings' })
+    } else {
+      alert('登入失敗')
+    }
   }
   </script>
   

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -46,14 +46,18 @@
   })
   const loginFormRef = ref(null)
   
-  function onLogin () {
-    // 1. 將角色與登入狀態儲存
-    localStorage.setItem('role', loginForm.value.role)
-    localStorage.setItem('isAuthenticated', 'true')
-    localStorage.setItem('username', loginForm.value.username)
-  
-    // 2. 依角色跳不同頁面
-    switch (loginForm.value.role) {
+async function onLogin () {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: loginForm.value.username, password: loginForm.value.password })
+  })
+  if (res.ok) {
+    const data = await res.json()
+    localStorage.setItem('token', data.token)
+    localStorage.setItem('role', data.user.role)
+
+    switch (data.user.role) {
       case 'employee':
         router.push('/front/attendance')
         break
@@ -61,23 +65,19 @@
         router.push('/front/schedule')
         break
       case 'hr':
-        // 你可以讓 HR 也去 /front/schedule 或 /front/attendance
         router.push('/front/attendance')
         break
       case 'admin':
-        // 若要讓 admin 走後台，可 push('/layout')
-        // 或若要讓 admin 測試前台某頁，也可:
         router.push('/front/attendance')
         break
       default:
-        // 若角色莫名無法對應，就導回 /front/attendance
         router.push('/front/attendance')
         break
     }
-  
-    // 3. 可選: alert 提示
-    alert(`以【${loginForm.value.role}】身份登入成功！(示範)`)
+  } else {
+    alert('登入失敗')
   }
+}
   </script>
   
   <style scoped>

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "express": "^4.18.4",
     "dotenv": "^16.3.1",
-    "mongoose": "^7.6.1"
+    "mongoose": "^7.6.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,6 +3,8 @@ import dotenv from 'dotenv';
 import { connectDB } from './config/db.js';
 import employeeRoutes from './routes/employeeRoutes.js';
 import attendanceRoutes from './routes/attendanceRoutes.js';
+import authRoutes from './routes/authRoutes.js';
+import { authenticate, authorizeRoles } from './middleware/auth.js';
 
 dotenv.config();
 
@@ -15,8 +17,9 @@ app.get('/api/health', (req, res) => {
   res.json({ status: 'OK' });
 });
 
-app.use('/api/employees', employeeRoutes);
-app.use('/api/attendance', attendanceRoutes);
+app.use('/api', authRoutes);
+app.use('/api/employees', authenticate, authorizeRoles('admin', 'hr'), employeeRoutes);
+app.use('/api/attendance', authenticate, authorizeRoles('employee', 'supervisor', 'hr', 'admin'), attendanceRoutes);
 
 connectDB(process.env.MONGODB_URI || 'mongodb://localhost/hr');
 

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,0 +1,24 @@
+import jwt from 'jsonwebtoken';
+
+export function authenticate(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'No token' });
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+export function authorizeRoles(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+import bcrypt from 'bcryptjs';
+
+const userSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: {
+    type: String,
+    enum: ['employee', 'supervisor', 'hr', 'admin'],
+    default: 'employee'
+  }
+}, { timestamps: true });
+
+userSchema.pre('save', async function(next) {
+  if (!this.isModified('password')) return next();
+  try {
+    const salt = await bcrypt.genSalt(10);
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+userSchema.methods.comparePassword = function(candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+export default mongoose.model('User', userSchema);

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = Router();
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = await User.findOne({ username });
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+
+  const match = await user.comparePassword(password);
+  if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+
+  const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+  res.json({ token, user: { id: user._id, role: user.role, username: user.username } });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add bcryptjs and jsonwebtoken dependencies for backend
- create User model with hashed passwords
- add /api/login route issuing JWT
- add auth middleware and secure routes
- update login views to use JWT tokens
- adjust router guard to check token

## Testing
- `npx vitest --run --dir client` *(fails: request to https://registry.npmjs.org/vitest failed)*