### PR TITLE
Add token expiry service

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { getToken } from '@/utils/tokenService'
 
 // ★ 既有的後台檔案
 const Login = () => import('@/views/Login.vue')
@@ -112,7 +113,7 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   // 簡易示範: 後台 requiresAuth
   if (to.meta.requiresAuth) {
-    const token = localStorage.getItem('token')
+    const token = getToken()
     if (!token) {
       return next({ name: 'Login' })
     }
@@ -120,7 +121,7 @@ router.beforeEach((to, from, next) => {
 
   // 若要檢查前台也需登入
   if (to.meta.frontRequiresAuth) {
-    const token = localStorage.getItem('token')
+    const token = getToken()
     if (!token) {
       return next({ name: 'FrontLogin' })
     }

--- a/client/src/utils/tokenService.js
+++ b/client/src/utils/tokenService.js
@@ -1,0 +1,52 @@
+export let _expiryTimeout = null;
+
+function parseExp(token) {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.exp ? payload.exp * 1000 : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function scheduleRemoval(expiresAt) {
+  clearTimeout(_expiryTimeout);
+  if (!expiresAt) return;
+  const delay = expiresAt - Date.now();
+  if (delay <= 0) {
+    clearToken();
+  } else {
+    _expiryTimeout = setTimeout(() => {
+      clearToken();
+    }, delay);
+  }
+}
+
+export function setToken(token) {
+  const expiresAt = parseExp(token);
+  localStorage.setItem('token', token);
+  if (expiresAt) {
+    localStorage.setItem('token_expires', String(expiresAt));
+  } else {
+    localStorage.removeItem('token_expires');
+  }
+  scheduleRemoval(expiresAt);
+}
+
+export function getToken() {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  const expiresAt = parseInt(localStorage.getItem('token_expires') || '0', 10);
+  if (expiresAt && Date.now() >= expiresAt) {
+    clearToken();
+    return null;
+  }
+  scheduleRemoval(expiresAt);
+  return token;
+}
+
+export function clearToken() {
+  clearTimeout(_expiryTimeout);
+  localStorage.removeItem('token');
+  localStorage.removeItem('token_expires');
+}

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -31,6 +31,7 @@ import { useRouter } from 'vue-router'
 import { useMenuStore } from '../stores/menu'
 import { storeToRefs } from 'pinia'
 import { apiFetch } from '../api'
+import { setToken } from '../utils/tokenService'
   
 const router = useRouter()
 const menuStore = useMenuStore()
@@ -49,7 +50,7 @@ const menuStore = useMenuStore()
     })
     if (res.ok) {
       const data = await res.json()
-      localStorage.setItem('token', data.token)
+      setToken(data.token)
       localStorage.setItem('role', data.user.role)
       localStorage.setItem('employeeId', data.user.employeeId)
       await menuStore.fetchMenu()

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -8,12 +8,13 @@
   </template>
   
   <script setup>
-  import { useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
+import { clearToken } from '../utils/tokenService'
   
   const router = useRouter()
   
 const logout = () => {
-  localStorage.removeItem('token')
+  clearToken()
   localStorage.removeItem('role')
   localStorage.removeItem('employeeId')
   router.push({ name: 'Login' })

--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -21,11 +21,12 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { apiFetch } from '../../api'
+import { getToken } from '../../utils/tokenService'
 
 const pendingList = ref([])
-const token = localStorage.getItem('token') || ''
 
 async function fetchApprovals() {
+  const token = getToken() || ''
   const res = await apiFetch('/api/approvals', {
     headers: { Authorization: `Bearer ${token}` }
   })
@@ -36,6 +37,7 @@ async function fetchApprovals() {
 
 async function approve(index) {
   const item = pendingList.value[index]
+  const token = getToken() || ''
   const res = await apiFetch(`/api/approvals/${item._id}/approve`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` }
@@ -47,6 +49,7 @@ async function approve(index) {
 
 async function reject(index) {
   const item = pendingList.value[index]
+  const token = getToken() || ''
   const res = await apiFetch(`/api/approvals/${item._id}/reject`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` }

--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -35,6 +35,7 @@
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
+import { getToken } from '../../utils/tokenService'
 
 // 將中文動作與後端定義的值互轉
 const actionMap = {
@@ -48,9 +49,9 @@ const reverseActionMap = Object.fromEntries(
 )
 
 const records = ref([])
-const token = localStorage.getItem('token') || ''
 
 async function fetchRecords() {
+  const token = getToken() || ''
   const res = await apiFetch('/api/attendance', {
     headers: { Authorization: `Bearer ${token}` }
   })
@@ -84,6 +85,7 @@ async function addRecord(action) {
     remark: '',
     employee: localStorage.getItem('employeeId') || ''
   }
+  const token = getToken() || ''
   const res = await apiFetch('/api/attendance', {
     method: 'POST',
     headers: {

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -32,6 +32,7 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useMenuStore } from "../../stores/menu";
+import { clearToken } from "../../utils/tokenService";
 import { storeToRefs } from "pinia";
 
 const router = useRouter();
@@ -59,7 +60,7 @@ function gotoPage(pageName) {
 function onLogout() {
   localStorage.removeItem("role");
   localStorage.removeItem("username");
-  localStorage.removeItem("token");
+  clearToken();
   // 回到前台登入
   router.push({ name: "FrontLogin" });
 }

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -38,6 +38,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMenuStore } from '../../stores/menu'
 import { apiFetch } from '../../api'
+import { setToken } from '../../utils/tokenService'
   
 const router = useRouter()
 const menuStore = useMenuStore()
@@ -57,7 +58,7 @@ async function onLogin () {
   })
   if (res.ok) {
     const data = await res.json()
-    localStorage.setItem('token', data.token)
+    setToken(data.token)
     localStorage.setItem('role', data.user.role)
     localStorage.setItem('employeeId', data.user.employeeId)
     await menuStore.fetchMenu()

--- a/client/src/views/front/Leave.vue
+++ b/client/src/views/front/Leave.vue
@@ -62,6 +62,7 @@
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
+import { getToken } from '../../utils/tokenService'
   
   const leaveForm = ref({
     leaveType: '',
@@ -72,9 +73,9 @@ import { apiFetch } from '../../api'
   
 const leaveRecords = ref([])
 
-const token = localStorage.getItem('token') || ''
 
 async function fetchLeaves() {
+  const token = getToken() || ''
   const res = await apiFetch('/api/leaves', {
     headers: { Authorization: `Bearer ${token}` }
   })
@@ -91,6 +92,7 @@ async function onSubmitLeave() {
     endDate: leaveForm.value.endDate,
     reason: leaveForm.value.reason
   }
+  const token = getToken() || ''
   const res = await apiFetch('/api/leaves', {
     method: 'POST',
     headers: {

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -36,12 +36,13 @@
   import { ref, onMounted } from 'vue'
   import dayjs from 'dayjs'
   import { apiFetch } from '../../api'
+  import { getToken } from '../../utils/tokenService'
 
   const schedules = ref([])
   const scheduleForm = ref({ date: '', shiftType: '' })
-  const token = localStorage.getItem('token') || ''
 
   async function downloadSchedules(format) {
+    const token = getToken() || ''
     const res = await apiFetch(`/api/schedules/export?format=${format}`, {
       headers: { Authorization: `Bearer ${token}` }
     })
@@ -57,6 +58,7 @@
   }
 
   async function fetchSchedules() {
+    const token = getToken() || ''
     const res = await apiFetch('/api/schedules', {
       headers: { Authorization: `Bearer ${token}` }
     })
@@ -71,6 +73,7 @@
       date: scheduleForm.value.date,
       shiftType: scheduleForm.value.shiftType
     }
+    const token = getToken() || ''
     const res = await apiFetch('/api/schedules', {
       method: 'POST',
       headers: {

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import FrontLogin from '../src/views/front/FrontLogin.vue'
 
+function createToken(offset = 3600) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + offset })).toString('base64')
+  return `${header}.${payload}.sig`
+}
+
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() })
 }))
@@ -21,7 +27,7 @@ describe('FrontLogin.vue', () => {
     fetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ token: 't', user: { role: 'employee', employeeId: 'e1' } })
+        json: async () => ({ token: createToken(), user: { role: 'employee', employeeId: 'e1' } })
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -37,7 +43,7 @@ describe('FrontLogin.vue', () => {
     fetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ token: 't', user: { role: 'hr' } })
+        json: async () => ({ token: createToken(), user: { role: 'hr' } })
       })
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
     const wrapper = mount(FrontLogin)

--- a/client/tests/tokenService.spec.js
+++ b/client/tests/tokenService.spec.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setToken, getToken, clearToken, _expiryTimeout } from '../src/utils/tokenService'
+
+function createToken(offset = 3600) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + offset })).toString('base64')
+  return `${header}.${payload}.sig`
+}
+
+describe('tokenService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    clearToken()
+  })
+
+  it('stores and retrieves token', () => {
+    const token = createToken(10)
+    setToken(token)
+    expect(getToken()).toBe(token)
+  })
+
+  it('clears token after expiry', () => {
+    const token = createToken(1)
+    setToken(token)
+    vi.advanceTimersByTime(1000)
+    vi.runOnlyPendingTimers()
+    expect(getToken()).toBeNull()
+    expect(localStorage.getItem('token')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- implement token service with expiry handling
- use token service in login flows and views
- check token expiry in router guards
- replace direct token usage in front-end views
- update unit tests and add tests for token service

## Testing
- `npm test` *(fails: jest and vitest not found)*