### PR TITLE
Add error pages and routing

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -14,6 +14,10 @@ const SalaryManagementSetting = () => import('@/components/backComponents/Salary
 const SocialInsuranceRetirementSetting = () => import('@/components/backComponents/SocialInsuranceRetirementSetting.vue')
 const HRManagementSystemSetting = () => import('@/components/backComponents/HRManagementSystemSetting.vue')
 
+// ★ 錯誤頁面
+const Forbidden = () => import('@/views/Forbidden.vue')
+const NotFound = () => import('@/views/NotFound.vue')
+
 // ★ 新增的前台檔案 (先確定檔案路徑無大小寫差異)
 const FrontLogin = () => import('@/views/front/FrontLogin.vue')
 const FrontLayout = () => import('@/views/front/FrontLayout.vue')
@@ -94,8 +98,9 @@ const routes = [
     ]
   },
 
-  // (可選) 404 頁面 or 其他
-  // { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFoundView }
+  // 錯誤頁面
+  { path: '/403', name: 'Forbidden', component: Forbidden },
+  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound }
 ]
 
 const router = createRouter({
@@ -125,7 +130,7 @@ router.beforeEach((to, from, next) => {
   if (to.meta.roles) {
     const userRole = localStorage.getItem('role') || 'employee'
     if (!to.meta.roles.includes(userRole)) {
-      return next('/403')
+      return next({ name: 'Forbidden' })
     }
   }
 

--- a/client/src/views/Forbidden.vue
+++ b/client/src/views/Forbidden.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="forbidden">
+    <h2>403 Forbidden</h2>
+    <p>您沒有權限瀏覽此頁面</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.forbidden {
+  padding: 40px;
+  text-align: center;
+}
+</style>

--- a/client/src/views/NotFound.vue
+++ b/client/src/views/NotFound.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="not-found">
+    <h2>404 Not Found</h2>
+    <p>找不到頁面</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.not-found {
+  padding: 40px;
+  text-align: center;
+}
+</style>

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -5,4 +5,10 @@ describe('router', () => {
   it('loads routes without error', () => {
     expect(() => router.getRoutes()).not.toThrow()
   })
+
+  it('contains error routes', () => {
+    const names = router.getRoutes().map(r => r.name)
+    expect(names).toContain('Forbidden')
+    expect(names).toContain('NotFound')
+  })
 })


### PR DESCRIPTION
## Summary
- add simple `Forbidden` and `NotFound` views
- register error routes in the router and redirect meta.role failures
- update router tests to check for new routes

## Testing
- `npm test` *(fails: `jest` not found)*