### PR TITLE
Add salary settings support

### DIFF
--- a/server/src/controllers/salarySettingController.js
+++ b/server/src/controllers/salarySettingController.js
@@ -1,0 +1,46 @@
+import SalarySetting from '../models/SalarySetting.js';
+
+export async function listSettings(req, res) {
+  const settings = await SalarySetting.find();
+  res.json(settings);
+}
+
+export async function createSetting(req, res) {
+  try {
+    const setting = new SalarySetting(req.body);
+    await setting.save();
+    res.status(201).json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getSetting(req, res) {
+  try {
+    const setting = await SalarySetting.findById(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateSetting(req, res) {
+  try {
+    const setting = await SalarySetting.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteSetting(req, res) {
+  try {
+    const setting = await SalarySetting.findByIdAndDelete(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,6 +13,7 @@ import payrollRoutes from './routes/payrollRoutes.js';
 import reportRoutes from './routes/reportRoutes.js';
 import insuranceRoutes from './routes/insuranceRoutes.js';
 import approvalRoutes from './routes/approvalRoutes.js';
+import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
 async function seedTestUsers() {
   const users = [
@@ -61,6 +62,7 @@ app.use('/api/payroll', authenticate, authorizeRoles('hr', 'admin'), payrollRout
 app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoutes);
 app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
 app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), approvalRoutes);
+app.use('/api/salary-settings', authenticate, authorizeRoles('hr', 'admin'), salarySettingRoutes);
 
 
 async function start() {

--- a/server/src/models/SalarySetting.js
+++ b/server/src/models/SalarySetting.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const salarySettingSchema = new mongoose.Schema({
+  salaryItems: { type: Array, default: [] },
+  grades: { type: Array, default: [] },
+  adjust: { type: Object, default: {} },
+  payment: { type: Object, default: {} },
+  other: { type: Object, default: {} }
+}, { timestamps: true });
+
+export default mongoose.model('SalarySetting', salarySettingSchema);

--- a/server/src/routes/salarySettingRoutes.js
+++ b/server/src/routes/salarySettingRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listSettings,
+  createSetting,
+  getSetting,
+  updateSetting,
+  deleteSetting
+} from '../controllers/salarySettingController.js';
+
+const router = Router();
+
+router.get('/', listSettings);
+router.post('/', createSetting);
+router.get('/:id', getSetting);
+router.put('/:id', updateSetting);
+router.delete('/:id', deleteSetting);
+
+export default router;

--- a/server/tests/salarySetting.test.js
+++ b/server/tests/salarySetting.test.js
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const SalarySetting = jest.fn().mockImplementation(() => ({ save: saveMock }));
+SalarySetting.find = jest.fn();
+SalarySetting.findByIdAndUpdate = jest.fn();
+
+jest.mock('../src/models/SalarySetting.js', () => ({ default: SalarySetting }), { virtual: true });
+
+let app;
+let salaryRoutes;
+
+beforeAll(async () => {
+  salaryRoutes = (await import('../src/routes/salarySettingRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/salary-settings', salaryRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  SalarySetting.find.mockReset();
+  SalarySetting.findByIdAndUpdate.mockReset();
+});
+
+describe('SalarySetting API', () => {
+  it('lists settings', async () => {
+    const fake = [{ salaryItems: [] }];
+    SalarySetting.find.mockResolvedValue(fake);
+    const res = await request(app).get('/api/salary-settings');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fake);
+  });
+
+  it('creates setting', async () => {
+    const payload = { salaryItems: [] };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/salary-settings').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
+  });
+
+  it('updates setting', async () => {
+    SalarySetting.findByIdAndUpdate.mockResolvedValue({ _id: '1', salaryItems: [] });
+    const res = await request(app).put('/api/salary-settings/1').send({ salaryItems: [] });
+    expect(res.status).toBe(200);
+    expect(SalarySetting.findByIdAndUpdate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add SalarySetting Mongoose model
- create salary setting CRUD controller and routes
- integrate salary setting routes with server
- persist salary management settings via API
- provide server tests for salary setting routes

## Testing
- `npm test` *(fails: jest not found)*