### PR TITLE
Expand HR modules and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each part has its own README with full instructions. Below is a quick overview.
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and adjust the `PORT` and `MONGODB_URI` values.
+2. Copy `.env.example` to `.env` and set `PORT`, `MONGODB_URI` and optionally `JWT_SECRET`.
 3. Start the development server with nodemon:
    ```bash
    npm run dev

--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -31,33 +31,56 @@
     </div>
   </template>
   
-  <script setup>
-  import { ref } from 'vue'
-  import dayjs from 'dayjs'
-  
-  const records = ref([])
-  
-  // 模擬按鈕事件
-  function onClockIn() {
-    addRecord('上班簽到')
+<script setup>
+import { ref, onMounted } from 'vue'
+import dayjs from 'dayjs'
+
+const records = ref([])
+const token = localStorage.getItem('token') || ''
+
+async function fetchRecords() {
+  const res = await fetch('/api/attendance', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    records.value = await res.json()
   }
-  function onClockOut() {
-    addRecord('下班簽退')
-  }
-  function onOuting() {
-    addRecord('外出登記')
-  }
-  function onBreakIn() {
-    addRecord('中午休息')
-  }
-  
-  function addRecord(action) {
+}
+
+function onClockIn() {
+  addRecord('上班簽到')
+}
+function onClockOut() {
+  addRecord('下班簽退')
+}
+function onOuting() {
+  addRecord('外出登記')
+}
+function onBreakIn() {
+  addRecord('中午休息')
+}
+
+async function addRecord(action) {
+  const payload = { action, time: new Date(), remark: '' }
+  const res = await fetch('/api/attendance', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(payload)
+  })
+  if (res.ok) {
+    const saved = await res.json()
     records.value.push({
-      action,
-      time: dayjs().format('YYYY-MM-DD HH:mm:ss'),
-      remark: '示範紀錄'
+      action: saved.action,
+      time: dayjs(saved.time).format('YYYY-MM-DD HH:mm:ss'),
+      remark: saved.remark || ''
     })
   }
+}
+
+onMounted(fetchRecords)
   </script>
   
   <style scoped>

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -82,6 +82,7 @@ function onLogout() {
   localStorage.removeItem("role");
   localStorage.removeItem("isAuthenticated");
   localStorage.removeItem("username");
+  localStorage.removeItem("token");
   // 回到前台登入
   router.push({ name: "FrontLogin" });
 }

--- a/client/src/views/front/Leave.vue
+++ b/client/src/views/front/Leave.vue
@@ -71,8 +71,12 @@ import dayjs from 'dayjs'
   
 const leaveRecords = ref([])
 
+const token = localStorage.getItem('token') || ''
+
 async function fetchLeaves() {
-  const res = await fetch('/api/leaves')
+  const res = await fetch('/api/leaves', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
   if (res.ok) {
     leaveRecords.value = await res.json()
   }
@@ -88,7 +92,10 @@ async function onSubmitLeave() {
   }
   const res = await fetch('/api/leaves', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
     body: JSON.stringify(payload)
   })
   if (res.ok) {

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -33,9 +33,12 @@
 
   const schedules = ref([])
   const scheduleForm = ref({ date: '', shiftType: '' })
+  const token = localStorage.getItem('token') || ''
 
   async function fetchSchedules() {
-    const res = await fetch('/api/schedules')
+    const res = await fetch('/api/schedules', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
     if (res.ok) {
       schedules.value = await res.json()
     }
@@ -49,7 +52,10 @@
     }
     const res = await fetch('/api/schedules', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
       body: JSON.stringify(payload)
     })
     if (res.ok) {

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,3 @@
 PORT=3000
 MONGODB_URI=mongodb://localhost/hr
+JWT_SECRET=your_jwt_secret

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,17 @@ This directory contains the Express backend for the HR system.
 npm install
 ```
 
