### PR TITLE
Ensure API base URL fallback

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,3 @@
 # Example Vite environment variables
+# If not set, VITE_API_BASE_URL defaults to http://localhost:3000
 VITE_API_BASE_URL=http://localhost:3000

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,5 +1,5 @@
 export const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
 
 export function apiFetch(path, options = {}) {
   return fetch(`${API_BASE_URL}${path}`, options)

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,7 +7,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  const API_BASE_URL = env.VITE_API_BASE_URL || 'http://localhost:3000'
+  const API_BASE_URL = env.VITE_API_BASE_URL ?? 'http://localhost:3000'
   return {
     plugins: [
       vue(),


### PR DESCRIPTION
## Summary
- handle undefined API base URL with `??` in `vite.config.js`
- mirror the same default logic in `src/api.js`
- document the default value in `.env.example`

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*