### PR TITLE
Add HR test user

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Each part has its own README with full instructions. Below is a quick overview.
 2. Copy `.env.example` to `.env` and set `PORT`, `MONGODB_URI` and optionally `JWT_SECRET`.
 3. Start the development server with nodemon:
    ```bash
-   npm run dev
-   ```
+  npm run dev
+  ```
 
 For more details see [`server/README.md`](server/README.md).
+
+The server seeds some default accounts on first run. See the **Server** README for the list of usernames and roles.
 
 ### Client
 

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import FrontLogin from '../src/views/front/FrontLogin.vue'
 
@@ -9,11 +9,30 @@ vi.mock('vue-router', () => ({
 describe('FrontLogin.vue', () => {
   beforeEach(() => {
     localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('stores role on login', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: 't', user: { role: 'employee' } })
+    })
     const wrapper = mount(FrontLogin)
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('role')).toBe('employee')
+  })
+
+  it('stores HR role when API returns hr', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: 't', user: { role: 'hr' } })
+    })
+    const wrapper = mount(FrontLogin)
+    await wrapper.find('button').trigger('click')
+    expect(localStorage.getItem('role')).toBe('hr')
   })
 })

--- a/server/README.md
+++ b/server/README.md
@@ -35,3 +35,14 @@ You can create a script under `scripts/seed.js` to insert initial users or refer
 ```bash
 node scripts/seed.js
 ```
+
+When running in development, the server automatically seeds a few test users if they do not already exist:
+
+| Username    | Role       |
+|-------------|-----------|
+| `user`      | employee  |
+| `supervisor`| supervisor|
+| `hr`        | hr        |
+| `admin`     | admin     |
+
+All test accounts use the password `password`.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,6 +17,7 @@ async function seedTestUsers() {
   const users = [
     { username: 'user', password: 'password', role: 'employee' },
     { username: 'supervisor', password: 'password', role: 'supervisor' },
+    { username: 'hr', password: 'password', role: 'hr' },
     { username: 'admin', password: 'password', role: 'admin' }
   ];
   for (const data of users) {


### PR DESCRIPTION
## Summary
- seed `hr` user on server start
- document default test users
- mention seeded accounts in root README
- verify HR role in login test

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*