### PR TITLE
Implement schedule calendar view

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -1,82 +1,155 @@
 <!-- src/views/front/Schedule.vue -->
 <template>
-    <div class="schedule-page">
-      <h2>排班管理</h2>
-      <p>這裡是「排班管理」的基本範例頁面。未來可顯示月曆、表格或拖曳指派班別功能。</p>
-  
-      <el-card class="schedule-card">
-        <el-form :model="scheduleForm" label-width="80px">
-          <el-form-item label="日期">
-            <el-date-picker v-model="scheduleForm.date" type="date" />
-          </el-form-item>
-          <el-form-item label="班別">
-            <el-input v-model="scheduleForm.shiftType" placeholder="班別" />
-          </el-form-item>
-          <el-form-item>
-            <el-button type="primary" @click="onAddSchedule">新增排班</el-button>
-          </el-form-item>
-        </el-form>
-      </el-card>
+  <div class="schedule-page">
+    <h2>排班管理</h2>
+    <el-card class="schedule-card">
+      <div class="controls">
+        <el-select v-model="selectedUnit" placeholder="選擇單位" class="mr-2">
+          <el-option
+            v-for="unit in unitList"
+            :key="unit._id"
+            :label="unit.label"
+            :value="unit._id"
+          />
+        </el-select>
+        <el-select v-model="selectedEmployee" placeholder="選擇員工">
+          <el-option
+            v-for="emp in employeeList"
+            :key="emp._id"
+            :label="emp.name"
+            :value="emp._id"
+          />
+        </el-select>
+      </div>
+      <el-calendar v-model="currentDate">
+        <template #date-cell="{ data }">
+          <div class="date-cell" @click="assignShift(data)">
+            <div>{{ data.day.split('-').pop() }}</div>
+            <span class="shift-label" v-if="scheduleMap[data.day]">{{ scheduleMap[data.day] }}</span>
+            <el-tag type="danger" size="small" v-if="leaveMap[data.day]">假</el-tag>
+          </div>
+        </template>
+      </el-calendar>
+    </el-card>
+  </div>
+</template>
 
-      <el-table :data="schedules" style="margin-top: 20px;">
-        <el-table-column label="日期" width="120">
-          <template #default="{ row }">{{ dayjs(row.date).format('YYYY-MM-DD') }}</template>
-        </el-table-column>
-        <el-table-column prop="shiftType" label="班別" width="100" />
-      </el-table>
-    </div>
-  </template>
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import dayjs from 'dayjs'
+import { apiFetch } from '../../api'
 
-  <script setup>
-  import { ref, onMounted } from 'vue'
-  import dayjs from 'dayjs'
-  import { apiFetch } from '../../api'
+const schedules = ref([])
+const scheduleMap = ref({})
+const leaveMap = ref({})
+const unitList = ref([])
+const employeeList = ref([])
+const selectedUnit = ref('')
+const selectedEmployee = ref('')
+const currentDate = ref(new Date())
+const token = localStorage.getItem('token') || ''
+const defaultShift = 'A'
 
-  const schedules = ref([])
-  const scheduleForm = ref({ date: '', shiftType: '' })
-  const token = localStorage.getItem('token') || ''
-
-  async function fetchSchedules() {
-    const res = await apiFetch('/api/schedules', {
-      headers: { Authorization: `Bearer ${token}` }
-    })
-    if (res.ok) {
-      schedules.value = await res.json()
-    }
+async function fetchUnits() {
+  const res = await apiFetch('/api/departments', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    unitList.value = await res.json()
   }
+}
 
-  async function onAddSchedule() {
-    const payload = {
-      employee: localStorage.getItem('employeeId') || '000000000000000000000000',
-      date: scheduleForm.value.date,
-      shiftType: scheduleForm.value.shiftType
-    }
-    const res = await apiFetch('/api/schedules', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
-      },
-      body: JSON.stringify(payload)
-    })
-    if (res.ok) {
-      const saved = await res.json()
-      schedules.value.push(saved)
-      scheduleForm.value.date = ''
-      scheduleForm.value.shiftType = ''
-    }
+async function fetchEmployees() {
+  const res = await apiFetch('/api/employees', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    employeeList.value = await res.json()
   }
+}
 
-  onMounted(fetchSchedules)
-  </script>
-  
-  <style scoped>
-  .schedule-page {
-    padding: 20px;
+async function fetchSchedules() {
+  const res = await apiFetch('/api/schedules', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    schedules.value = await res.json()
+    scheduleMap.value = Object.fromEntries(
+      schedules.value.map(s => [dayjs(s.date).format('YYYY-MM-DD'), s.shiftType])
+    )
   }
-  .schedule-card {
-    margin-top: 20px;
-    padding: 20px;
+}
+
+async function fetchLeaves() {
+  if (!selectedEmployee.value) return
+  const res = await apiFetch('/api/leaves', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    const all = await res.json()
+    leaveMap.value = {}
+    all
+      .filter(l => l.status === 'approved' && l.employee?._id === selectedEmployee.value)
+      .forEach(l => {
+        let start = dayjs(l.startDate)
+        const end = dayjs(l.endDate)
+        for (; start.isSameOrBefore(end); start = start.add(1, 'day')) {
+          leaveMap.value[start.format('YYYY-MM-DD')] = true
+        }
+      })
   }
-  </style>
-  
+}
+
+watch(selectedEmployee, fetchLeaves)
+
+async function assignShift(data) {
+  if (!selectedEmployee.value) return
+  const day = data.day
+  const payload = {
+    employee: selectedEmployee.value,
+    date: dayjs(day).toDate(),
+    shiftType: defaultShift,
+    unit: selectedUnit.value || ''
+  }
+  const res = await apiFetch('/api/schedules', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(payload)
+  })
+  if (res.ok) {
+    scheduleMap.value[day] = defaultShift
+  }
+}
+
+onMounted(() => {
+  fetchUnits()
+  fetchEmployees()
+  fetchSchedules()
+})
+</script>
+
+<style scoped>
+.schedule-page {
+  padding: 20px;
+}
+.schedule-card {
+  margin-top: 20px;
+  padding: 20px;
+}
+.controls {
+  margin-bottom: 20px;
+}
+.date-cell {
+  position: relative;
+  height: 80px;
+}
+.shift-label {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  font-size: 12px;
+}
+</style>

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import Schedule from '../src/views/front/Schedule.vue'
+
+describe('Schedule.vue', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })))
+    localStorage.setItem('token', 'tok')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('fetches units and employees on mount', () => {
+    mount(Schedule, { global: { plugins: [ElementPlus] } })
+    expect(fetch).toHaveBeenCalledWith('/api/departments', expect.any(Object))
+    expect(fetch).toHaveBeenCalledWith('/api/employees', expect.any(Object))
+  })
+
+  it('posts schedule when assigning shift', async () => {
+    const wrapper = mount(Schedule, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.selectedEmployee = 'e1'
+    fetch.mockClear()
+    await wrapper.vm.assignShift({ day: '2023-01-01' })
+    expect(fetch).toHaveBeenCalledWith('/api/schedules', expect.objectContaining({ method: 'POST' }))
+  })
+})


### PR DESCRIPTION
## Summary
- redesign Schedule page with calendar UI
- fetch department and employee lists for dropdowns
- allow assigning shifts via calendar click
- highlight approved leaves on the calendar
- add unit tests for Schedule view

## Testing
- `npm test` *(fails: jest not found)*