### PR TITLE
Fix supertest dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "nodemon": "^3.0.3",
     "jest": "^29.7.0",
-    "supertest": "^6.4.2",
+    "supertest": "^6.3.3",
     "@jest/globals": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- correct the supertest dev dependency version so `npm install` works

## Testing
- `npm test` *(fails: jest not found)*