### PR TITLE
Add role-based menu endpoint and store

### DIFF
--- a/client/src/stores/menu.js
+++ b/client/src/stores/menu.js
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useMenuStore = defineStore('menu', () => {
+  const items = ref([])
+
+  async function fetchMenu() {
+    const token = localStorage.getItem('token')
+    const res = await fetch('/api/menu', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    if (res.ok) {
+      items.value = await res.json()
+    }
+  }
+
+  function setMenu(data) {
+    items.value = data
+  }
+
+  return { items, fetchMenu, setMenu }
+})

--- a/client/src/views/Layout.vue
+++ b/client/src/views/Layout.vue
@@ -22,23 +22,16 @@
 
 <script setup>
 import { useRouter } from "vue-router";
+import { useMenuStore } from "../stores/menu";
+import { storeToRefs } from "pinia";
 const router = useRouter();
+const menuStore = useMenuStore();
+const { items: menuItems } = storeToRefs(menuStore);
 
 const gotoPage = (name) => {
   router.push({ name });
 };
 
-const menuItems = [
-  { name: 'AttendanceSetting', label: '出勤設定', icon: 'el-icon-postcard' },
-  { name: 'AttendanceManagementSetting', label: '考勤管理設定', icon: 'el-icon-folder-opened' },
-  { name: 'LeaveOvertimeSetting', label: '請假與加班設定', icon: 'el-icon-date' },
-  { name: 'ShiftScheduleSetting', label: '排班管理設定', icon: 'el-icon-timer' },
-  { name: 'ApprovalFlowSetting', label: '簽核流程設定', icon: 'el-icon-s-operation' },
-  { name: 'ReportManagementSetting', label: '報表管理設定', icon: 'el-icon-document-copy' },
-  { name: 'SalaryManagementSetting', label: '薪資管理設定', icon: 'el-icon-coin' },
-  { name: 'SocialInsuranceRetirementSetting', label: '勞健保 / 勞退設定', icon: 'el-icon-s-check' },
-  { name: 'HRManagementSystemSetting', label: '人事管理與系統設定', icon: 'el-icon-user-solid' },
-];
 </script>
 
 <style scoped>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -26,10 +26,13 @@
   </template>
   
   <script setup>
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMenuStore } from '../stores/menu'
+import { storeToRefs } from 'pinia'
   
-  const router = useRouter()
+const router = useRouter()
+const menuStore = useMenuStore()
   const loginForm = ref({
     username: '',
     password: ''
@@ -48,6 +51,7 @@
       localStorage.setItem('token', data.token)
       localStorage.setItem('role', data.user.role)
       localStorage.setItem('employeeId', data.user.id)
+      await menuStore.fetchMenu()
       router.push({ name: 'Settings' })
     } else {
       alert('登入失敗')

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -3,41 +3,15 @@
     <!-- 左側導覽列 -->
     <aside class="sidebar">
       <el-menu default-active="" class="el-menu-vertical-demo">
-        <!-- 出勤打卡 -->
-        <template
-          v-if="['employee', 'supervisor', 'hr', 'admin'].includes(role)"
+        <el-menu-item
+          v-for="item in menuItems"
+          :key="item.name"
+          :index="item.name"
+          @click="gotoPage(item.name)"
         >
-          <el-menu-item index="attendance" @click="gotoPage('attendance')">
-            <i class="el-icon-postcard"></i>
-            <span>出勤打卡</span>
-          </el-menu-item>
-        </template>
-
-        <!-- 請假申請 -->
-        <template
-          v-if="['employee', 'supervisor', 'hr', 'admin'].includes(role)"
-        >
-          <el-menu-item index="leave" @click="gotoPage('leave')">
-            <i class="el-icon-date"></i>
-            <span>請假申請</span>
-          </el-menu-item>
-        </template>
-
-        <!-- 排班管理 (主管/HR/Admin) -->
-        <template v-if="['supervisor', 'hr', 'admin'].includes(role)">
-          <el-menu-item index="schedule" @click="gotoPage('schedule')">
-            <i class="el-icon-timer"></i>
-            <span>排班管理</span>
-          </el-menu-item>
-        </template>
-
-        <!-- 簽核流程 (主管/HR/Admin) -->
-        <template v-if="['supervisor', 'hr', 'admin'].includes(role)">
-          <el-menu-item index="approval" @click="gotoPage('approval')">
-            <i class="el-icon-s-operation"></i>
-            <span>簽核流程</span>
-          </el-menu-item>
-        </template>
+          <i :class="item.icon"></i>
+          <span>{{ item.label }}</span>
+        </el-menu-item>
       </el-menu>
 
       <!-- 登出按鈕 -->
@@ -57,8 +31,12 @@
 <script setup>
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
+import { useMenuStore } from "../../stores/menu";
+import { storeToRefs } from "pinia";
 
 const router = useRouter();
+const menuStore = useMenuStore();
+const { items: menuItems } = storeToRefs(menuStore);
 
 // 暫存角色，從 localStorage 讀取
 const role = ref("employee");

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -34,10 +34,12 @@
   </template>
   
   <script setup>
-  import { ref } from 'vue'
-  import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMenuStore } from '../../stores/menu'
   
-  const router = useRouter()
+const router = useRouter()
+const menuStore = useMenuStore()
   
   const loginForm = ref({
     role: 'employee',   // 預設員工
@@ -57,6 +59,7 @@ async function onLogin () {
     localStorage.setItem('token', data.token)
     localStorage.setItem('role', data.user.role)
     localStorage.setItem('employeeId', data.user.id)
+    await menuStore.fetchMenu()
 
     switch (data.user.role) {
       case 'employee':

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -18,10 +18,15 @@ describe('FrontLogin.vue', () => {
 
 
   it('stores role on login', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: 't', user: { role: 'employee' } })
-    })
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: 't', user: { role: 'employee' } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([])
+      })
     const wrapper = mount(FrontLogin)
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('role')).toBe('employee')
@@ -29,10 +34,12 @@ describe('FrontLogin.vue', () => {
   })
 
   it('stores HR role when API returns hr', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: 't', user: { role: 'hr' } })
