### PR TITLE
Add persistent token blacklist using MongoDB

### DIFF
--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,12 +1,12 @@
 import jwt from 'jsonwebtoken'
 import { isTokenBlacklisted } from '../utils/tokenBlacklist.js'
 
-export function authenticate(req, res, next) {
+export async function authenticate(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader) return res.status(401).json({ error: 'No token' });
 
   const token = authHeader.split(' ')[1]
-  if (isTokenBlacklisted(token)) {
+  if (await isTokenBlacklisted(token)) {
     return res.status(401).json({ error: 'Invalid token' })
   }
   try {

--- a/server/src/models/BlacklistedToken.js
+++ b/server/src/models/BlacklistedToken.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const blacklistedTokenSchema = new mongoose.Schema({
+  token: { type: String, required: true, index: true },
+  expiresAt: { type: Date, required: true, index: true, expires: 0 }
+});
+
+export default mongoose.model('BlacklistedToken', blacklistedTokenSchema);

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -17,11 +17,11 @@ router.post('/login', async (req, res) => {
   res.json({ token, user: { id: user._id, role: user.role, username: user.username, employeeId: user.employee } });
 });
 
-router.post('/logout', (req, res) => {
+router.post('/logout', async (req, res) => {
   const auth = req.headers.authorization
   if (auth) {
     const token = auth.split(' ')[1]
-    blacklistToken(token)
+    await blacklistToken(token)
   }
   res.status(204).end()
 })

--- a/server/src/utils/tokenBlacklist.js
+++ b/server/src/utils/tokenBlacklist.js
@@ -1,9 +1,16 @@
-const invalidTokens = new Set()
+import jwt from 'jsonwebtoken';
+import BlacklistedToken from '../models/BlacklistedToken.js';
 
-export function blacklistToken(token) {
-  if (token) invalidTokens.add(token)
+export async function blacklistToken(token) {
+  if (!token) return;
+  const decoded = jwt.decode(token);
+  const exp = decoded?.exp;
+  const expiresAt = exp ? new Date(exp * 1000) : new Date();
+  await BlacklistedToken.create({ token, expiresAt });
 }
 
-export function isTokenBlacklisted(token) {
-  return invalidTokens.has(token)
+export async function isTokenBlacklisted(token) {
+  if (!token) return false;
+  const existing = await BlacklistedToken.findOne({ token, expiresAt: { $gt: new Date() } });
+  return !!existing;
 }

--- a/server/tests/tokenBlacklist.test.js
+++ b/server/tests/tokenBlacklist.test.js
@@ -1,0 +1,37 @@
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+import jwt from 'jsonwebtoken'
+
+const BlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
+
+jest.mock('../src/models/BlacklistedToken.js', () => ({ default: BlacklistedToken }), { virtual: true });
+
+let blacklistUtils;
+let authenticate;
+
+beforeEach(async () => {
+  process.env.JWT_SECRET = 'secret';
+  jest.resetModules();
+  blacklistUtils = await import('../src/utils/tokenBlacklist.js');
+  ({ authenticate } = await import('../src/middleware/auth.js'));
+  BlacklistedToken.create.mockReset();
+  BlacklistedToken.findOne.mockReset();
+});
+
+test('blacklisted token rejected after server restart', async () => {
+  const token = jwt.sign({ id: 1 }, 'secret', { expiresIn: '1h' });
+  BlacklistedToken.create.mockResolvedValue();
+  await blacklistUtils.blacklistToken(token);
+
+  jest.resetModules();
+  blacklistUtils = await import('../src/utils/tokenBlacklist.js');
+  ({ authenticate } = await import('../src/middleware/auth.js'));
+  BlacklistedToken.findOne.mockResolvedValue({ token, expiresAt: new Date(Date.now() + 3600000) });
+
+  const app = express();
+  app.get('/protected', authenticate, (req, res) => res.sendStatus(200));
+
+  const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+  expect(res.status).toBe(401);
+});


### PR DESCRIPTION
## Summary
- add BlacklistedToken mongoose model
- replace in-memory blacklist with MongoDB-based utils
- update auth middleware and logout route to handle async blacklist
- create tests for blacklist persistence and update existing tests

## Testing
- `npm test --prefix server` *(fails: jest not found)*