### PR TITLE
Fix EmployeeManagement mounted hook

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -308,7 +308,6 @@ const token = localStorage.getItem('token') || ''
 
 
   onMounted(() => {
-    fetchUsers()
     fetchDepartments()
     fetchEmployees()
   })


### PR DESCRIPTION
## Summary
- remove stray `fetchUsers()` call from EmployeeManagement

## Testing
- `npm test` *(fails: jest not found)*