### PR TITLE
Add modern layout and slim admin menu

### DIFF
--- a/client/src/assets/responsive.css
+++ b/client/src/assets/responsive.css
@@ -1,0 +1,9 @@
+/* responsive styles for ModernLayout */
+@media (max-width: 768px) {
+  .modern-layout .layout-aside {
+    position: absolute;
+    z-index: 1000;
+    height: 100%;
+    background: #fff;
+  }
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -6,6 +6,7 @@ import router from './router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import './assets/main.css'
+import './assets/responsive.css'
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 // ★ 既有的後台檔案
 const Login = () => import('@/views/Login.vue')
-const Layout = () => import('@/views/Layout.vue')
+const Layout = () => import('@/views/ModernLayout.vue')
 const Settings = () => import('@/views/Settings.vue')
 const AttendanceSetting = () => import('@/components/backComponents/AttendanceSetting.vue')
 const AttendanceManagementSetting = () => import('@/components/backComponents/AttendanceManagementSetting.vue')

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -53,7 +53,12 @@ const menuStore = useMenuStore()
       localStorage.setItem('role', data.user.role)
       localStorage.setItem('employeeId', data.user.employeeId)
       await menuStore.fetchMenu()
-      router.push({ name: 'Settings' })
+      const first = menuStore.items[0]
+      if (first) {
+        router.push({ name: first.name })
+      } else {
+        router.push({ name: 'Login' })
+      }
     } else {
       alert('登入失敗')
     }

--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -1,0 +1,81 @@
+<template>
+  <el-container class="modern-layout">
+    <el-header class="layout-header">
+      <el-button link @click="toggleCollapse" class="collapse-btn">
+        <el-icon><i :class="isCollapse ? 'el-icon-menu' : 'el-icon-close'" /></el-icon>
+      </el-button>
+    </el-header>
+    <el-container>
+      <el-aside :width="isCollapse ? '64px' : '200px'" class="layout-aside">
+        <el-menu :default-active="active" :collapse="isCollapse">
+          <el-menu-item
+            v-for="item in menuItems"
+            :key="item.name"
+            :index="item.name"
+            @click="gotoPage(item.name)"
+          >
+            <i :class="item.icon"></i>
+            <span>{{ item.label }}</span>
+          </el-menu-item>
+        </el-menu>
+      </el-aside>
+      <el-main class="layout-main">
+        <router-view />
+      </el-main>
+    </el-container>
+  </el-container>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMenuStore } from '../stores/menu'
+import { storeToRefs } from 'pinia'
+
+const router = useRouter()
+const menuStore = useMenuStore()
+const { items: menuItems } = storeToRefs(menuStore)
+
+const active = ref('')
+const isCollapse = ref(false)
+
+function gotoPage(name) {
+  active.value = name
+  router.push({ name })
+}
+function toggleCollapse() {
+  isCollapse.value = !isCollapse.value
+}
+</script>
+
+<style scoped>
+.modern-layout {
+  height: 100vh;
+}
+.layout-header {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+}
+.collapse-btn {
+  margin-left: 10px;
+}
+.layout-aside {
+  overflow: auto;
+  border-right: 1px solid #ebeef5;
+}
+.layout-main {
+  padding: 20px;
+  overflow: auto;
+}
+@media (max-width: 768px) {
+  .layout-aside {
+    position: absolute;
+    z-index: 1000;
+    height: 100%;
+    background: #fff;
+  }
+}
+</style>

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -73,7 +73,12 @@ async function onLogin () {
         router.push('/front/attendance')
         break
       case 'admin':
-        router.push('/layout/settings')
+        const first = menuStore.items[0]
+        if (first) {
+          router.push({ name: first.name })
+        } else {
+          router.push('/layout')
+        }
         break
       default:
         router.push('/front/attendance')

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -18,15 +18,10 @@ export function getMenu(req, res) {
       { name: 'approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     admin: [
-      { name: 'AttendanceSetting', label: '出勤設定', icon: 'el-icon-postcard' },
-      { name: 'AttendanceManagementSetting', label: '考勤管理設定', icon: 'el-icon-folder-opened' },
-      { name: 'LeaveOvertimeSetting', label: '請假與加班設定', icon: 'el-icon-date' },
-      { name: 'ShiftScheduleSetting', label: '排班管理設定', icon: 'el-icon-timer' },
-      { name: 'ApprovalFlowSetting', label: '簽核流程設定', icon: 'el-icon-s-operation' },
-      { name: 'ReportManagementSetting', label: '報表管理設定', icon: 'el-icon-document-copy' },
-      { name: 'SalaryManagementSetting', label: '薪資管理設定', icon: 'el-icon-coin' },
-      { name: 'SocialInsuranceRetirementSetting', label: '勞健保 / 勞退設定', icon: 'el-icon-s-check' },
-      { name: 'HRManagementSystemSetting', label: '人事管理與系統設定', icon: 'el-icon-user-solid' }
+      { name: 'HRManagementSystemSetting', label: '人資管理', icon: 'el-icon-user-solid' },
+      { name: 'Approval', label: '簽核表單', icon: 'el-icon-s-operation' },
+      { name: 'ShiftScheduleSetting', label: '排班表設定', icon: 'el-icon-timer' },
+      { name: 'SystemOrgSetting', label: '權限 & 機構 & 部門設定', icon: 'el-icon-setting' }
     ]
   };
   res.json(menus[role] || []);


### PR DESCRIPTION
## Summary
- create `ModernLayout.vue` with Element Plus container layout
- update router to use the new layout
- redirect to the first menu item after login
- simplify admin menu items returned from server
- adjust front-end login navigation
- add responsive CSS

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: vitest not found)*