### PR TITLE
Add approval workflow

### DIFF
--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -7,7 +7,7 @@
       <el-table :data="pendingList" style="margin-top: 20px;">
         <el-table-column prop="applicant" label="申請人" width="120" />
         <el-table-column prop="type" label="申請類型" width="120" />
-        <el-table-column prop="detail" label="申請內容" />
+        <el-table-column prop="content" label="申請內容" />
         <el-table-column label="操作" width="200">
           <template #default="{ row, $index }">
             <el-button type="primary" @click="approve($index)">通過</el-button>
@@ -18,27 +18,45 @@
     </div>
   </template>
   
-  <script setup>
-  import { ref } from 'vue'
-  
-  // 模擬待簽核清單
-  const pendingList = ref([
-    { applicant: '王小明', type: '請假', detail: '事假：2025/04/15 ~ 2025/04/16' },
-    { applicant: '李大華', type: '補打卡', detail: '補 2025/04/10 上午打卡' },
-    { applicant: '林美麗', type: '加班', detail: '2025/04/18 18:00~22:00' }
-  ])
-  
-  function approve(index) {
-    const item = pendingList.value[index]
-    alert(`已通過：${item.applicant} 的 ${item.type}\n(示範, 未串後端)`)
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const pendingList = ref([])
+const token = localStorage.getItem('token') || ''
+
+async function fetchApprovals() {
+  const res = await fetch('/api/approvals', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    pendingList.value = await res.json()
+  }
+}
+
+async function approve(index) {
+  const item = pendingList.value[index]
+  const res = await fetch(`/api/approvals/${item._id}/approve`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
     pendingList.value.splice(index, 1)
   }
-  function reject(index) {
-    const item = pendingList.value[index]
-    alert(`已退回：${item.applicant} 的 ${item.type}\n(示範, 未串後端)`)
+}
+
+async function reject(index) {
+  const item = pendingList.value[index]
+  const res = await fetch(`/api/approvals/${item._id}/reject`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
     pendingList.value.splice(index, 1)
   }
-  </script>
+}
+
+onMounted(fetchApprovals)
+</script>
   
   <style scoped>
   .approval-page {

--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Approval from '../src/views/front/Approval.vue'
+
+describe('Approval.vue', () => {
+  it('fetches list on mount', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+    mount(Approval)
+    expect(window.fetch).toHaveBeenCalledWith('/api/approvals', expect.any(Object))
+    window.fetch.mockRestore()
+  })
+})

--- a/server/src/controllers/approvalController.js
+++ b/server/src/controllers/approvalController.js
@@ -1,0 +1,34 @@
+import Approval from '../models/Approval.js';
+
+export async function listApprovals(req, res) {
+  const approvals = await Approval.find().populate('applicant');
+  res.json(approvals);
+}
+
+export async function approve(req, res) {
+  try {
+    const approval = await Approval.findByIdAndUpdate(
+      req.params.id,
+      { status: 'approved' },
+      { new: true }
+    );
+    if (!approval) return res.status(404).json({ error: 'Not found' });
+    res.json(approval);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function reject(req, res) {
+  try {
+    const approval = await Approval.findByIdAndUpdate(
+      req.params.id,
+      { status: 'rejected' },
+      { new: true }
+    );
+    if (!approval) return res.status(404).json({ error: 'Not found' });
+    res.json(approval);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -12,6 +12,7 @@ import scheduleRoutes from './routes/scheduleRoutes.js';
 import payrollRoutes from './routes/payrollRoutes.js';
 import reportRoutes from './routes/reportRoutes.js';
 import insuranceRoutes from './routes/insuranceRoutes.js';
+import approvalRoutes from './routes/approvalRoutes.js';
 
 async function seedTestUsers() {
   const users = [
@@ -58,6 +59,7 @@ app.use('/api/schedules', authenticate, authorizeRoles('supervisor', 'hr', 'admi
 app.use('/api/payroll', authenticate, authorizeRoles('hr', 'admin'), payrollRoutes);
 app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoutes);
 app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
+app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), approvalRoutes);
 
 
 async function start() {

--- a/server/src/models/Approval.js
+++ b/server/src/models/Approval.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const approvalSchema = new mongoose.Schema({
+  applicant: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
+  type: { type: String, required: true },
+  content: String,
+  status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' }
+}, { timestamps: true });
+
+export default mongoose.model('Approval', approvalSchema);

--- a/server/src/routes/approvalRoutes.js
+++ b/server/src/routes/approvalRoutes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { listApprovals, approve, reject } from '../controllers/approvalController.js';
+
+const router = Router();
+
+router.get('/', listApprovals);
+router.post('/:id/approve', approve);
+router.post('/:id/reject', reject);
+
+export default router;

--- a/server/tests/approval.test.js
+++ b/server/tests/approval.test.js
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const Approval = {
+  find: jest.fn(),
+  findByIdAndUpdate: jest.fn()
+};
+
+jest.mock('../src/models/Approval.js', () => ({ default: Approval }), { virtual: true });
+
+let app;
+let approvalRoutes;
+
+beforeAll(async () => {
+  approvalRoutes = (await import('../src/routes/approvalRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/approvals', approvalRoutes);
+});
+
+beforeEach(() => {
+  Approval.find.mockReset();
+  Approval.findByIdAndUpdate.mockReset();
+});
+
+describe('Approval API', () => {
+  it('lists approvals', async () => {
+    const fakeApprovals = [{ type: 'leave' }];
+    Approval.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeApprovals) });
+    const res = await request(app).get('/api/approvals');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeApprovals);
+  });
+
+  it('approves request', async () => {
+    Approval.findByIdAndUpdate.mockResolvedValue({ status: 'approved' });
+    const res = await request(app).post('/api/approvals/123/approve');
+    expect(res.status).toBe(200);
+    expect(Approval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'approved' }, { new: true });
+  });
+
+  it('rejects request', async () => {
+    Approval.findByIdAndUpdate.mockResolvedValue({ status: 'rejected' });
+    const res = await request(app).post('/api/approvals/123/reject');
+    expect(res.status).toBe(200);
+    expect(Approval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'rejected' }, { new: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add Approval model and controller
- expose `/api/approvals` endpoints with role checks
- fetch approval list from API in Approval.vue
- test server approval routes and Approval.vue

## Testing
- `npm test` *(fails: jest not found)*