### PR TITLE
Refine seed data to only create admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
    - `PORT` – 伺服器埠號
    - `MONGODB_URI` – MongoDB 連線字串
    - `JWT_SECRET` – (必填) JWT 簽章密鑰
+   - `ADMIN_USERNAME` – (選擇性) 初始管理員帳號
+   - `ADMIN_PASSWORD` – (選擇性) 初始管理員密碼
 3. 啟動開發伺服器（使用 nodemon）：
    ```bash
    npm run dev
@@ -49,16 +51,7 @@
    npm test
    ```
 
-首次啟動時會自動建立幾個測試帳號並同步產生對應的員工紀錄，預設密碼均為 `password`：
-
-| 帳號          | 角色         |
-|---------------|-------------|
-| `user`        | employee    |
-| `supervisor`  | supervisor  |
-| `hr`          | hr          |
-| `admin`       | admin       |
-
-更詳細說明請參閱 [`server/README.md`](server/README.md)。
+啟動時若 `.env` 檔案提供 `ADMIN_USERNAME` 與 `ADMIN_PASSWORD`，伺服器會自動建立一個管理員帳號。詳細說明請參閱 [`server/README.md`](server/README.md)。
 
 ## 前端 (`client/`)
 
@@ -80,7 +73,7 @@
 
 ## 開始使用
 
-前後端皆啟動後，開啟瀏覽器造訪前端網址（預設 http://localhost:5173 ），即可使用提供的測試帳號登入並與後端 API 互動。
+前後端皆啟動後，開啟瀏覽器造訪前端網址（預設 http://localhost:5173 ），即可使用管理員帳號登入並與後端 API 互動。
 
 
 ## 執行測試

--- a/client/README.md
+++ b/client/README.md
@@ -27,3 +27,21 @@ npm run dev
 ```sh
 npm run build
 ```
+
+## Employee form fields
+
+The HR Management screen creates employees using the following fields:
+
+- `name` (string)
+- `email` (string)
+- `role` (string)
+- `department` (string)
+- `title` (string)
+- `idNumber` (string)
+- `birthDate` (date)
+- `contact` (string)
+- `licenses` (array of strings)
+- `trainings` (array of strings)
+- `status` (string)
+
+There are no additional backend dependencies for these fields.

--- a/client/src/components/backComponents/HRManagementSystemSetting.vue
+++ b/client/src/components/backComponents/HRManagementSystemSetting.vue
@@ -120,6 +120,21 @@
                 <el-form-item label="職稱">
                   <el-input v-model="employeeForm.title" />
                 </el-form-item>
+                <el-form-item label="身分證字號">
+                  <el-input v-model="employeeForm.idNumber" />
+                </el-form-item>
+                <el-form-item label="出生日期">
+                  <el-date-picker v-model="employeeForm.birthDate" type="date" format="YYYY-MM-DD" />
+                </el-form-item>
+                <el-form-item label="聯絡方式">
+                  <el-input v-model="employeeForm.contact" />
+                </el-form-item>
+                <el-form-item label="證照">
+                  <el-input v-model="employeeForm.licenses" placeholder="以逗號分隔" />
+                </el-form-item>
+                <el-form-item label="教育訓練">
+                  <el-input v-model="employeeForm.trainings" placeholder="以逗號分隔" />
+                </el-form-item>
                 <el-form-item label="在職狀態">
                   <el-select v-model="employeeForm.status">
                     <el-option label="在職" value="在職" />
@@ -306,6 +321,11 @@ async function fetchDepartments() {
     name: '',
     department: '',
     title: '',
+    idNumber: '',
+    birthDate: '',
+    contact: '',
+    licenses: '',
+    trainings: '',
     status: '在職'
   })
   
