### PR TITLE
更新後端選單名稱並新增一致性測試

### DIFF
--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -2,26 +2,31 @@ export function getMenu(req, res) {
   const role = req.user?.role || 'employee';
   const menus = {
     employee: [
-      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
-      { name: 'leave', label: '請假申請', icon: 'el-icon-date' }
+      { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'Leave', label: '請假申請', icon: 'el-icon-date' }
     ],
     supervisor: [
-      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
-      { name: 'leave', label: '請假申請', icon: 'el-icon-date' },
-      { name: 'schedule', label: '排班管理', icon: 'el-icon-timer' },
-      { name: 'approval', label: '簽核流程', icon: 'el-icon-s-operation' }
+      { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'Leave', label: '請假申請', icon: 'el-icon-date' },
+      { name: 'Schedule', label: '排班管理', icon: 'el-icon-timer' },
+      { name: 'Approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     hr: [
-      { name: 'attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
-      { name: 'leave', label: '請假申請', icon: 'el-icon-date' },
-      { name: 'schedule', label: '排班管理', icon: 'el-icon-timer' },
-      { name: 'approval', label: '簽核流程', icon: 'el-icon-s-operation' }
+      { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'Leave', label: '請假申請', icon: 'el-icon-date' },
+      { name: 'Schedule', label: '排班管理', icon: 'el-icon-timer' },
+      { name: 'Approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     admin: [
-      { name: 'HRManagementSystemSetting', label: '人資管理', icon: 'el-icon-user-solid' },
-      { name: 'Approval', label: '簽核表單', icon: 'el-icon-s-operation' },
+      { name: 'AttendanceSetting', label: '出勤設定', icon: 'el-icon-setting' },
+      { name: 'AttendanceManagementSetting', label: '出勤管理', icon: 'el-icon-postcard' },
+      { name: 'LeaveOvertimeSetting', label: '請假加班設定', icon: 'el-icon-date' },
       { name: 'ShiftScheduleSetting', label: '排班表設定', icon: 'el-icon-timer' },
-      { name: 'SystemOrgSetting', label: '權限 & 機構 & 部門設定', icon: 'el-icon-setting' }
+      { name: 'ApprovalFlowSetting', label: '簽核流程設定', icon: 'el-icon-s-operation' },
+      { name: 'ReportManagementSetting', label: '報表管理', icon: 'el-icon-document' },
+      { name: 'SalaryManagementSetting', label: '薪資管理', icon: 'el-icon-money' },
+      { name: 'SocialInsuranceRetirementSetting', label: '社保與退休', icon: 'el-icon-s-check' },
+      { name: 'HRManagementSystemSetting', label: '人資管理', icon: 'el-icon-user-solid' }
     ]
   };
   res.json(menus[role] || []);

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -21,6 +21,18 @@ describe('Menu API', () => {
     const res = await request(app).get('/api/menu');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.find(i => i.name === 'attendance')).toBeDefined();
+    expect(res.body.find(i => i.name === 'Attendance')).toBeDefined();
+  });
+
+  it('menu names exist in frontend routes', async () => {
+    const res = await request(app).get('/api/menu');
+    const fs = await import('fs');
+    const path = await import('path');
+    const routerPath = path.resolve(__dirname, '../../client/src/router/index.js');
+    const content = fs.readFileSync(routerPath, 'utf-8');
+    const matches = Array.from(content.matchAll(/name:\s*'([^']+)'/g)).map(m => m[1]);
+    res.body.forEach(item => {
+      expect(matches).toContain(item.name);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- 後端 `menuController` 的功能名稱改為與前端路由一致
- 調整 admin 的選單內容
- menu API 測試同步更新並驗證名稱與前端路由相符

## Testing
- `npm test` *(failed: jest not found)*