### PR TITLE
Add monthly schedule APIs and table view

### DIFF
--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Schedule from '../src/views/front/Schedule.vue'
+
+vi.mock('../src/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+}))
+vi.mock('../src/utils/tokenService', () => ({ getToken: () => 'tok' }))
+
+describe('Schedule.vue', () => {
+  it('fetches schedule on mount', () => {
+    const { apiFetch } = require('../src/api')
+    mount(Schedule)
+    expect(apiFetch).toHaveBeenCalled()
+  })
+})

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -1,5 +1,34 @@
 import ShiftSchedule from '../models/ShiftSchedule.js';
 
+export async function listMonthlySchedules(req, res) {
+  try {
+    const { month, employee } = req.query;
+    if (!month) return res.status(400).json({ error: 'month required' });
+    const start = new Date(`${month}-01`);
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+    const query = { date: { $gte: start, $lt: end } };
+    if (employee) query.employee = employee;
+    const schedules = await ShiftSchedule.find(query).populate('employee');
+    res.json(schedules);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function createSchedulesBatch(req, res) {
+  try {
+    const { schedules } = req.body;
+    if (!Array.isArray(schedules)) {
+      return res.status(400).json({ error: 'schedules must be array' });
+    }
+    const inserted = await ShiftSchedule.insertMany(schedules, { ordered: false });
+    res.status(201).json(inserted);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
 export async function listSchedules(req, res) {
   try {
     const schedules = await ShiftSchedule.find().populate('employee');

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -28,6 +28,7 @@ async function seedTestUsers() {
     { username: 'hr', password: 'password', role: 'hr' },
     { username: 'admin', password: 'password', role: 'admin' }
   ];
+  let supervisorId = null;
   for (const data of users) {
     const existing = await User.findOne({ username: data.username });
     if (!existing) {
@@ -40,8 +41,12 @@ async function seedTestUsers() {
         status: '在職'
       });
       await User.create({ ...data, employee: employee._id });
+      if (data.role === 'supervisor') supervisorId = employee._id;
       console.log(`Created test user ${data.username}`);
     }
+  }
+  if (supervisorId) {
+    await Employee.updateMany({ role: 'employee' }, { supervisor: supervisorId });
   }
 }
 

--- a/server/src/middleware/supervisor.js
+++ b/server/src/middleware/supervisor.js
@@ -1,0 +1,35 @@
+import User from '../models/User.js';
+import Employee from '../models/Employee.js';
+import ShiftSchedule from '../models/ShiftSchedule.js';
+
+export async function verifySupervisor(req, res, next) {
+  try {
+    const user = await User.findById(req.user.id).populate('employee');
+    if (!user) return res.status(401).json({ error: 'Invalid user' });
+    if (['admin', 'hr'].includes(user.role)) return next();
+
+    let employeeId = req.body.employee;
+    if (!employeeId && Array.isArray(req.body.schedules) && req.body.schedules.length) {
+      employeeId = req.body.schedules[0].employee;
+    }
+    if (!employeeId && req.params.id) {
+      const schedule = await ShiftSchedule.findById(req.params.id);
+      if (schedule) employeeId = schedule.employee.toString();
+    }
+    if (!employeeId) return res.status(400).json({ error: 'Missing employee' });
+
+    const employee = await Employee.findById(employeeId);
+    if (!employee) return res.status(404).json({ error: 'Employee not found' });
+
+    if (
+      employee.supervisor &&
+      user.employee &&
+      employee.supervisor.toString() === user.employee._id.toString()
+    ) {
+      return next();
+    }
+    return res.status(403).json({ error: 'Forbidden' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -61,6 +61,7 @@ const employeeSchema = new mongoose.Schema({
   subDepartment: String,
   title: String,
   practiceTitle: String,
+  supervisor: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
   role: {
     type: String,
     enum: ['employee', 'supervisor', 'hr', 'admin'],

--- a/server/src/models/ShiftSchedule.js
+++ b/server/src/models/ShiftSchedule.js
@@ -6,4 +6,6 @@ const shiftScheduleSchema = new mongoose.Schema({
   shiftType: { type: String, required: true }
 }, { timestamps: true });
 
+shiftScheduleSchema.index({ employee: 1, date: 1 }, { unique: true });
+
 export default mongoose.model('ShiftSchedule', shiftScheduleSchema);

--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -5,16 +5,21 @@ import {
   getSchedule,
   updateSchedule,
   deleteSchedule,
-  exportSchedules
+  exportSchedules,
+  listMonthlySchedules,
+  createSchedulesBatch
 } from '../controllers/scheduleController.js';
+import { verifySupervisor } from '../middleware/supervisor.js';
 
 const router = Router();
 
 router.get('/', listSchedules);
+router.get('/monthly', listMonthlySchedules);
 router.get('/export', exportSchedules);
-router.post('/', createSchedule);
+router.post('/batch', verifySupervisor, createSchedulesBatch);
+router.post('/', verifySupervisor, createSchedule);
 router.get('/:id', getSchedule);
-router.put('/:id', updateSchedule);
+router.put('/:id', verifySupervisor, updateSchedule);
 router.delete('/:id', deleteSchedule);
 
 export default router;


### PR DESCRIPTION
## Summary
- support unique employee/date schedules
- add monthly schedule APIs with supervisor check middleware
- extend schedule routes
- seed supervisor relations in sample data
- build monthly schedule table on frontend
- add basic schedule tests

## Testing
- `npm test` *(fails: jest not found)*