-Create a `.env` file based on `.env.example` and set the `PORT` and MongoDB connection string `MONGODB_URI`.
+Create a `.env` file based on `.env.example` and set the following variables:
+
+- `PORT` – port for the HTTP server
+- `MONGODB_URI` – MongoDB connection string
+- `JWT_SECRET` – (optional) secret used to sign JSON Web Tokens
+
+To run the unit tests:
+
+```bash
+npm test
+```
 
 ## Development
 
@@ -17,3 +27,11 @@ npm run dev
 ```
 
 This starts the server with nodemon enabled.
+
+### Seeding example data
+
+You can create a script under `scripts/seed.js` to insert initial users or reference data into MongoDB. Run it with:
+
+```bash
+node scripts/seed.js
+```

--- a/server/package.json
+++ b/server/package.json
@@ -13,8 +13,8 @@
     "dotenv": "^16.3.1",
     "mongoose": "^7.6.1",
     "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.0"
-    "express": "^4.18.4",    
+    "jsonwebtoken": "^9.0.0",
+    "express": "^4.18.4"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/server/src/controllers/insuranceController.js
+++ b/server/src/controllers/insuranceController.js
@@ -1,0 +1,46 @@
+import InsuranceRecord from '../models/InsuranceRecord.js';
+
+export async function listInsurance(req, res) {
+  const records = await InsuranceRecord.find().populate('employee');
+  res.json(records);
+}
+
+export async function createInsurance(req, res) {
+  try {
+    const record = new InsuranceRecord(req.body);
+    await record.save();
+    res.status(201).json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getInsurance(req, res) {
+  try {
+    const record = await InsuranceRecord.findById(req.params.id).populate('employee');
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateInsurance(req, res) {
+  try {
+    const record = await InsuranceRecord.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteInsurance(req, res) {
+  try {
+    const record = await InsuranceRecord.findByIdAndDelete(req.params.id);
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/leaveController.js
+++ b/server/src/controllers/leaveController.js
@@ -14,3 +14,33 @@ export async function createLeave(req, res) {
     res.status(400).json({ error: err.message });
   }
 }
+
+export async function getLeave(req, res) {
+  try {
+    const leave = await LeaveRequest.findById(req.params.id).populate('employee');
+    if (!leave) return res.status(404).json({ error: 'Not found' });
+    res.json(leave);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateLeave(req, res) {
+  try {
+    const leave = await LeaveRequest.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!leave) return res.status(404).json({ error: 'Not found' });
+    res.json(leave);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteLeave(req, res) {
+  try {
+    const leave = await LeaveRequest.findByIdAndDelete(req.params.id);
+    if (!leave) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/payrollController.js
+++ b/server/src/controllers/payrollController.js
@@ -1,0 +1,46 @@
+import PayrollRecord from '../models/PayrollRecord.js';
+
+export async function listPayrolls(req, res) {
+  const records = await PayrollRecord.find().populate('employee');
+  res.json(records);
+}
+
+export async function createPayroll(req, res) {
+  try {
+    const record = new PayrollRecord(req.body);
+    await record.save();
+    res.status(201).json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getPayroll(req, res) {
+  try {
+    const record = await PayrollRecord.findById(req.params.id).populate('employee');
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updatePayroll(req, res) {
+  try {
+    const record = await PayrollRecord.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deletePayroll(req, res) {
+  try {
+    const record = await PayrollRecord.findByIdAndDelete(req.params.id);
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/reportController.js
+++ b/server/src/controllers/reportController.js
@@ -1,0 +1,46 @@
+import Report from '../models/Report.js';
+
+export async function listReports(req, res) {
+  const reports = await Report.find();
+  res.json(reports);
+}
+
+export async function createReport(req, res) {
+  try {
+    const report = new Report(req.body);
+    await report.save();
+    res.status(201).json(report);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getReport(req, res) {
+  try {
+    const report = await Report.findById(req.params.id);
+    if (!report) return res.status(404).json({ error: 'Not found' });
+    res.json(report);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateReport(req, res) {
+  try {
+    const report = await Report.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!report) return res.status(404).json({ error: 'Not found' });
+    res.json(report);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteReport(req, res) {
+  try {
+    const report = await Report.findByIdAndDelete(req.params.id);
+    if (!report) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -14,3 +14,33 @@ export async function createSchedule(req, res) {
     res.status(400).json({ error: err.message });
   }
 }
+
+export async function getSchedule(req, res) {
+  try {
+    const schedule = await ShiftSchedule.findById(req.params.id).populate('employee');
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateSchedule(req, res) {
+  try {
+    const schedule = await ShiftSchedule.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteSchedule(req, res) {
+  try {
+    const schedule = await ShiftSchedule.findByIdAndDelete(req.params.id);
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,9 @@ import authRoutes from './routes/authRoutes.js';
 import { authenticate, authorizeRoles } from './middleware/auth.js';
 import leaveRoutes from './routes/leaveRoutes.js';
 import scheduleRoutes from './routes/scheduleRoutes.js';
+import payrollRoutes from './routes/payrollRoutes.js';
+import reportRoutes from './routes/reportRoutes.js';
+import insuranceRoutes from './routes/insuranceRoutes.js';
 
 dotenv.config();
 
@@ -34,8 +37,11 @@ app.use('/api/employees', authenticate, authorizeRoles('admin', 'hr'), employeeR
 app.use('/api/attendance', authenticate, authorizeRoles('employee', 'supervisor', 'hr', 'admin'), attendanceRoutes);
 
 
-app.use('/api/leaves', leaveRoutes);
-app.use('/api/schedules', scheduleRoutes);
+app.use('/api/leaves', authenticate, authorizeRoles('employee', 'supervisor', 'hr', 'admin'), leaveRoutes);
+app.use('/api/schedules', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), scheduleRoutes);
+app.use('/api/payroll', authenticate, authorizeRoles('hr', 'admin'), payrollRoutes);
+app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoutes);
+app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
 
 
 connectDB(process.env.MONGODB_URI);

--- a/server/src/models/InsuranceRecord.js
+++ b/server/src/models/InsuranceRecord.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const insuranceRecordSchema = new mongoose.Schema({
+  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
+  provider: String,
+  policyNumber: String,
+  coverageStart: Date,
+  coverageEnd: Date
+}, { timestamps: true });
+
+export default mongoose.model('InsuranceRecord', insuranceRecordSchema);

--- a/server/src/models/PayrollRecord.js
+++ b/server/src/models/PayrollRecord.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const payrollRecordSchema = new mongoose.Schema({
+  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
+  month: { type: Date, required: true },
+  amount: { type: Number, required: true }
+}, { timestamps: true });
+
+export default mongoose.model('PayrollRecord', payrollRecordSchema);

--- a/server/src/models/Report.js
+++ b/server/src/models/Report.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const reportSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  data: { type: mongoose.Schema.Types.Mixed, required: true }
+}, { timestamps: true });
+
+export default mongoose.model('Report', reportSchema);

--- a/server/src/routes/insuranceRoutes.js
+++ b/server/src/routes/insuranceRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listInsurance,
+  createInsurance,
+  getInsurance,
+  updateInsurance,
+  deleteInsurance
+} from '../controllers/insuranceController.js';
+
+const router = Router();
+
+router.get('/', listInsurance);
+router.post('/', createInsurance);
+router.get('/:id', getInsurance);
+router.put('/:id', updateInsurance);
+router.delete('/:id', deleteInsurance);
+
+export default router;

--- a/server/src/routes/leaveRoutes.js
+++ b/server/src/routes/leaveRoutes.js
@@ -1,9 +1,18 @@
 import { Router } from 'express';
-import { listLeaves, createLeave } from '../controllers/leaveController.js';
+import {
+  listLeaves,
+  createLeave,
+  getLeave,
+  updateLeave,
+  deleteLeave
+} from '../controllers/leaveController.js';
 
 const router = Router();
 
 router.get('/', listLeaves);
 router.post('/', createLeave);
+router.get('/:id', getLeave);
+router.put('/:id', updateLeave);
+router.delete('/:id', deleteLeave);
 
 export default router;

--- a/server/src/routes/payrollRoutes.js
+++ b/server/src/routes/payrollRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listPayrolls,
+  createPayroll,
+  getPayroll,
+  updatePayroll,
+  deletePayroll
+} from '../controllers/payrollController.js';
+
+const router = Router();
+
+router.get('/', listPayrolls);
+router.post('/', createPayroll);
+router.get('/:id', getPayroll);
+router.put('/:id', updatePayroll);
+router.delete('/:id', deletePayroll);
+
+export default router;

--- a/server/src/routes/reportRoutes.js
+++ b/server/src/routes/reportRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listReports,
+  createReport,
+  getReport,
+  updateReport,
+  deleteReport
+} from '../controllers/reportController.js';
+
+const router = Router();
+
+router.get('/', listReports);
+router.post('/', createReport);
+router.get('/:id', getReport);
+router.put('/:id', updateReport);
+router.delete('/:id', deleteReport);
+
+export default router;

--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -1,9 +1,18 @@
 import { Router } from 'express';
-import { listSchedules, createSchedule } from '../controllers/scheduleController.js';
+import {
+  listSchedules,
+  createSchedule,
+  getSchedule,
+  updateSchedule,
+  deleteSchedule
+} from '../controllers/scheduleController.js';
 
 const router = Router();
 
 router.get('/', listSchedules);
 router.post('/', createSchedule);
+router.get('/:id', getSchedule);
+router.put('/:id', updateSchedule);
+router.delete('/:id', deleteSchedule);
 
 export default router;

--- a/server/tests/leave.test.js
+++ b/server/tests/leave.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const LeaveRequest = jest.fn().mockImplementation(() => ({ save: saveMock }));
+LeaveRequest.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+
+jest.mock('../src/models/LeaveRequest.js', () => ({ default: LeaveRequest }), { virtual: true });
+
+let app;
+let leaveRoutes;
+
+beforeAll(async () => {
+  leaveRoutes = (await import('../src/routes/leaveRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/leaves', leaveRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  LeaveRequest.find.mockReset();
+});
+
+describe('Leave API', () => {
+  it('lists leaves', async () => {
+    const fakeLeaves = [{ leaveType: 'vacation' }];
+    LeaveRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeLeaves) });
+    const res = await request(app).get('/api/leaves');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeLeaves);
+  });
+
+  it('creates leave', async () => {
+    const payload = { leaveType: 'vacation' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/leaves').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const ShiftSchedule = jest.fn().mockImplementation(() => ({ save: saveMock }));
+ShiftSchedule.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+
+jest.mock('../src/models/ShiftSchedule.js', () => ({ default: ShiftSchedule }), { virtual: true });
+
+let app;
+let scheduleRoutes;
+
+beforeAll(async () => {
+  scheduleRoutes = (await import('../src/routes/scheduleRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/schedules', scheduleRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  ShiftSchedule.find.mockReset();
+});
+
+describe('Schedule API', () => {
+  it('lists schedules', async () => {
+    const fakeSchedules = [{ shiftType: 'morning' }];
+    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
+    const res = await request(app).get('/api/schedules');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeSchedules);
+  });
+
+  it('creates schedule', async () => {
+    const payload = { shiftType: 'morning' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/schedules').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `server/package.json` syntax
- document `JWT_SECRET` in env example and README
- add CRUD routes for leaves, schedules, payroll, reports and insurance with auth
- add models & controllers for new modules
- integrate Vue pages with API using JWT
- add unit tests for leaves and schedules
- provide seeding instructions

## Testing
- `npm test` *(fails: `jest` not found)*