### PR TITLE
Add Pinia auth store and tests

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,12 +1,15 @@
 // src/main.js
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import './assets/main.css'
 
+const pinia = createPinia()
 const app = createApp(App)
+app.use(pinia)
 app.use(router)
 app.use(ElementPlus)
 app.mount('#app')

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
 // ★ 既有的後台檔案
 const Login = () => import('@/views/Login.vue')
@@ -110,25 +111,24 @@ const router = createRouter({
 
 // ★ 路由守衛
 router.beforeEach((to, from, next) => {
+  const auth = useAuthStore()
   // 簡易示範: 後台 requiresAuth
   if (to.meta.requiresAuth) {
-    const token = localStorage.getItem('token')
-    if (!token) {
+    if (!auth.token) {
       return next({ name: 'Login' })
     }
   }
 
   // 若要檢查前台也需登入
   if (to.meta.frontRequiresAuth) {
-    const token = localStorage.getItem('token')
-    if (!token) {
+    if (!auth.token) {
       return next({ name: 'FrontLogin' })
     }
   }
 
   // 若有角色限制 meta.roles
   if (to.meta.roles) {
-    const userRole = localStorage.getItem('role') || 'employee'
+    const userRole = auth.role || 'employee'
     if (!to.meta.roles.includes(userRole)) {
       return next({ name: 'Forbidden' })
     }

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', () => {
+  const token = ref(localStorage.getItem('token') || '')
+  const role = ref(localStorage.getItem('role') || '')
+  const employeeId = ref(localStorage.getItem('employeeId') || '')
+
+  function setAuth({ token: t, role: r, employeeId: id }) {
+    token.value = t
+    role.value = r
+    employeeId.value = id
+    localStorage.setItem('token', t)
+    localStorage.setItem('role', r)
+    localStorage.setItem('employeeId', id)
+  }
+
+  function clearAuth() {
+    token.value = ''
+    role.value = ''
+    employeeId.value = ''
+    localStorage.removeItem('token')
+    localStorage.removeItem('role')
+    localStorage.removeItem('employeeId')
+  }
+
+  return { token, role, employeeId, setAuth, clearAuth }
+})

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -26,10 +26,12 @@
   </template>
   
   <script setup>
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
   
-  const router = useRouter()
+const router = useRouter()
+const auth = useAuthStore()
   const loginForm = ref({
     username: '',
     password: ''
@@ -45,9 +47,7 @@
     })
     if (res.ok) {
       const data = await res.json()
-      localStorage.setItem('token', data.token)
-      localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.id)
+      auth.setAuth({ token: data.token, role: data.user.role, employeeId: data.user.id })
       router.push({ name: 'Settings' })
     } else {
       alert('登入失敗')

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -8,13 +8,16 @@
   </template>
   
   <script setup>
-  import { useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
   
-  const router = useRouter()
+const router = useRouter()
+const auth = useAuthStore()
   
-  const logout = () => {
-    router.push({ name: 'Login' })
-  }
+const logout = () => {
+  auth.clearAuth()
+  router.push({ name: 'Login' })
+}
   </script>
   
   <style scoped>

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -57,8 +57,10 @@
 <script setup>
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 
 const router = useRouter();
+const auth = useAuthStore();
 
 // 暫存角色，從 localStorage 讀取
 const role = ref("employee");
@@ -79,9 +81,7 @@ function gotoPage(pageName) {
 
 // 登出
 function onLogout() {
-  localStorage.removeItem("role");
-  localStorage.removeItem("username");
-  localStorage.removeItem("token");
+  auth.clearAuth();
   // 回到前台登入
   router.push({ name: "FrontLogin" });
 }

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -34,10 +34,12 @@
   </template>
   
   <script setup>
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
   
-  const router = useRouter()
+const router = useRouter()
+const auth = useAuthStore()
   
   const loginForm = ref({
     role: 'employee',   // 預設員工
@@ -54,9 +56,7 @@ async function onLogin () {
   })
   if (res.ok) {
     const data = await res.json()
-    localStorage.setItem('token', data.token)
-    localStorage.setItem('role', data.user.role)
-    localStorage.setItem('employeeId', data.user.id)
+    auth.setAuth({ token: data.token, role: data.user.role, employeeId: data.user.id })
 
     switch (data.user.role) {
       case 'employee':

--- a/client/tests/authStore.spec.js
+++ b/client/tests/authStore.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../src/stores/auth'
+
+describe('auth store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('stores credentials on setAuth', () => {
+    const store = useAuthStore()
+    store.setAuth({ token: 'tok', role: 'hr', employeeId: 'e1' })
+    expect(store.token).toBe('tok')
+    expect(store.role).toBe('hr')
+    expect(store.employeeId).toBe('e1')
+    expect(localStorage.getItem('token')).toBe('tok')
+    expect(localStorage.getItem('role')).toBe('hr')
+    expect(localStorage.getItem('employeeId')).toBe('e1')
+  })
+
+  it('clears all credentials', () => {
+    const store = useAuthStore()
+    store.setAuth({ token: 'tok', role: 'hr', employeeId: 'e1' })
+    store.clearAuth()
+    expect(store.token).toBe('')
+    expect(store.role).toBe('')
+    expect(store.employeeId).toBe('')
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('role')).toBeNull()
+    expect(localStorage.getItem('employeeId')).toBeNull()
+  })
+})

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
 import FrontLogin from '../src/views/front/FrontLogin.vue'
+import { useAuthStore } from '../src/stores/auth'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() })
 }))
 
 describe('FrontLogin.vue', () => {
+  let pinia
   beforeEach(() => {
     localStorage.clear()
     vi.stubGlobal('fetch', vi.fn())
+    pinia = createPinia()
+    setActivePinia(pinia)
   })
 
   afterEach(() => {
@@ -22,9 +27,10 @@ describe('FrontLogin.vue', () => {
       ok: true,
       json: async () => ({ token: 't', user: { role: 'employee' } })
     })
-    const wrapper = mount(FrontLogin)
+    const wrapper = mount(FrontLogin, { global: { plugins: [pinia] } })
+    const store = useAuthStore()
     await wrapper.find('button').trigger('click')
-    expect(localStorage.getItem('role')).toBe('employee')
+    expect(store.role).toBe('employee')
     expect(localStorage.getItem('employeeId')).toBeDefined()
   })
 
@@ -33,8 +39,9 @@ describe('FrontLogin.vue', () => {
       ok: true,
       json: async () => ({ token: 't', user: { role: 'hr' } })
     })
-    const wrapper = mount(FrontLogin)
+    const wrapper = mount(FrontLogin, { global: { plugins: [pinia] } })
+    const store = useAuthStore()
     await wrapper.find('button').trigger('click')
-    expect(localStorage.getItem('role')).toBe('hr')
+    expect(store.role).toBe('hr')
   })
 })


### PR DESCRIPTION
## Summary
- add Pinia auth store
- integrate auth store in router guards and login/logout screens
- register Pinia in main.js
- test login flow and store behaviour

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*