### PR TITLE
Add employee detail route and validation

### DIFF
--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -12,6 +12,9 @@ export async function listEmployees(req, res) {
 export async function createEmployee(req, res) {
   try {
     const { name, email, role, department, title, status } = req.body;
+    if (!name) {
+      return res.status(400).json({ error: 'Name is required' });
+    }
     const employee = new Employee({ name, email, role, department, title, status });
     await employee.save();
     res.status(201).json(employee);
@@ -33,12 +36,18 @@ export async function getEmployee(req, res) {
 
 export async function updateEmployee(req, res) {
   try {
-    const employee = await Employee.findByIdAndUpdate(req.params.id, req.body, {
-      new: true
-    });
-
-
+    const employee = await Employee.findById(req.params.id);
     if (!employee) return res.status(404).json({ error: 'Not found' });
+
+    const { name, email, role, department, title, status } = req.body;
+    if (name !== undefined) employee.name = name;
+    if (email !== undefined) employee.email = email;
+    if (role !== undefined) employee.role = role;
+    if (department !== undefined) employee.department = department;
+    if (title !== undefined) employee.title = title;
+    if (status !== undefined) employee.status = status;
+
+    await employee.save();
     res.json(employee);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/src/routes/employeeRoutes.js
+++ b/server/src/routes/employeeRoutes.js
@@ -11,6 +11,7 @@ const router = Router();
 
 router.get('/', listEmployees);
 router.post('/', createEmployee);
+router.get('/:id', getEmployee);
 router.put('/:id', updateEmployee);
 router.delete('/:id', deleteEmployee);
 

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals';
 const saveMock = jest.fn();
 const Employee = jest.fn().mockImplementation(() => ({ save: saveMock }));
 Employee.find = jest.fn();
-Employee.findByIdAndUpdate = jest.fn();
+Employee.findById = jest.fn();
 Employee.findByIdAndDelete = jest.fn();
 
 jest.mock('../src/models/Employee.js', () => ({ default: Employee }), { virtual: true });
@@ -23,7 +23,7 @@ beforeAll(async () => {
 beforeEach(() => {
   saveMock.mockReset();
   Employee.find.mockReset();
-  Employee.findByIdAndUpdate.mockReset();
+  Employee.findById.mockReset();
   Employee.findByIdAndDelete.mockReset();
 });
 
@@ -56,13 +56,24 @@ describe('Employee API', () => {
     expect(res.body).toMatchObject(newEmp);
   });
 
+  it('gets employee', async () => {
+    const fake = { _id: '1', name: 'John' };
+    Employee.findById.mockResolvedValue(fake);
+    const res = await request(app).get('/api/employees/1');
+    expect(res.status).toBe(200);
+    expect(Employee.findById).toHaveBeenCalledWith('1');
+    expect(res.body).toEqual(fake);
+  });
+
   it('updates employee', async () => {
-    Employee.findByIdAndUpdate.mockResolvedValue({ _id: '1', name: 'Updated' });
+    Employee.findById.mockResolvedValue({ _id: '1', name: 'John', save: saveMock });
+    saveMock.mockResolvedValue();
     const res = await request(app)
       .put('/api/employees/1')
       .send({ name: 'Updated' });
     expect(res.status).toBe(200);
-    expect(Employee.findByIdAndUpdate).toHaveBeenCalled();
+    expect(Employee.findById).toHaveBeenCalledWith('1');
+    expect(saveMock).toHaveBeenCalled();
     expect(res.body).toMatchObject({ _id: '1', name: 'Updated' });
 
   });


### PR DESCRIPTION
## Summary
- validate fields when creating/updating employees
- implement `getEmployee` route
- expand employee tests for CRUD operations

## Testing
- `npm test --prefix server` *(fails: jest not found)*