### PR TITLE
Seed default user accounts

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,6 +15,14 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  },
   test: {
     environment: 'jsdom'
   }

--- a/server/README.md
+++ b/server/README.md
@@ -30,8 +30,12 @@ This starts the server with nodemon enabled.
 
 ### Seeding example data
 
-You can create a script under `scripts/seed.js` to insert initial users or reference data into MongoDB. Run it with:
+When the server starts it automatically creates a few test accounts if they don't already exist:
 
-```bash
-node scripts/seed.js
-```
+| Username    | Password  | Role        |
+|-------------|-----------|-------------|
+| `employee`  | password  | employee    |
+| `supervisor`| password  | supervisor  |
+| `admin`     | password  | admin       |
+
+These users let you try logging in right away during development.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,23 @@ import scheduleRoutes from './routes/scheduleRoutes.js';
 import payrollRoutes from './routes/payrollRoutes.js';
 import reportRoutes from './routes/reportRoutes.js';
 import insuranceRoutes from './routes/insuranceRoutes.js';
+import User from './models/User.js';
+
+async function seedTestUsers() {
+  const defaults = [
+    { username: 'employee', password: 'password', role: 'employee' },
+    { username: 'supervisor', password: 'password', role: 'supervisor' },
+    { username: 'admin', password: 'password', role: 'admin' }
+  ];
+  for (const data of defaults) {
+    const existing = await User.findOne({ username: data.username });
+    if (!existing) {
+      const user = new User(data);
+      await user.save();
+      console.log(`Created test user ${data.username}`);
+    }
+  }
+}
 
 dotenv.config();
 
@@ -44,8 +61,12 @@ app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoute
 app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
 
 
-connectDB(process.env.MONGODB_URI);
+async function start() {
+  await connectDB(process.env.MONGODB_URI);
+  await seedTestUsers();
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+start();


### PR DESCRIPTION
## Summary
- seed standard, supervisor and admin accounts automatically
- document default credentials in the server README

## Testing
- `npm test` *(fails: `jest: not found`)*