### PR TITLE
Fix employeeId storage

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -51,7 +51,7 @@ const menuStore = useMenuStore()
       const data = await res.json()
       localStorage.setItem('token', data.token)
       localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.id)
+      localStorage.setItem('employeeId', data.user.employeeId)
       await menuStore.fetchMenu()
       router.push({ name: 'Settings' })
     } else {

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -59,7 +59,7 @@ async function onLogin () {
     const data = await res.json()
     localStorage.setItem('token', data.token)
     localStorage.setItem('role', data.user.role)
-    localStorage.setItem('employeeId', data.user.id)
+    localStorage.setItem('employeeId', data.user.employeeId)
     await menuStore.fetchMenu()
 
     switch (data.user.role) {


### PR DESCRIPTION
## Summary
- store `employeeId` using `data.user.employeeId` in login views

## Testing
- `npm test` *(fails: jest: not found)*