### PR TITLE
Handle model errors in list APIs

### DIFF
--- a/server/src/controllers/approvalController.js
+++ b/server/src/controllers/approvalController.js
@@ -1,8 +1,12 @@
 import Approval from '../models/Approval.js';
 
 export async function listApprovals(req, res) {
-  const approvals = await Approval.find().populate('applicant');
-  res.json(approvals);
+  try {
+    const approvals = await Approval.find().populate('applicant');
+    res.json(approvals);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function approve(req, res) {

--- a/server/src/controllers/attendanceController.js
+++ b/server/src/controllers/attendanceController.js
@@ -1,8 +1,12 @@
 import AttendanceRecord from '../models/AttendanceRecord.js';
 
 export async function listRecords(req, res) {
-  const records = await AttendanceRecord.find().populate('employee');
-  res.json(records);
+  try {
+    const records = await AttendanceRecord.find().populate('employee');
+    res.json(records);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createRecord(req, res) {

--- a/server/src/controllers/attendanceSettingController.js
+++ b/server/src/controllers/attendanceSettingController.js
@@ -2,8 +2,12 @@
 import AttendanceManagementSetting from '../models/AttendanceManagementSetting.js';
 
 export async function listSettings(req, res) {
-  const settings = await AttendanceManagementSetting.find();
-  res.json(settings);
+  try {
+    const settings = await AttendanceManagementSetting.find();
+    res.json(settings);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createSetting(req, res) {

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -1,8 +1,12 @@
 import Employee from '../models/Employee.js';
 
 export async function listEmployees(req, res) {
-  const employees = await Employee.find();
-  res.json(employees);
+  try {
+    const employees = await Employee.find();
+    res.json(employees);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createEmployee(req, res) {

--- a/server/src/controllers/insuranceController.js
+++ b/server/src/controllers/insuranceController.js
@@ -1,8 +1,12 @@
 import InsuranceRecord from '../models/InsuranceRecord.js';
 
 export async function listInsurance(req, res) {
-  const records = await InsuranceRecord.find().populate('employee');
-  res.json(records);
+  try {
+    const records = await InsuranceRecord.find().populate('employee');
+    res.json(records);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createInsurance(req, res) {

--- a/server/src/controllers/leaveController.js
+++ b/server/src/controllers/leaveController.js
@@ -1,8 +1,12 @@
 import LeaveRequest from '../models/LeaveRequest.js';
 
 export async function listLeaves(req, res) {
-  const leaves = await LeaveRequest.find().populate('employee');
-  res.json(leaves);
+  try {
+    const leaves = await LeaveRequest.find().populate('employee');
+    res.json(leaves);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createLeave(req, res) {

--- a/server/src/controllers/payrollController.js
+++ b/server/src/controllers/payrollController.js
@@ -1,8 +1,12 @@
 import PayrollRecord from '../models/PayrollRecord.js';
 
 export async function listPayrolls(req, res) {
-  const records = await PayrollRecord.find().populate('employee');
-  res.json(records);
+  try {
+    const records = await PayrollRecord.find().populate('employee');
+    res.json(records);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createPayroll(req, res) {

--- a/server/src/controllers/reportController.js
+++ b/server/src/controllers/reportController.js
@@ -1,8 +1,12 @@
 import Report from '../models/Report.js';
 
 export async function listReports(req, res) {
-  const reports = await Report.find();
-  res.json(reports);
+  try {
+    const reports = await Report.find();
+    res.json(reports);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createReport(req, res) {

--- a/server/src/controllers/salarySettingController.js
+++ b/server/src/controllers/salarySettingController.js
@@ -1,8 +1,12 @@
 import SalarySetting from '../models/SalarySetting.js';
 
 export async function listSettings(req, res) {
-  const settings = await SalarySetting.find();
-  res.json(settings);
+  try {
+    const settings = await SalarySetting.find();
+    res.json(settings);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createSetting(req, res) {

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -1,8 +1,12 @@
 import ShiftSchedule from '../models/ShiftSchedule.js';
 
 export async function listSchedules(req, res) {
-  const schedules = await ShiftSchedule.find().populate('employee');
-  res.json(schedules);
+  try {
+    const schedules = await ShiftSchedule.find().populate('employee');
+    res.json(schedules);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 }
 
 export async function createSchedule(req, res) {

--- a/server/tests/approval.test.js
+++ b/server/tests/approval.test.js
@@ -33,6 +33,13 @@ describe('Approval API', () => {
     expect(res.body).toEqual(fakeApprovals);
   });
 
+  it('returns 500 if listing fails', async () => {
+    Approval.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/approvals');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('approves request', async () => {
     Approval.findByIdAndUpdate.mockResolvedValue({ status: 'approved' });
     const res = await request(app).post('/api/approvals/123/approve');

--- a/server/tests/attendance.test.js
+++ b/server/tests/attendance.test.js
@@ -32,6 +32,13 @@ describe('Attendance API', () => {
     expect(res.body).toEqual(fakeRecords);
   });
 
+  it('returns 500 if listing fails', async () => {
+    AttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/attendance');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates record', async () => {
     const payload = { action: 'clockIn' };
     saveMock.mockResolvedValue();

--- a/server/tests/attendanceSetting.test.js
+++ b/server/tests/attendanceSetting.test.js
@@ -34,6 +34,13 @@ describe('AttendanceSetting API', () => {
     expect(res.body).toEqual(data);
   });
 
+  it('returns 500 if listing fails', async () => {
+    AttendanceSetting.findOne.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/attendance-settings');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('updates settings', async () => {
     const payload = { shifts: [] };
     AttendanceSetting.findOneAndUpdate.mockResolvedValue(payload);

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -32,6 +32,13 @@ describe('Employee API', () => {
     expect(res.body).toEqual(fakeEmployees);
   });
 
+  it('returns 500 if listing fails', async () => {
+    Employee.find.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/employees');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates employee', async () => {
     const newEmp = { name: 'Jane' };
     saveMock.mockResolvedValue();

--- a/server/tests/insurance.test.js
+++ b/server/tests/insurance.test.js
@@ -32,6 +32,13 @@ describe('Insurance API', () => {
     expect(res.body).toEqual(fakeRecords);
   });
 
+  it('returns 500 if listing fails', async () => {
+    InsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/insurance');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates insurance record', async () => {
     const payload = { provider: 'InsureCo' };
     saveMock.mockResolvedValue();

--- a/server/tests/leave.test.js
+++ b/server/tests/leave.test.js
@@ -32,6 +32,13 @@ describe('Leave API', () => {
     expect(res.body).toEqual(fakeLeaves);
   });
 
+  it('returns 500 if listing fails', async () => {
+    LeaveRequest.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/leaves');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates leave', async () => {
     const payload = { leaveType: 'vacation' };
     saveMock.mockResolvedValue();

--- a/server/tests/payroll.test.js
+++ b/server/tests/payroll.test.js
@@ -32,6 +32,13 @@ describe('Payroll API', () => {
     expect(res.body).toEqual(fakeRecords);
   });
 
+  it('returns 500 if listing fails', async () => {
+    PayrollRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/payroll');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates payroll record', async () => {
     const payload = { amount: 100 };
     saveMock.mockResolvedValue();

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -32,6 +32,13 @@ describe('Report API', () => {
     expect(res.body).toEqual(fakeReports);
   });
 
+  it('returns 500 if listing fails', async () => {
+    Report.find.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/reports');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates report', async () => {
     const payload = { name: 'Monthly' };
     saveMock.mockResolvedValue();

--- a/server/tests/salarySetting.test.js
+++ b/server/tests/salarySetting.test.js
@@ -34,6 +34,13 @@ describe('SalarySetting API', () => {
     expect(res.body).toEqual(fake);
   });
 
+  it('returns 500 if listing fails', async () => {
+    SalarySetting.find.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/salary-settings');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates setting', async () => {
     const payload = { salaryItems: [] };
     saveMock.mockResolvedValue();

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -32,6 +32,13 @@ describe('Schedule API', () => {
     expect(res.body).toEqual(fakeSchedules);
   });
 
+  it('returns 500 if listing fails', async () => {
+    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    const res = await request(app).get('/api/schedules');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   it('creates schedule', async () => {
     const payload = { shiftType: 'morning' };
     saveMock.mockResolvedValue();


### PR DESCRIPTION
## Summary
- catch model errors in list endpoints and send HTTP 500
- add unit tests for list error handling

## Testing
- `npm test --prefix server` *(fails: jest not found)*