### PR TITLE
Add user and department management API

### DIFF
--- a/client/src/components/backComponents/HRManagementSystemSetting.vue
+++ b/client/src/components/backComponents/HRManagementSystemSetting.vue
@@ -177,14 +177,10 @@
 
   import { apiFetch } from '../../api'
 
-  const activeTab = ref('accountRole')
-  
-  // ============== (1) 帳號與權限 ==============
-  const userList = ref([
-    { username: 'admin001', role: 'admin', department: 'DEP001' },
-    { username: 'hr01', role: 'hr', department: 'DEP002' },
-    { username: 'sup01', role: 'supervisor', department: 'DEP003' }
-  ])
+const activeTab = ref('accountRole')
+
+// ============== (1) 帳號與權限 ==============
+const userList = ref([])
   
   const userDialogVisible = ref(false)
   let editUserIndex = null
@@ -196,12 +192,27 @@
     department: ''
   })
   
-  // 假的部門下拉選單
-  const departmentList = ref([
-    { label: '人事部', value: 'DEP001' },
-    { label: '財務部', value: 'DEP002' },
-    { label: '業務部', value: 'DEP003' }
-  ])
+const departmentList = ref([])
+
+async function fetchUsers() {
+  const token = localStorage.getItem('token') || ''
+  const res = await apiFetch('/api/users', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    userList.value = await res.json()
+  }
+}
+
+async function fetchDepartments() {
+  const token = localStorage.getItem('token') || ''
+  const res = await apiFetch('/api/departments', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    departmentList.value = await res.json()
+  }
+}
   
   function openUserDialog(index = null) {
     if (index !== null) {
@@ -214,23 +225,41 @@
     userDialogVisible.value = true
   }
   
-  function saveUser() {
+  async function saveUser() {
+    const payload = { ...userForm.value }
+    const token = localStorage.getItem('token') || ''
+    let res
     if (editUserIndex === null) {
-      userList.value.push({ ...userForm.value })
+      res = await apiFetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload)
+      })
     } else {
-      // 若 password 為空就不更新原密碼 (示範)
-      const original = userList.value[editUserIndex]
-      userList.value[editUserIndex] = {
-        ...original,
-        ...userForm.value,
-        password: userForm.value.password ? userForm.value.password : original.password
-      }
+      const id = userList.value[editUserIndex]._id
+      res = await apiFetch(`/api/users/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload)
+      })
     }
-    userDialogVisible.value = false
+    if (res && res.ok) {
+      await fetchUsers()
+      userDialogVisible.value = false
+    }
   }
-  
+
   function deleteUser(index) {
-    userList.value.splice(index, 1)
+    const token = localStorage.getItem('token') || ''
+    const id = userList.value[index]._id
+    apiFetch(`/api/users/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` }
+    }).then(res => {
+      if (res.ok) {
+        userList.value.splice(index, 1)
+      }
+    })
   }
   
   // ============== (2) 系統與機構基本資料 ==============
@@ -270,7 +299,11 @@
   }
 
 
-  onMounted(fetchEmployees)
+  onMounted(() => {
+    fetchUsers()
+    fetchDepartments()
+    fetchEmployees()
+  })
 
   const employeeDialogVisible = ref(false)
   let editEmployeeIndex = null
@@ -358,17 +391,40 @@
     deptDialogVisible.value = true
   }
   
-  function saveDept() {
+  async function saveDept() {
+    const token = localStorage.getItem('token') || ''
+    let res
     if (editDeptIndex === null) {
-      departmentList.value.push({ ...deptForm.value })
+      res = await apiFetch('/api/departments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(deptForm.value)
+      })
     } else {
-      departmentList.value[editDeptIndex] = { ...deptForm.value }
+      const id = departmentList.value[editDeptIndex]._id
+      res = await apiFetch(`/api/departments/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(deptForm.value)
+      })
     }
-    deptDialogVisible.value = false
+    if (res && res.ok) {
+      await fetchDepartments()
+      deptDialogVisible.value = false
+    }
   }
-  
+
   function deleteDept(index) {
-    departmentList.value.splice(index, 1)
+    const token = localStorage.getItem('token') || ''
+    const id = departmentList.value[index]._id
+    apiFetch(`/api/departments/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` }
+    }).then(res => {
+      if (res.ok) {
+        departmentList.value.splice(index, 1)
+      }
+    })
   }
   </script>
   

