### PR TITLE
Fix dev proxy

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,6 +15,14 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  },
   test: {
     environment: 'jsdom'
   }


### PR DESCRIPTION
## Summary
- configure a dev server proxy in `vite.config.js` so API calls reach the Express backend

## Testing
- `npm test` *(fails: `jest: not found`)*