### PR TITLE
Fix supertest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@
    ```bash
    npm install
    ```
-2. 啟動 Vite 開發伺服器：
+2. (選擇性) 在 `client/.env` 設定 `VITE_API_BASE_URL` 以指定後端 API 位址，預設可使用 `http://localhost:3000`
+3. 啟動 Vite 開發伺服器：
    ```bash
    npm run dev
    ```
-3. 需要時可建立正式版：
+4. 需要時可建立正式版：
    ```bash
    npm run build
    ```

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
+# Example Vite environment variables
 VITE_API_BASE_URL=http://localhost:3000

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,4 +1,5 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
 
 export function apiFetch(path, options = {}) {
   return fetch(`${API_BASE_URL}${path}`, options)

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,5 +1,6 @@
 // src/main.js
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import ElementPlus from 'element-plus'
@@ -7,6 +8,8 @@ import 'element-plus/dist/index.css'
 import './assets/main.css'
 
 const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
 app.use(router)
 app.use(ElementPlus)
 app.mount('#app')

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,6 +7,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const API_BASE_URL = env.VITE_API_BASE_URL || 'http://localhost:3000'
   return {
     plugins: [
       vue(),
@@ -20,7 +21,7 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         '/api': {
-          target: env.VITE_API_BASE_URL,
+          target: API_BASE_URL,
           changeOrigin: true
         }
       }

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "nodemon": "^3.0.3",
     "jest": "^29.7.0",
-    "supertest": "^6.4.2",
+    "supertest": "^6.3.3",
     "@jest/globals": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- correct the supertest dev dependency version so `npm install` works
- add Pinia initialization and default API URL so login succeeds
- update example environment file and README

## Testing
- `npm test` *(fails: jest not found)*