@@ -314,17 +334,39 @@ async function fetchDepartments() {
       editEmployeeIndex = index
       const emp = employeeList.value[index]
       editEmployeeId = emp._id || ''
-      employeeForm.value = { ...emp }
+      employeeForm.value = {
+        ...emp,
+        licenses: Array.isArray(emp.licenses) ? emp.licenses.join(',') : '',
+        trainings: Array.isArray(emp.trainings) ? emp.trainings.join(',') : ''
+      }
     } else {
       editEmployeeIndex = null
       editEmployeeId = ''
-      employeeForm.value = { name: '', department: '', title: '', status: '在職' }
+      employeeForm.value = {
+        name: '',
+        department: '',
+        title: '',
+        idNumber: '',
+        birthDate: '',
+        contact: '',
+        licenses: '',
+        trainings: '',
+        status: '在職'
+      }
     }
     employeeDialogVisible.value = true
   }
 
   async function saveEmployee() {
-    const payload = { ...employeeForm.value }
+    const payload = {
+      ...employeeForm.value,
+      licenses: employeeForm.value.licenses
+        ? employeeForm.value.licenses.split(',').map(s => s.trim()).filter(Boolean)
+        : [],
+      trainings: employeeForm.value.trainings
+        ? employeeForm.value.trainings.split(',').map(s => s.trim()).filter(Boolean)
+        : []
+    }
 
     let res
     if (editEmployeeIndex === null) {

--- a/client/tests/employeeForm.spec.js
+++ b/client/tests/employeeForm.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import HRManagementSystemSetting from '../src/components/backComponents/HRManagementSystemSetting.vue'
+
+vi.mock('../src/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }))
+}))
+
+const { apiFetch } = require('../src/api')
+
+describe('Employee form', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sends licenses and trainings arrays', async () => {
+    const wrapper = mount(HRManagementSystemSetting, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.employeeForm = {
+      name: 'Jane',
+      department: 'HR',
+      title: 'Manager',
+      idNumber: 'A',
+      birthDate: '1990-01-01',
+      contact: '09',
+      licenses: 'A,B',
+      trainings: 'T1,T2',
+      status: '在職'
+    }
+    wrapper.vm.editEmployeeIndex = null
+    await wrapper.vm.saveEmployee()
+    const body = JSON.parse(apiFetch.mock.calls[0][1].body)
+    expect(body.licenses).toEqual(['A', 'B'])
+    expect(body.trainings).toEqual(['T1', 'T2'])
+  })
+})
+

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,6 @@ PORT=3000
 MONGODB_URI=mongodb://localhost/hr
 # JWT signing secret (required)
 JWT_SECRET=your_jwt_secret
+# Credentials for the initial admin account
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=password

--- a/server/README.md
+++ b/server/README.md
@@ -28,21 +28,32 @@ npm run dev
 
 This starts the server with nodemon enabled.
 
-### Seeding example data
+### Seeding initial data
 
-This repository provides a seeding script under `scripts/seed.js` to insert the default test users into MongoDB. Make sure your `.env` file includes a valid `MONGODB_URI` and run it with:
+The project includes a seeding script under `scripts/seed.js` which creates an initial admin user.  Provide `ADMIN_USERNAME` and `ADMIN_PASSWORD` in your `.env` and run:
 
 ```bash
 node scripts/seed.js
 ```
 
-When running in development, the server automatically seeds a few test users if they do not already exist.  Each user is also given a matching record in the `Employee` collection, and the employee id will be returned when logging in:
+When the server starts it will also attempt to create this admin account automatically if it does not already exist.
 
-| Username    | Role       |
-|-------------|-----------|
-| `user`      | employee  |
-| `supervisor`| supervisor|
-| `hr`        | hr        |
-| `admin`     | admin     |
+## Employee form fields
 
