### PR TITLE
Fix JWT_SECRET requirement in server docs

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,7 @@ Create a `.env` file based on `.env.example` and set the following variables:
 
 - `PORT` – port for the HTTP server
 - `MONGODB_URI` – MongoDB connection string
-- `JWT_SECRET` – (optional) secret used to sign JSON Web Tokens
+- `JWT_SECRET` – (required) secret used to sign JSON Web Tokens
 
 To run the unit tests:
 


### PR DESCRIPTION
## Summary
- mark `JWT_SECRET` as a required variable in server README

## Testing
- `npm test` *(fails: jest not found)*