--- a/client/tests/hrManagement.spec.js
+++ b/client/tests/hrManagement.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import HRSetting from '../src/components/backComponents/HRManagementSystemSetting.vue'
+
+describe('HRManagementSystemSetting.vue', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }))
+    localStorage.setItem('token', 'tok')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('fetches lists on mount', async () => {
+    mount(HRSetting)
+    expect(fetch).toHaveBeenCalledWith('/api/users', expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer tok' })
+    }))
+    expect(fetch).toHaveBeenCalledWith('/api/departments', expect.any(Object))
+  })
+
+  it('creates user', async () => {
+    const wrapper = mount(HRSetting)
+    fetch.mockClear()
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    wrapper.vm.userForm = { username: 'u', password: 'p', role: 'hr', department: 'd1' }
+    wrapper.vm.editUserIndex = null
+    await wrapper.vm.saveUser()
+    expect(fetch).toHaveBeenCalledWith('/api/users', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('deletes department', async () => {
+    const wrapper = mount(HRSetting)
+    fetch.mockClear()
+    wrapper.vm.departmentList = [{ _id: '1', label: 'HR', value: 'D' }]
+    fetch.mockResolvedValueOnce({ ok: true })
+    await wrapper.vm.deleteDept(0)
+    expect(fetch).toHaveBeenCalledWith('/api/departments/1', expect.objectContaining({ method: 'DELETE' }))
+  })
+})

--- a/server/src/controllers/departmentController.js
+++ b/server/src/controllers/departmentController.js
@@ -1,0 +1,40 @@
+import Department from '../models/Department.js';
+
+export async function listDepartments(req, res) {
+  try {
+    const departments = await Department.find();
+    res.json(departments);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createDepartment(req, res) {
+  try {
+    const dept = new Department(req.body);
+    await dept.save();
+    res.status(201).json(dept);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateDepartment(req, res) {
+  try {
+    const dept = await Department.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!dept) return res.status(404).json({ error: 'Not found' });
+    res.json(dept);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteDepartment(req, res) {
+  try {
+    const dept = await Department.findByIdAndDelete(req.params.id);
+    if (!dept) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -1,0 +1,50 @@
+import User from '../models/User.js';
+
+export async function listUsers(req, res) {
+  try {
+    const users = await User.find().select('-password');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createUser(req, res) {
+  try {
+    const { username, password, role, department } = req.body;
+    const user = new User({ username, password, role, department });
+    await user.save();
+    const plain = user.toObject();
+    delete plain.password;
+    res.status(201).json(plain);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateUser(req, res) {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) return res.status(404).json({ error: 'Not found' });
+    if (req.body.username !== undefined) user.username = req.body.username;
+    if (req.body.password) user.password = req.body.password;
+    if (req.body.role !== undefined) user.role = req.body.role;
+    if (req.body.department !== undefined) user.department = req.body.department;
+    await user.save();
+    const plain = user.toObject();
+    delete plain.password;
+    res.json(plain);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteUser(req, res) {
+  try {
+    const user = await User.findByIdAndDelete(req.params.id);
+    if (!user) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -15,6 +15,8 @@ import reportRoutes from './routes/reportRoutes.js';
 import insuranceRoutes from './routes/insuranceRoutes.js';
 import approvalRoutes from './routes/approvalRoutes.js';
 import menuRoutes from './routes/menuRoutes.js';
+import userRoutes from './routes/userRoutes.js';
+import departmentRoutes from './routes/departmentRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
@@ -73,6 +75,8 @@ app.use('/api/reports', authenticate, authorizeRoles('hr', 'admin'), reportRoute
 app.use('/api/insurance', authenticate, authorizeRoles('hr', 'admin'), insuranceRoutes);
 app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admin'), approvalRoutes);
 app.use('/api/menu', authenticate, menuRoutes);
+app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
+app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);
 
 app.use('/api/salary-settings', authenticate, authorizeRoles('hr', 'admin'), salarySettingRoutes);
 

--- a/server/src/models/Department.js
+++ b/server/src/models/Department.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const departmentSchema = new mongoose.Schema({
+  label: String,
+  value: String
+}, { timestamps: true });
+
+export default mongoose.model('Department', departmentSchema);

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -9,7 +9,8 @@ const userSchema = new mongoose.Schema({
     enum: ['employee', 'supervisor', 'hr', 'admin'],
     default: 'employee'
   },
-  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' }
+  employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
+  department: String
 }, { timestamps: true });
 
 userSchema.pre('save', async function(next) {

--- a/server/src/routes/departmentRoutes.js
+++ b/server/src/routes/departmentRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  listDepartments,
+  createDepartment,
+  updateDepartment,
+  deleteDepartment
+} from '../controllers/departmentController.js';
+
+const router = Router();
+
+router.get('/', listDepartments);
+router.post('/', createDepartment);
+router.put('/:id', updateDepartment);
+router.delete('/:id', deleteDepartment);
+
+export default router;

--- a/server/src/routes/userRoutes.js
+++ b/server/src/routes/userRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  listUsers,
+  createUser,
+  updateUser,
+  deleteUser
+} from '../controllers/userController.js';
+
+const router = Router();
+
+router.get('/', listUsers);
+router.post('/', createUser);
+router.put('/:id', updateUser);
+router.delete('/:id', deleteUser);
+
+export default router;

--- a/server/tests/department.test.js
+++ b/server/tests/department.test.js
@@ -1,0 +1,57 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const Department = jest.fn().mockImplementation(() => ({ save: saveMock }));
+Department.find = jest.fn();
+Department.findByIdAndUpdate = jest.fn();
+Department.findByIdAndDelete = jest.fn();
+
+jest.mock('../src/models/Department.js', () => ({ default: Department }), { virtual: true });
+
+let app;
+let departmentRoutes;
+
+beforeAll(async () => {
+  departmentRoutes = (await import('../src/routes/departmentRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/departments', departmentRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  Department.find.mockReset();
+  Department.findByIdAndUpdate.mockReset();
+  Department.findByIdAndDelete.mockReset();
+});
+
+describe('Department API', () => {
+  it('lists departments', async () => {
+    Department.find.mockResolvedValue([{ label: 'HR' }]);
+    const res = await request(app).get('/api/departments');
+    expect(res.status).toBe(200);
+  });
+
+  it('creates department', async () => {
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/departments').send({ label: 'HR' });
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('updates department', async () => {
+    Department.findByIdAndUpdate.mockResolvedValue({ label: 'HR' });
+    const res = await request(app).put('/api/departments/1').send({ label: 'HR' });
+    expect(res.status).toBe(200);
+    expect(Department.findByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  it('deletes department', async () => {
+    Department.findByIdAndDelete.mockResolvedValue({});
+    const res = await request(app).delete('/api/departments/1');
+    expect(res.status).toBe(200);
+    expect(Department.findByIdAndDelete).toHaveBeenCalledWith('1');
+  });
+});

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const User = jest.fn().mockImplementation(() => ({ save: saveMock }));
+User.find = jest.fn();
+User.findById = jest.fn();
+User.findByIdAndDelete = jest.fn();
+
+jest.mock('../src/models/User.js', () => ({ default: User }), { virtual: true });
+
+let app;
+let userRoutes;
+
+beforeAll(async () => {
+  userRoutes = (await import('../src/routes/userRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/users', userRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  User.find.mockReset();
+  User.findById.mockReset();
+  User.findByIdAndDelete.mockReset();
+});
+
+describe('User API', () => {
+  it('lists users', async () => {
+    const fake = [{ username: 'a' }];
+    User.find.mockResolvedValue(fake);
+    const res = await request(app).get('/api/users');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fake);
+  });
+
+  it('creates user', async () => {
+    const payload = { username: 'u', password: 'p', role: 'hr' };
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/users').send(payload);
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('updates user', async () => {
+    User.findById.mockResolvedValue({ save: saveMock, username: 'u' });
+    saveMock.mockResolvedValue();
+    const res = await request(app).put('/api/users/1').send({ username: 'b' });
+    expect(res.status).toBe(200);
+    expect(User.findById).toHaveBeenCalledWith('1');
+  });
+
+  it('deletes user', async () => {
+    User.findByIdAndDelete.mockResolvedValue({});
+    const res = await request(app).delete('/api/users/1');
+    expect(res.status).toBe(200);
+    expect(User.findByIdAndDelete).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add Department model and expand User with department field
- implement user and department controllers and routes
- expose new endpoints in server
- fetch users/departments via API in HRManagementSystemSetting
- update user/department CRUD methods to call backend
- add unit tests for new endpoints and component

## Testing
- `npm test` *(fails: jest not found)*