### PR TITLE
Implement schedule export download

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -24,6 +24,11 @@
         </el-table-column>
         <el-table-column prop="shiftType" label="班別" width="100" />
       </el-table>
+
+      <div style="margin-top: 20px;">
+        <el-button type="success" @click="downloadSchedules('pdf')">下載 PDF</el-button>
+        <el-button type="success" @click="downloadSchedules('excel')" style="margin-left: 10px;">下載 Excel</el-button>
+      </div>
     </div>
   </template>
 
@@ -35,6 +40,21 @@
   const schedules = ref([])
   const scheduleForm = ref({ date: '', shiftType: '' })
   const token = localStorage.getItem('token') || ''
+
+  async function downloadSchedules(format) {
+    const res = await apiFetch(`/api/schedules/export?format=${format}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    if (res.ok) {
+      const blob = await res.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = format === 'excel' ? 'schedules.xlsx' : 'schedules.pdf'
+      a.click()
+      window.URL.revokeObjectURL(url)
+    }
+  }
 
   async function fetchSchedules() {
     const res = await apiFetch('/api/schedules', {

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,9 @@
     "mongoose": "^7.6.1",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.0",
-    "express": "^4.18.4"
+    "express": "^4.18.4",
+    "pdfkit": "^0.13.0",
+    "exceljs": "^4.3.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -48,3 +48,65 @@ export async function deleteSchedule(req, res) {
     res.status(400).json({ error: err.message });
   }
 }
+
+export async function exportSchedules(req, res) {
+  try {
+    const schedules = await ShiftSchedule.find().populate('employee');
+    const format = req.query.format === 'excel' ? 'excel' : 'pdf';
+
+    if (format === 'excel') {
+      let ExcelJS;
+      try {
+        ExcelJS = (await import('exceljs')).default;
+      } catch (err) {
+        return res.status(500).json({ error: 'exceljs module not installed' });
+      }
+      const workbook = new ExcelJS.Workbook();
+      const ws = workbook.addWorksheet('Schedules');
+      ws.columns = [
+        { header: 'Employee', key: 'employee' },
+        { header: 'Date', key: 'date' },
+        { header: 'Shift Type', key: 'shiftType' }
+      ];
+      schedules.forEach((s) => {
+        ws.addRow({
+          employee: s.employee?.name ?? '',
+          date: new Date(s.date).toISOString().split('T')[0],
+          shiftType: s.shiftType
+        });
+      });
+      res.setHeader(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      );
+      res.setHeader('Content-Disposition', 'attachment; filename="schedules.xlsx"');
+      const buffer = await workbook.xlsx.writeBuffer();
+      return res.send(buffer);
+    } else {
+      let PDFDocument;
+      try {
+        PDFDocument = (await import('pdfkit')).default;
+      } catch (err) {
+        return res.status(500).json({ error: 'pdfkit module not installed' });
+      }
+      const doc = new PDFDocument();
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', 'attachment; filename="schedules.pdf"');
+      doc.fontSize(16).text('Schedules', { align: 'center' });
+      doc.moveDown();
+      schedules.forEach((s) => {
+        doc
+          .fontSize(12)
+          .text(
+            `${s.employee?.name ?? ''}\t${new Date(s.date)
+              .toISOString()
+              .split('T')[0]}\t${s.shiftType}`
+          );
+      });
+      doc.pipe(res);
+      doc.end();
+    }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -4,12 +4,14 @@ import {
   createSchedule,
   getSchedule,
   updateSchedule,
-  deleteSchedule
+  deleteSchedule,
+  exportSchedules
 } from '../controllers/scheduleController.js';
 
 const router = Router();
 
 router.get('/', listSchedules);
+router.get('/export', exportSchedules);
 router.post('/', createSchedule);
 router.get('/:id', getSchedule);
 router.put('/:id', updateSchedule);


### PR DESCRIPTION
## Summary
- add pdfkit and exceljs deps to server
- create schedule export controller and route
- expose `/api/schedules/export` endpoint
- add download buttons on the Schedule page
- test export endpoints

## Testing
- `npm test` *(fails: jest not found)*