### PR TITLE
Extend employee schema

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -27,7 +27,10 @@ async function seed() {
       const employee = await Employee.create({
         name: data.username,
         email: `${data.username}@example.com`,
-        role: data.role
+        role: data.role,
+        department: 'General',
+        title: 'Staff',
+        status: '在職'
       });
       await User.create({ ...data, employee: employee._id });
       console.log(`Created user ${data.username}`);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -34,7 +34,10 @@ async function seedTestUsers() {
       const employee = await Employee.create({
         name: data.username,
         email: `${data.username}@example.com`,
-        role: data.role
+        role: data.role,
+        department: 'General',
+        title: 'Staff',
+        status: '在職'
       });
       await User.create({ ...data, employee: employee._id });
       console.log(`Created test user ${data.username}`);

--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -1,19 +1,126 @@
 import mongoose from 'mongoose';
 
+const experienceSchema = new mongoose.Schema({
+  organization: String,
+  title: String,
+  start: Date,
+  end: Date
+}, { _id: false });
+
+const licenseSchema = new mongoose.Schema({
+  name: String,
+  number: String,
+  issueDate: Date,
+  expiryDate: Date,
+  file: String
+}, { _id: false });
+
+const trainingSchema = new mongoose.Schema({
+  name: String,
+  code: String,
+  date: Date,
+  file: String,
+  category: String,
+  score: Number
+}, { _id: false });
+
+const contactSchema = new mongoose.Schema({
+  name: String,
+  relation: String,
+  phone1: String,
+  phone2: String
+}, { _id: false });
+
 const employeeSchema = new mongoose.Schema({
+  // 基本資料
+  employeeId: String,
   name: { type: String, required: true },
+  photo: String,
+  gender: { type: String, enum: ['男', '女', '其他'] },
+  idNumber: String,
+  birthDate: Date,
+  birthPlace: String,
+  bloodType: { type: String, enum: ['A', 'B', 'O', 'AB', 'HR'] },
+  languages: [String],
+  disabilityLevel: String,
+  identityCategory: String,
+  maritalStatus: { type: String, enum: ['已婚', '未婚', '離婚', '喪偶'] },
+  dependents: { type: Number, default: 0 },
 
-
+  // 聯絡方式
+  phone: String,
+  mobile: String,
   email: { type: String, unique: true },
+  address: String,
+  mailingAddress: String,
+  lineId: String,
+
+  // 部門與職稱
+  organization: String,
+  department: String,
+  subDepartment: String,
+  title: String,
+  practiceTitle: String,
   role: {
     type: String,
     enum: ['employee', 'supervisor', 'hr', 'admin'],
     default: 'employee'
   },
-  department: String,
-  title: String,
+  partTime: { type: Boolean, default: false },
+  needClockIn: { type: Boolean, default: true },
 
-  status: { type: String, default: '在職' }
+  // 在職狀態
+  status: {
+    type: String,
+    enum: ['在職', '試用', '離職', '停薪'],
+    default: '在職'
+  },
+  probationDays: { type: Number, default: 0 },
+
+  // 身體檢查
+  medicalCheck: {
+    height: Number,
+    weight: Number,
+    bloodType: { type: String, enum: ['A', 'B', 'O', 'AB', 'HR'] }
+  },
+
+  // 學歷
+  education: {
+    level: String,
+    school: String,
+    major: String,
+    status: String,
+    graduationYear: Number
+  },
+
+  // 役別資訊
+  militaryService: {
+    type: String,
+    branch: String,
+    rank: String,
+    dischargeYear: Number
+  },
+
+  emergencyContacts: [contactSchema],
+
+  keywords: String,
+
+  experiences: [experienceSchema],
+  licenses: [licenseSchema],
+  trainings: [trainingSchema],
+
+  // 聘任 / 任職日期
+  appointment: {
+    hireDate: Date,
+    startDate: Date,
+    resignationDate: Date,
+    dismissalDate: Date,
+    practiceTitle: String,
+    rehireStartDate: Date,
+    rehireEndDate: Date,
+    remark: String
+  }
+
 }, { timestamps: true });
 
 export default mongoose.model('Employee', employeeSchema);


### PR DESCRIPTION
## Summary
- expand the Employee mongoose schema to cover documented fields
- include reusable sub-schemas for experience, license and training
- add defaults in seed logic for department/title/status
- seed default values when the dev server starts

## Testing
- `npm test` *(fails: jest not found)*