### PR TITLE
Add API base URL configuration

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,5 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+
+export function apiFetch(path, options = {}) {
+  return fetch(`${API_BASE_URL}${path}`, options)
+}

--- a/client/src/components/backComponents/AttendanceManagementSetting.vue
+++ b/client/src/components/backComponents/AttendanceManagementSetting.vue
@@ -77,7 +77,8 @@
   </template>
   
   <script setup>
-  import { ref, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { apiFetch } from '../../api'
   
   const form = ref({
     // 1) 資料匯入設定
@@ -105,7 +106,7 @@
   const token = localStorage.getItem('token') || ''
 
   async function fetchSetting() {
-    const res = await fetch('/api/attendance-settings', {
+    const res = await apiFetch('/api/attendance-settings', {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (res.ok) {
@@ -121,13 +122,13 @@
     const payload = { ...form.value }
     let res
     if (settingId.value) {
-      res = await fetch(`/api/attendance-settings/${settingId.value}`, {
+      res = await apiFetch(`/api/attendance-settings/${settingId.value}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload)
       })
     } else {
-      res = await fetch('/api/attendance-settings', {
+      res = await apiFetch('/api/attendance-settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload)

--- a/client/src/components/backComponents/AttendanceSetting.vue
+++ b/client/src/components/backComponents/AttendanceSetting.vue
@@ -124,11 +124,12 @@
   
   <script setup>
   import { ref, onMounted } from 'vue'
+  import { apiFetch } from '../../api'
 
   const token = localStorage.getItem('token') || ''
 
   async function loadSettings() {
-    const res = await fetch('/api/attendance-settings', {
+    const res = await apiFetch('/api/attendance-settings', {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (res.ok) {
@@ -147,7 +148,7 @@
       breakOutRules: breakOutForm.value,
       overtimeRules: overtimeForm.value
     }
-    await fetch('/api/attendance-settings', {
+    await apiFetch('/api/attendance-settings', {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/components/backComponents/SalaryManagementSetting.vue
+++ b/client/src/components/backComponents/SalaryManagementSetting.vue
@@ -198,6 +198,7 @@
   
 <script setup>
 import { ref, onMounted } from 'vue'
+import { apiFetch } from '../../api'
   
   // 目前所在的Tab
 const activeTab = ref('salaryItem')
@@ -371,7 +372,7 @@ const settingId = ref(null)
   }
 
   async function fetchSetting() {
-    const res = await fetch('/api/salary-settings', {
+    const res = await apiFetch('/api/salary-settings', {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (res.ok) {
@@ -400,7 +401,7 @@ const settingId = ref(null)
       ? `/api/salary-settings/${settingId.value}`
       : '/api/salary-settings'
     const method = settingId.value ? 'PUT' : 'POST'
-    const res = await fetch(url, {
+    const res = await apiFetch(url, {
       method,
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/stores/menu.js
+++ b/client/src/stores/menu.js
@@ -1,12 +1,13 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import { apiFetch } from '../api'
 
 export const useMenuStore = defineStore('menu', () => {
   const items = ref([])
 
   async function fetchMenu() {
     const token = localStorage.getItem('token')
-    const res = await fetch('/api/menu', {
+    const res = await apiFetch('/api/menu', {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (res.ok) {

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -30,6 +30,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMenuStore } from '../stores/menu'
 import { storeToRefs } from 'pinia'
+import { apiFetch } from '../api'
   
 const router = useRouter()
 const menuStore = useMenuStore()
@@ -41,7 +42,7 @@ const menuStore = useMenuStore()
   const loginFormRef = ref(null)
   
   const onLogin = async () => {
-    const res = await fetch('/api/login', {
+    const res = await apiFetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(loginForm.value)

--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -20,12 +20,13 @@
   
 <script setup>
 import { ref, onMounted } from 'vue'
+import { apiFetch } from '../../api'
 
 const pendingList = ref([])
 const token = localStorage.getItem('token') || ''
 
 async function fetchApprovals() {
-  const res = await fetch('/api/approvals', {
+  const res = await apiFetch('/api/approvals', {
     headers: { Authorization: `Bearer ${token}` }
   })
   if (res.ok) {
@@ -35,7 +36,7 @@ async function fetchApprovals() {
 
 async function approve(index) {
   const item = pendingList.value[index]
-  const res = await fetch(`/api/approvals/${item._id}/approve`, {
+  const res = await apiFetch(`/api/approvals/${item._id}/approve`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` }
   })
@@ -46,7 +47,7 @@ async function approve(index) {
 
 async function reject(index) {
   const item = pendingList.value[index]
-  const res = await fetch(`/api/approvals/${item._id}/reject`, {
+  const res = await apiFetch(`/api/approvals/${item._id}/reject`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` }
   })

--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -34,6 +34,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
+import { apiFetch } from '../../api'
 
 // 將中文動作與後端定義的值互轉
 const actionMap = {
@@ -50,7 +51,7 @@ const records = ref([])
 const token = localStorage.getItem('token') || ''
 
 async function fetchRecords() {
-  const res = await fetch('/api/attendance', {
+  const res = await apiFetch('/api/attendance', {
     headers: { Authorization: `Bearer ${token}` }
   })
   if (res.ok) {
@@ -83,7 +84,7 @@ async function addRecord(action) {
     remark: '',
     employee: localStorage.getItem('employeeId') || ''
   }
-  const res = await fetch('/api/attendance', {
+  const res = await apiFetch('/api/attendance', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -37,6 +37,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMenuStore } from '../../stores/menu'
+import { apiFetch } from '../../api'
   
 const router = useRouter()
 const menuStore = useMenuStore()
@@ -49,7 +50,7 @@ const menuStore = useMenuStore()
   const loginFormRef = ref(null)
   
 async function onLogin () {
-  const res = await fetch('/api/login', {
+  const res = await apiFetch('/api/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username: loginForm.value.username, password: loginForm.value.password })

--- a/client/src/views/front/Leave.vue
+++ b/client/src/views/front/Leave.vue
@@ -61,6 +61,7 @@
   <script setup>
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
+import { apiFetch } from '../../api'
   
   const leaveForm = ref({
     leaveType: '',
@@ -74,7 +75,7 @@ const leaveRecords = ref([])
 const token = localStorage.getItem('token') || ''
 
 async function fetchLeaves() {
-  const res = await fetch('/api/leaves', {
+  const res = await apiFetch('/api/leaves', {
     headers: { Authorization: `Bearer ${token}` }
   })
   if (res.ok) {
@@ -90,7 +91,7 @@ async function onSubmitLeave() {
     endDate: leaveForm.value.endDate,
     reason: leaveForm.value.reason
   }
-  const res = await fetch('/api/leaves', {
+  const res = await apiFetch('/api/leaves', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -30,13 +30,14 @@
   <script setup>
   import { ref, onMounted } from 'vue'
   import dayjs from 'dayjs'
+  import { apiFetch } from '../../api'
 
   const schedules = ref([])
   const scheduleForm = ref({ date: '', shiftType: '' })
   const token = localStorage.getItem('token') || ''
 
   async function fetchSchedules() {
-    const res = await fetch('/api/schedules', {
+    const res = await apiFetch('/api/schedules', {
       headers: { Authorization: `Bearer ${token}` }
     })
     if (res.ok) {
@@ -50,7 +51,7 @@
       date: scheduleForm.value.date,
       shiftType: scheduleForm.value.shiftType
     }
-    const res = await fetch('/api/schedules', {
+    const res = await apiFetch('/api/schedules', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,29 +1,32 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [
+      vue(),
+      vueDevTools(),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+      },
     },
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true
+        }
       }
+    },
+    test: {
+      environment: 'jsdom'
     }
-  },
-  test: {
-    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- allow configuring API base URL with `.env` file
- update Vite proxy to use the environment variable
- centralize fetch calls through `apiFetch`
- adjust existing components and store to use `apiFetch`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in `server` *(fails: jest not found)*