### PR TITLE
Remove unused element packages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,10 +8,8 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
-        "element": "^0.1.4",
         "element-plus": "^2.9.7",
         "pinia": "^3.0.1",
-        "plus": "^0.1.0",
         "dayjs": "^1.11.13",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
@@ -2025,16 +2023,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/element": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/element/-/element-0.1.4.tgz",
-      "integrity": "sha512-bIKdd1hQ4/srLeqmURQRYmUhbRvyLD7leuyRGcb0EbyylEa/A5lxzvoRN/tbrwWBRQGd5K6RM11EhqpbmGs0rA==",
-      "dependencies": {
-        "ent": "0.0.5",
-        "global": "~2.0.7",
-        "lru-cache": "~2.3.0"
-      }
-    },
     "node_modules/element-plus": {
       "version": "2.9.7",
       "resolved": "https://registry.npmjs.org/element-plus/-/element-plus-2.9.7.tgz",
@@ -2060,12 +2048,6 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
-    },
-    "node_modules/element/node_modules/lru-cache": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
-      "integrity": "sha512-EjtmtXFUu+wXm6PW3T6RT1ekQUxobC7B5TDCU0CS0212wzpwKiXs6vLun+JI+OoWmmliWdYqnrpjrlK7W3ELdQ==",
-      "license": "MIT"
     },
     "node_modules/ent": {
       "version": "0.0.5",
@@ -2883,14 +2865,6 @@
         "confbox": "^0.2.1",
         "exsolve": "^1.0.1",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/plus": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/plus/-/plus-0.1.0.tgz",
-      "integrity": "sha512-VuCrK6MX/nuTAUWkNWCMSpXixN78hjFHCITzQiQSH8tCLRCBABfe460zOB95/0uPAwBeqPcqSoEFgZA4Jh8fFw==",
-      "engines": {
-        "node": ">=0.4.9"
       }
     },
     "node_modules/postcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,10 +10,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "element": "^0.1.4",
     "element-plus": "^2.9.7",
     "pinia": "^3.0.1",
-    "plus": "^0.1.0",
     "dayjs": "^1.11.13",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"


### PR DESCRIPTION
## Summary
- remove `element` and `plus` from client dependencies
- regenerate `package-lock.json`

## Testing
- `npm test` in `server/` *(fails: jest not found)*
- `npm test` in `client/` *(fails: vitest not found)*