### PR TITLE
Update login storage tests

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -51,7 +51,7 @@ const menuStore = useMenuStore()
       const data = await res.json()
       localStorage.setItem('token', data.token)
       localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.id)
+      localStorage.setItem('employeeId', data.user.employeeId)
       await menuStore.fetchMenu()
       router.push({ name: 'Settings' })
     } else {

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -59,7 +59,7 @@ async function onLogin () {
     const data = await res.json()
     localStorage.setItem('token', data.token)
     localStorage.setItem('role', data.user.role)
-    localStorage.setItem('employeeId', data.user.id)
+    localStorage.setItem('employeeId', data.user.employeeId)
     await menuStore.fetchMenu()
 
     switch (data.user.role) {

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -17,11 +17,11 @@ describe('FrontLogin.vue', () => {
   })
 
 
-  it('stores role on login', async () => {
+  it('stores role and employeeId on login', async () => {
     fetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ token: 't', user: { role: 'employee' } })
+        json: async () => ({ token: 't', user: { role: 'employee', employeeId: 'e1' } })
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -30,7 +30,7 @@ describe('FrontLogin.vue', () => {
     const wrapper = mount(FrontLogin)
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('role')).toBe('employee')
-    expect(localStorage.getItem('employeeId')).toBeDefined()
+    expect(localStorage.getItem('employeeId')).toBe('e1')
   })
 
   it('stores HR role when API returns hr', async () => {


### PR DESCRIPTION
## Summary
- expect employeeId value from API in FrontLogin unit test
- store employeeId from response in Login views

## Testing
- `npm --prefix server test` *(fails: jest not found)*
