### PR TITLE
Update login to store employeeId

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -47,6 +47,7 @@
       const data = await res.json()
       localStorage.setItem('token', data.token)
       localStorage.setItem('role', data.user.role)
+      localStorage.setItem('employeeId', data.user.id)
       router.push({ name: 'Settings' })
     } else {
       alert('登入失敗')

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -56,6 +56,7 @@ async function onLogin () {
     const data = await res.json()
     localStorage.setItem('token', data.token)
     localStorage.setItem('role', data.user.role)
+    localStorage.setItem('employeeId', data.user.id)
 
     switch (data.user.role) {
       case 'employee':

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -11,9 +11,10 @@ describe('FrontLogin.vue', () => {
     localStorage.clear()
   })
 
-  it('stores role on login', async () => {
+  it('stores role and employeeId on login', async () => {
     const wrapper = mount(FrontLogin)
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('role')).toBe('employee')
+    expect(localStorage.getItem('employeeId')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- store `employeeId` in FrontLogin and Login
- update FrontLogin test expectation

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm --prefix client test` *(fails: `vitest` not found)*