### PR TITLE
Add API and component tests

### DIFF
--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FrontLogin from '../src/views/front/FrontLogin.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+describe('FrontLogin.vue', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('stores role on login', async () => {
+    const wrapper = mount(FrontLogin)
+    await wrapper.find('button').trigger('click')
+    expect(localStorage.getItem('role')).toBe('employee')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hr-system-root",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix server test && npm --prefix client test"
+  }
+}

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "express": "^4.18.4",
@@ -13,6 +14,9 @@
     "mongoose": "^7.6.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.3"
+    "nodemon": "^3.0.3",
+    "jest": "^29.7.0",
+    "supertest": "^6.4.2",
+    "@jest/globals": "^29.7.0"
   }
 }

--- a/server/tests/attendance.test.js
+++ b/server/tests/attendance.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const AttendanceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+AttendanceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+
+jest.mock('../src/models/AttendanceRecord.js', () => ({ default: AttendanceRecord }), { virtual: true });
+
+let app;
+let attendanceRoutes;
+
+beforeAll(async () => {
+  attendanceRoutes = (await import('../src/routes/attendanceRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/attendance', attendanceRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  AttendanceRecord.find.mockReset();
+});
+
+describe('Attendance API', () => {
+  it('lists records', async () => {
+    const fakeRecords = [{ action: 'clockIn' }];
+    AttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    const res = await request(app).get('/api/attendance');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeRecords);
+  });
+
+  it('creates record', async () => {
+    const payload = { action: 'clockIn' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/attendance').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const Employee = jest.fn().mockImplementation(() => ({ save: saveMock }));
+Employee.find = jest.fn();
+
+jest.mock('../src/models/Employee.js', () => ({ default: Employee }), { virtual: true });
+
+let app;
+let employeeRoutes;
+
+beforeAll(async () => {
+  employeeRoutes = (await import('../src/routes/employeeRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/employees', employeeRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  Employee.find.mockReset();
+});
+
+describe('Employee API', () => {
+  it('lists employees', async () => {
+    const fakeEmployees = [{ name: 'John' }];
+    Employee.find.mockResolvedValue(fakeEmployees);
+    const res = await request(app).get('/api/employees');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeEmployees);
+  });
+
+  it('creates employee', async () => {
+    const newEmp = { name: 'Jane' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/employees').send(newEmp);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(newEmp);
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest config in `server`
- add Supertest API tests for employee and attendance endpoints
- add Vue component test for `FrontLogin` using Vitest
- add root `package.json` with combined test script
- update server `package.json` to include Jest and Supertest

## Testing
- `npm test` *(fails: `jest: not found`)*