### PR TITLE
Update employeeId storage in login

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -51,7 +51,8 @@ const menuStore = useMenuStore()
       const data = await res.json()
       localStorage.setItem('token', data.token)
       localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.id)
+      // Store the employee ID provided by the API response
+      localStorage.setItem('employeeId', data.user.employeeId)
       await menuStore.fetchMenu()
       router.push({ name: 'Settings' })
     } else {

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -59,7 +59,8 @@ async function onLogin () {
     const data = await res.json()
     localStorage.setItem('token', data.token)
     localStorage.setItem('role', data.user.role)
-    localStorage.setItem('employeeId', data.user.id)
+    // Store the employee ID provided by the API response
+    localStorage.setItem('employeeId', data.user.employeeId)
     await menuStore.fetchMenu()
 
     switch (data.user.role) {


### PR DESCRIPTION
## Summary
- store `employeeId` from login response in login views
- confirm attendance, leave, and schedule views still read `employeeId` from localStorage

## Testing
- `npm test` *(fails: jest not found)*