### PR TITLE
Remove duplicate attendance settings route

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -67,7 +67,6 @@ app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insurance
 app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), approvalRoutes);
 
 app.use('/api/salary-settings', authenticate, authorizeRoles('hr', 'admin'), salarySettingRoutes);
-app.use('/api/attendance-settings', authenticate, authorizeRoles('hr', 'admin'), attendanceSettingRoutes);
 
 
 


### PR DESCRIPTION
## Summary
- delete the duplicate attendance settings route in `server/src/index.js`

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*