### PR TITLE
Remove unused loadEmployees

### DIFF
--- a/client/src/components/backComponents/HRManagementSystemSetting.vue
+++ b/client/src/components/backComponents/HRManagementSystemSetting.vue
@@ -261,13 +261,6 @@
     }
   }
 
-  async function loadEmployees() {
-    const res = await fetch('/api/employees')
-
-    if (res.ok) {
-      employeeList.value = await res.json()
-    }
-  }
 
 
   onMounted(fetchEmployees)


### PR DESCRIPTION
## Summary
- drop the `loadEmployees` helper

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*