### PR TITLE
Implement logout storage clearing

### DIFF
--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -12,9 +12,12 @@
   
   const router = useRouter()
   
-  const logout = () => {
-    router.push({ name: 'Login' })
-  }
+const logout = () => {
+  localStorage.removeItem('token')
+  localStorage.removeItem('role')
+  localStorage.removeItem('employeeId')
+  router.push({ name: 'Login' })
+}
   </script>
   
   <style scoped>

--- a/client/tests/logout.spec.js
+++ b/client/tests/logout.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Settings from '../src/views/Settings.vue'
+
+const pushMock = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock })
+}))
+
+describe('Settings.vue logout', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 't')
+    localStorage.setItem('role', 'r')
+    localStorage.setItem('employeeId', 'e')
+    pushMock.mockClear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('removes auth values and redirects', async () => {
+    const wrapper = mount(Settings)
+    await wrapper.find('button').trigger('click')
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(localStorage.getItem('role')).toBeNull()
+    expect(localStorage.getItem('employeeId')).toBeNull()
+    expect(pushMock).toHaveBeenCalledWith({ name: 'Login' })
+  })
+})

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,10 +1,14 @@
-import jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken'
+import { isTokenBlacklisted } from '../utils/tokenBlacklist.js'
 
 export function authenticate(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader) return res.status(401).json({ error: 'No token' });
 
-  const token = authHeader.split(' ')[1];
+  const token = authHeader.split(' ')[1]
+  if (isTokenBlacklisted(token)) {
+    return res.status(401).json({ error: 'Invalid token' })
+  }
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
     req.user = decoded;

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -1,6 +1,7 @@
-import { Router } from 'express';
-import jwt from 'jsonwebtoken';
-import User from '../models/User.js';
+import { Router } from 'express'
+import jwt from 'jsonwebtoken'
+import User from '../models/User.js'
+import { blacklistToken } from '../utils/tokenBlacklist.js'
 
 const router = Router();
 
@@ -15,5 +16,14 @@ router.post('/login', async (req, res) => {
   const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
   res.json({ token, user: { id: user._id, role: user.role, username: user.username, employeeId: user.employee } });
 });
+
+router.post('/logout', (req, res) => {
+  const auth = req.headers.authorization
+  if (auth) {
+    const token = auth.split(' ')[1]
+    blacklistToken(token)
+  }
+  res.status(204).end()
+})
 
 export default router;

--- a/server/src/utils/tokenBlacklist.js
+++ b/server/src/utils/tokenBlacklist.js
@@ -1,0 +1,9 @@
+const invalidTokens = new Set()
+
+export function blacklistToken(token) {
+  if (token) invalidTokens.add(token)
+}
+
+export function isTokenBlacklisted(token) {
+  return invalidTokens.has(token)
+}

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,7 +1,8 @@
-import request from 'supertest';
-import express from 'express';
-import { jest } from '@jest/globals';
-import jwt from 'jsonwebtoken';
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+import jwt from 'jsonwebtoken'
+import { isTokenBlacklisted } from '../src/utils/tokenBlacklist.js'
 
 const compareMock = jest.fn();
 const fakeUser = { _id: 'u1', role: 'employee', username: 'john', employee: 'e1', comparePassword: compareMock };
@@ -42,4 +43,10 @@ describe('Auth API', () => {
     const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' });
     expect(res.status).toBe(401);
   });
+
+  it('invalidates token on logout', async () => {
+    const res = await request(app).post('/api/logout').set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(204)
+    expect(isTokenBlacklisted('tok')).toBe(true)
+  })
 });


### PR DESCRIPTION
## Summary
- ensure Settings logout clears `token`, `role`, and `employeeId` from localStorage
- add logout test for Settings view
- add server logout endpoint and token blacklist
- reject blacklisted tokens via middleware
- test server logout route

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*