-All test accounts use the password `password`.
+The `Employee` model stores the following fields:
+
+| Field       | Type    | Description        |
+|-------------|---------|--------------------|
+| `name`      | String  | Employee name      |
+| `email`     | String  | Email address      |
+| `role`      | String  | one of `employee`, `supervisor`, `hr`, `admin` |
+| `department`| String  | Department name    |
+| `title`     | String  | Job title          |
+| `idNumber`  | String  | National ID number |
+| `birthDate` | Date    | Date of birth      |
+| `contact`   | String  | Contact info       |
+| `licenses`  | [String]| Licenses list      |
+| `trainings` | [String]| Training records   |
+| `status`    | String  | Employment status  |
+
+No additional environment variables are required for these fields.

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -14,11 +14,14 @@ if (!process.env.MONGODB_URI) {
 async function seed() {
   await connectDB(process.env.MONGODB_URI);
 
+  const { ADMIN_USERNAME, ADMIN_PASSWORD } = process.env;
+  if (!ADMIN_USERNAME || !ADMIN_PASSWORD) {
+    console.error('ADMIN_USERNAME and ADMIN_PASSWORD must be provided');
+    process.exit(1);
+  }
+
   const users = [
-    { username: 'user', password: 'password', role: 'employee' },
-    { username: 'supervisor', password: 'password', role: 'supervisor' },
-    { username: 'hr', password: 'password', role: 'hr' },
-    { username: 'admin', password: 'password', role: 'admin' }
+    { username: ADMIN_USERNAME, password: ADMIN_PASSWORD, role: 'admin' }
   ];
 
   for (const data of users) {
@@ -27,7 +30,12 @@ async function seed() {
       const employee = await Employee.create({
         name: data.username,
         email: `${data.username}@example.com`,
-        role: data.role
+        role: data.role,
+        idNumber: '',
+        birthDate: new Date('1990-01-01'),
+        contact: '',
+        licenses: [],
+        trainings: []
       });
       await User.create({ ...data, employee: employee._id });
       console.log(`Created user ${data.username}`);

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -11,8 +11,32 @@ export async function listEmployees(req, res) {
 
 export async function createEmployee(req, res) {
   try {
-    const { name, email, role, department, title, status } = req.body;
-    const employee = new Employee({ name, email, role, department, title, status });
+    const {
+      name,
+      email,
+      role,
+      department,
+      title,
+      status,
+      idNumber,
+      birthDate,
+      contact,
+      licenses,
+      trainings
+    } = req.body;
+    const employee = new Employee({
+      name,
+      email,
+      role,
+      department,
+      title,
+      status,
+      idNumber,
+      birthDate,
+      contact,
+      licenses,
+      trainings
+    });
     await employee.save();
     res.status(201).json(employee);
   } catch (err) {
@@ -33,9 +57,14 @@ export async function getEmployee(req, res) {
 
 export async function updateEmployee(req, res) {
   try {
-    const employee = await Employee.findByIdAndUpdate(req.params.id, req.body, {
-      new: true
-    });
+    const employee = await Employee.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      {
+        new: true,
+        runValidators: true
+      }
+    );
 
 
     if (!employee) return res.status(404).json({ error: 'Not found' });

--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -13,6 +13,13 @@ const employeeSchema = new mongoose.Schema({
   department: String,
   title: String,
 
+  // 新增欄位
+  idNumber: { type: String, default: '' }, // 身分證字號
+  birthDate: Date, // 出生日期
+  contact: { type: String, default: '' }, // 聯絡方式
+  licenses: { type: [String], default: [] }, // 證照
+  trainings: { type: [String], default: [] }, // 教育訓練
+
   status: { type: String, default: '在職' }
 }, { timestamps: true });
 

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -47,7 +47,17 @@ describe('Employee API', () => {
 
   it('creates employee', async () => {
 
-    const newEmp = { name: 'Jane', department: 'HR', title: 'Manager', status: '在職' };
+    const newEmp = {
+      name: 'Jane',
+      department: 'HR',
+      title: 'Manager',
+      status: '在職',
+      idNumber: 'A123456789',
+      birthDate: '1990-01-01',
+      contact: '0912',
+      licenses: ['CPA'],
+      trainings: ['Onboard']
+    };
 
     saveMock.mockResolvedValue();
     const res = await request(app).post('/api/employees').send(newEmp);
@@ -57,10 +67,15 @@ describe('Employee API', () => {
   });
 
   it('updates employee', async () => {
-    Employee.findByIdAndUpdate.mockResolvedValue({ _id: '1', name: 'Updated' });
+    Employee.findByIdAndUpdate.mockResolvedValue({
+      _id: '1',
+      name: 'Updated',
+      licenses: ['A'],
+      trainings: []
+    });
     const res = await request(app)
       .put('/api/employees/1')
-      .send({ name: 'Updated' });
+      .send({ name: 'Updated', licenses: ['A'], trainings: [] });
     expect(res.status).toBe(200);
     expect(Employee.findByIdAndUpdate).toHaveBeenCalled();
     expect(res.body).toMatchObject({ _id: '1', name: 'Updated' });


### PR DESCRIPTION
## Summary
- only seed an admin account using `ADMIN_USERNAME` and `ADMIN_PASSWORD`
- auto create the admin on server start
- document new environment variables

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*