### PR TITLE
Add employee info fields

### DIFF
--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -11,7 +11,8 @@ export async function listEmployees(req, res) {
 
 export async function createEmployee(req, res) {
   try {
-    const employee = new Employee(req.body);
+    const { name, email, role, department, title, status } = req.body;
+    const employee = new Employee({ name, email, role, department, title, status });
     await employee.save();
     res.status(201).json(employee);
   } catch (err) {

--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -3,7 +3,10 @@ import mongoose from 'mongoose';
 const employeeSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
-  role: { type: String, enum: ['employee', 'supervisor', 'hr', 'admin'], default: 'employee' }
+  role: { type: String, enum: ['employee', 'supervisor', 'hr', 'admin'], default: 'employee' },
+  department: { type: String },
+  title: { type: String },
+  status: { type: String, default: '在職' }
 }, { timestamps: true });
 
 export default mongoose.model('Employee', employeeSchema);

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -25,7 +25,12 @@ beforeEach(() => {
 
 describe('Employee API', () => {
   it('lists employees', async () => {
-    const fakeEmployees = [{ name: 'John' }];
+    const fakeEmployees = [{
+      name: 'John',
+      department: 'DEP001',
+      title: 'Manager',
+      status: '在職'
+    }];
     Employee.find.mockResolvedValue(fakeEmployees);
     const res = await request(app).get('/api/employees');
     expect(res.status).toBe(200);
@@ -40,7 +45,11 @@ describe('Employee API', () => {
   });
 
   it('creates employee', async () => {
-    const newEmp = { name: 'Jane' };
+    const newEmp = {
+      name: 'Jane',
+      department: 'DEP002',
+      title: 'Engineer'
+    };
     saveMock.mockResolvedValue();
     const res = await request(app).post('/api/employees').send(newEmp);
     expect(res.status).toBe(201);


### PR DESCRIPTION
## Summary
- extend Employee model with department, title and status
- accept those fields in `createEmployee`
- adapt tests for extra fields

## Testing
- `npm test` *(fails: jest not found)*