### PR TITLE
Add shift schedule fields and update tests

### DIFF
--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -2,7 +2,9 @@ import ShiftSchedule from '../models/ShiftSchedule.js';
 
 export async function listSchedules(req, res) {
   try {
-    const schedules = await ShiftSchedule.find().populate('employee');
+    const schedules = await ShiftSchedule.find()
+      .populate('employee')
+      .populate('unit');
     res.json(schedules);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -21,7 +23,9 @@ export async function createSchedule(req, res) {
 
 export async function getSchedule(req, res) {
   try {
-    const schedule = await ShiftSchedule.findById(req.params.id).populate('employee');
+    const schedule = await ShiftSchedule.findById(req.params.id)
+      .populate('employee')
+      .populate('unit');
     if (!schedule) return res.status(404).json({ error: 'Not found' });
     res.json(schedule);
   } catch (err) {

--- a/server/src/models/ShiftSchedule.js
+++ b/server/src/models/ShiftSchedule.js
@@ -3,7 +3,11 @@ import mongoose from 'mongoose';
 const shiftScheduleSchema = new mongoose.Schema({
   employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
   date: { type: Date, required: true },
-  shiftType: { type: String, required: true }
+  shiftType: { type: String, required: true },
+  floor: String,
+  unit: { type: mongoose.Schema.Types.ObjectId, ref: 'Department' },
+  startTime: String,
+  endTime: String
 }, { timestamps: true });
 
 export default mongoose.model('ShiftSchedule', shiftScheduleSchema);

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -4,7 +4,7 @@ import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
 const ShiftSchedule = jest.fn().mockImplementation(() => ({ save: saveMock }));
-ShiftSchedule.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+ShiftSchedule.find = jest.fn();
 
 jest.mock('../src/models/ShiftSchedule.js', () => ({ default: ShiftSchedule }), { virtual: true });
 
@@ -25,22 +25,26 @@ beforeEach(() => {
 
 describe('Schedule API', () => {
   it('lists schedules', async () => {
-    const fakeSchedules = [{ shiftType: 'morning' }];
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
+    const fakeSchedules = [{ shiftType: 'morning', floor: '1F', startTime: '09:00', endTime: '17:00' }];
+    ShiftSchedule.find.mockReturnValue({
+      populate: jest.fn(() => ({ populate: jest.fn().mockResolvedValue(fakeSchedules) }))
+    });
     const res = await request(app).get('/api/schedules');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeSchedules);
   });
 
   it('returns 500 if listing fails', async () => {
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    ShiftSchedule.find.mockReturnValue({
+      populate: jest.fn(() => ({ populate: jest.fn().mockRejectedValue(new Error('fail')) }))
+    });
     const res = await request(app).get('/api/schedules');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
   });
 
   it('creates schedule', async () => {
-    const payload = { shiftType: 'morning' };
+    const payload = { shiftType: 'morning', floor: '1F', startTime: '09:00', endTime: '17:00' };
     saveMock.mockResolvedValue();
     const res = await request(app).post('/api/schedules').send(payload);
     expect(res.status).toBe(201);


### PR DESCRIPTION
## Summary
- extend `ShiftSchedule` model with floor/unit and time fields
- populate `unit` when listing or fetching schedules
- update schedule tests for new schema

## Testing
- `npm test` *(fails: jest not found)*