### PR TITLE
Implement employee update and delete endpoints

### DIFF
--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -18,3 +18,23 @@ export async function createEmployee(req, res) {
     res.status(400).json({ error: err.message });
   }
 }
+
+export async function updateEmployee(req, res) {
+  try {
+    const employee = await Employee.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!employee) return res.status(404).json({ error: 'Not found' });
+    res.json(employee);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteEmployee(req, res) {
+  try {
+    const employee = await Employee.findByIdAndDelete(req.params.id);
+    if (!employee) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/routes/employeeRoutes.js
+++ b/server/src/routes/employeeRoutes.js
@@ -1,9 +1,16 @@
 import { Router } from 'express';
-import { listEmployees, createEmployee } from '../controllers/employeeController.js';
+import {
+  listEmployees,
+  createEmployee,
+  updateEmployee,
+  deleteEmployee
+} from '../controllers/employeeController.js';
 
 const router = Router();
 
 router.get('/', listEmployees);
 router.post('/', createEmployee);
+router.put('/:id', updateEmployee);
+router.delete('/:id', deleteEmployee);
 
 export default router;

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -5,6 +5,8 @@ import { jest } from '@jest/globals';
 const saveMock = jest.fn();
 const Employee = jest.fn().mockImplementation(() => ({ save: saveMock }));
 Employee.find = jest.fn();
+Employee.findByIdAndUpdate = jest.fn();
+Employee.findByIdAndDelete = jest.fn();
 
 jest.mock('../src/models/Employee.js', () => ({ default: Employee }), { virtual: true });
 
@@ -21,6 +23,8 @@ beforeAll(async () => {
 beforeEach(() => {
   saveMock.mockReset();
   Employee.find.mockReset();
+  Employee.findByIdAndUpdate.mockReset();
+  Employee.findByIdAndDelete.mockReset();
 });
 
 describe('Employee API', () => {
@@ -46,5 +50,19 @@ describe('Employee API', () => {
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
     expect(res.body).toMatchObject(newEmp);
+  });
+
+  it('updates employee', async () => {
+    Employee.findByIdAndUpdate.mockResolvedValue({ _id: '1', name: 'Jane' });
+    const res = await request(app).put('/api/employees/1').send({ name: 'Jane' });
+    expect(res.status).toBe(200);
+    expect(Employee.findByIdAndUpdate).toHaveBeenCalledWith('1', { name: 'Jane' }, { new: true });
+  });
+
+  it('deletes employee', async () => {
+    Employee.findByIdAndDelete.mockResolvedValue({ _id: '1' });
+    const res = await request(app).delete('/api/employees/1');
+    expect(res.status).toBe(200);
+    expect(Employee.findByIdAndDelete).toHaveBeenCalledWith('1');
   });
 });


### PR DESCRIPTION
## Summary
- support updating/deleting employees in controller and routes
- test new PUT and DELETE endpoints

## Testing
- `npm test --prefix server` *(fails: jest not found)*