### PR TITLE
Add tests for new settings controllers

### DIFF
--- a/server/tests/insurance.test.js
+++ b/server/tests/insurance.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const InsuranceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+InsuranceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+
+jest.mock('../src/models/InsuranceRecord.js', () => ({ default: InsuranceRecord }), { virtual: true });
+
+let app;
+let insuranceRoutes;
+
+beforeAll(async () => {
+  insuranceRoutes = (await import('../src/routes/insuranceRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/insurance', insuranceRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  InsuranceRecord.find.mockReset();
+});
+
+describe('Insurance API', () => {
+  it('lists insurance records', async () => {
+    const fakeRecords = [{ provider: 'InsureCo' }];
+    InsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    const res = await request(app).get('/api/insurance');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeRecords);
+  });
+
+  it('creates insurance record', async () => {
+    const payload = { provider: 'InsureCo' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/insurance').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});

--- a/server/tests/payroll.test.js
+++ b/server/tests/payroll.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const PayrollRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+PayrollRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+
+jest.mock('../src/models/PayrollRecord.js', () => ({ default: PayrollRecord }), { virtual: true });
+
+let app;
+let payrollRoutes;
+
+beforeAll(async () => {
+  payrollRoutes = (await import('../src/routes/payrollRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/payroll', payrollRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  PayrollRecord.find.mockReset();
+});
+
+describe('Payroll API', () => {
+  it('lists payroll records', async () => {
+    const fakeRecords = [{ amount: 100 }];
+    PayrollRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    const res = await request(app).get('/api/payroll');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeRecords);
+  });
+
+  it('creates payroll record', async () => {
+    const payload = { amount: 100 };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/payroll').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const Report = jest.fn().mockImplementation(() => ({ save: saveMock }));
+Report.find = jest.fn();
+
+jest.mock('../src/models/Report.js', () => ({ default: Report }), { virtual: true });
+
+let app;
+let reportRoutes;
+
+beforeAll(async () => {
+  reportRoutes = (await import('../src/routes/reportRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/reports', reportRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  Report.find.mockReset();
+});
+
+describe('Report API', () => {
+  it('lists reports', async () => {
+    const fakeReports = [{ name: 'Monthly' }];
+    Report.find.mockResolvedValue(fakeReports);
+    const res = await request(app).get('/api/reports');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeReports);
+  });
+
+  it('creates report', async () => {
+    const payload = { name: 'Monthly' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/reports').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add insurance controller tests
- add payroll controller tests
- add report controller tests

## Testing
- `npm --prefix server test` *(fails: `jest` not found)*