-    })
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: 't', user: { role: 'hr' } })
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
     const wrapper = mount(FrontLogin)
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('role')).toBe('hr')

--- a/client/tests/menuStore.spec.js
+++ b/client/tests/menuStore.spec.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMenuStore } from '../src/stores/menu'
+
+describe('menu store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', vi.fn())
+    localStorage.setItem('token', 'tok')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('fetchMenu stores items', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([{ name: 'a' }])
+    })
+    const store = useMenuStore()
+    await store.fetchMenu()
+    expect(fetch).toHaveBeenCalledWith('/api/menu', expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer tok' })
+    }))
+    expect(store.items).toEqual([{ name: 'a' }])
+  })
+})

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -1,0 +1,33 @@
+export function getMenu(req, res) {
+  const role = req.user?.role || 'employee';
+  const menus = {
+    employee: [
+      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'leave', label: '請假申請', icon: 'el-icon-date' }
+    ],
+    supervisor: [
+      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'leave', label: '請假申請', icon: 'el-icon-date' },
+      { name: 'schedule', label: '排班管理', icon: 'el-icon-timer' },
+      { name: 'approval', label: '簽核流程', icon: 'el-icon-s-operation' }
+    ],
+    hr: [
+      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'leave', label: '請假申請', icon: 'el-icon-date' },
+      { name: 'schedule', label: '排班管理', icon: 'el-icon-timer' },
+      { name: 'approval', label: '簽核流程', icon: 'el-icon-s-operation' }
+    ],
+    admin: [
+      { name: 'AttendanceSetting', label: '出勤設定', icon: 'el-icon-postcard' },
+      { name: 'AttendanceManagementSetting', label: '考勤管理設定', icon: 'el-icon-folder-opened' },
+      { name: 'LeaveOvertimeSetting', label: '請假與加班設定', icon: 'el-icon-date' },
+      { name: 'ShiftScheduleSetting', label: '排班管理設定', icon: 'el-icon-timer' },
+      { name: 'ApprovalFlowSetting', label: '簽核流程設定', icon: 'el-icon-s-operation' },
+      { name: 'ReportManagementSetting', label: '報表管理設定', icon: 'el-icon-document-copy' },
+      { name: 'SalaryManagementSetting', label: '薪資管理設定', icon: 'el-icon-coin' },
+      { name: 'SocialInsuranceRetirementSetting', label: '勞健保 / 勞退設定', icon: 'el-icon-s-check' },
+      { name: 'HRManagementSystemSetting', label: '人事管理與系統設定', icon: 'el-icon-user-solid' }
+    ]
+  };
+  res.json(menus[role] || []);
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,6 +13,7 @@ import payrollRoutes from './routes/payrollRoutes.js';
 import reportRoutes from './routes/reportRoutes.js';
 import insuranceRoutes from './routes/insuranceRoutes.js';
 import approvalRoutes from './routes/approvalRoutes.js';
+import menuRoutes from './routes/menuRoutes.js';
 
 async function seedTestUsers() {
   const users = [
@@ -61,6 +62,7 @@ app.use('/api/payroll', authenticate, authorizeRoles('hr', 'admin'), payrollRout
 app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoutes);
 app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
 app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), approvalRoutes);
+app.use('/api/menu', menuRoutes);
 
 
 async function start() {

--- a/server/src/routes/menuRoutes.js
+++ b/server/src/routes/menuRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getMenu } from '../controllers/menuController.js';
+import { authenticate } from '../middleware/auth.js';
+
+const router = Router();
+
+router.get('/', authenticate, getMenu);
+
+export default router;

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -1,0 +1,26 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+jest.mock('../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => { req.user = { role: 'employee' }; next(); },
+  authorizeRoles: () => (req, res, next) => next()
+}), { virtual: true });
+
+let app;
+let menuRoutes;
+
+beforeAll(async () => {
+  menuRoutes = (await import('../src/routes/menuRoutes.js')).default;
+  app = express();
+  app.use('/api/menu', menuRoutes);
+});
+
+describe('Menu API', () => {
+  it('returns menu for employee role', async () => {
+    const res = await request(app).get('/api/menu');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.find(i => i.name === 'attendance')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- provide `/api/menu` route with role-based results
- save menu items in new Pinia store
- fetch menu during login
- use menu store in both layouts
- test menu store and API

## Testing
- `npm test --silent --prefix server` *(fails: jest not found)*
- `npm test --silent --prefix client` *(fails: vitest not found)*