### PR TITLE
新增組織與次部門模組

### DIFF
--- a/server/src/controllers/organizationController.js
+++ b/server/src/controllers/organizationController.js
@@ -1,0 +1,40 @@
+import Organization from '../models/Organization.js';
+
+export async function listOrganizations(req, res) {
+  try {
+    const organizations = await Organization.find();
+    res.json(organizations);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createOrganization(req, res) {
+  try {
+    const org = new Organization(req.body);
+    await org.save();
+    res.status(201).json(org);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateOrganization(req, res) {
+  try {
+    const org = await Organization.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!org) return res.status(404).json({ error: 'Not found' });
+    res.json(org);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteOrganization(req, res) {
+  try {
+    const org = await Organization.findByIdAndDelete(req.params.id);
+    if (!org) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/subDepartmentController.js
+++ b/server/src/controllers/subDepartmentController.js
@@ -1,0 +1,40 @@
+import SubDepartment from '../models/SubDepartment.js';
+
+export async function listSubDepartments(req, res) {
+  try {
+    const subDepts = await SubDepartment.find();
+    res.json(subDepts);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createSubDepartment(req, res) {
+  try {
+    const subDept = new SubDepartment(req.body);
+    await subDept.save();
+    res.status(201).json(subDept);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateSubDepartment(req, res) {
+  try {
+    const subDept = await SubDepartment.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!subDept) return res.status(404).json({ error: 'Not found' });
+    res.json(subDept);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteSubDepartment(req, res) {
+  try {
+    const subDept = await SubDepartment.findByIdAndDelete(req.params.id);
+    if (!subDept) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,6 +17,8 @@ import approvalRoutes from './routes/approvalRoutes.js';
 import menuRoutes from './routes/menuRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import departmentRoutes from './routes/departmentRoutes.js';
+import organizationRoutes from './routes/organizationRoutes.js';
+import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
@@ -85,6 +87,8 @@ app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'hr', 'admi
 app.use('/api/menu', authenticate, menuRoutes);
 app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
 app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);
+app.use('/api/organizations', authenticate, authorizeRoles('admin'), organizationRoutes);
+app.use('/api/sub-departments', authenticate, authorizeRoles('admin'), subDepartmentRoutes);
 
 app.use('/api/salary-settings', authenticate, authorizeRoles('hr', 'admin'), salarySettingRoutes);
 

--- a/server/src/models/Organization.js
+++ b/server/src/models/Organization.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const organizationSchema = new mongoose.Schema({
+  systemCode: String,
+  orgCode: String,
+  taxIdNumber: String,
+  laborInsuranceNo: String,
+  healthInsuranceNo: String,
+  taxCode: String,
+  address: String,
+  phone: String,
+  principal: String
+}, { timestamps: true });
+
+export default mongoose.model('Organization', organizationSchema);

--- a/server/src/models/SubDepartment.js
+++ b/server/src/models/SubDepartment.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const subDepartmentSchema = new mongoose.Schema({
+  department: { type: mongoose.Schema.Types.ObjectId, ref: 'Department', required: true },
+  code: String,
+  name: String,
+  phone: String,
+  manager: String,
+  headcount: Number,
+  scheduleSetting: String
+}, { timestamps: true });
+
+export default mongoose.model('SubDepartment', subDepartmentSchema);

--- a/server/src/routes/organizationRoutes.js
+++ b/server/src/routes/organizationRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  listOrganizations,
+  createOrganization,
+  updateOrganization,
+  deleteOrganization
+} from '../controllers/organizationController.js';
+
+const router = Router();
+
+router.get('/', listOrganizations);
+router.post('/', createOrganization);
+router.put('/:id', updateOrganization);
+router.delete('/:id', deleteOrganization);
+
+export default router;

--- a/server/src/routes/subDepartmentRoutes.js
+++ b/server/src/routes/subDepartmentRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  listSubDepartments,
+  createSubDepartment,
+  updateSubDepartment,
+  deleteSubDepartment
+} from '../controllers/subDepartmentController.js';
+
+const router = Router();
+
+router.get('/', listSubDepartments);
+router.post('/', createSubDepartment);
+router.put('/:id', updateSubDepartment);
+router.delete('/:id', deleteSubDepartment);
+
+export default router;

--- a/server/tests/organization.test.js
+++ b/server/tests/organization.test.js
@@ -1,0 +1,57 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const Organization = jest.fn().mockImplementation(() => ({ save: saveMock }));
+Organization.find = jest.fn();
+Organization.findByIdAndUpdate = jest.fn();
+Organization.findByIdAndDelete = jest.fn();
+
+jest.mock('../src/models/Organization.js', () => ({ default: Organization }), { virtual: true });
+
+let app;
+let organizationRoutes;
+
+beforeAll(async () => {
+  organizationRoutes = (await import('../src/routes/organizationRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/organizations', organizationRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  Organization.find.mockReset();
+  Organization.findByIdAndUpdate.mockReset();
+  Organization.findByIdAndDelete.mockReset();
+});
+
+describe('Organization API', () => {
+  it('lists organizations', async () => {
+    Organization.find.mockResolvedValue([{ name: 'Org' }]);
+    const res = await request(app).get('/api/organizations');
+    expect(res.status).toBe(200);
+  });
+
+  it('creates organization', async () => {
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/organizations').send({ name: 'Org' });
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('updates organization', async () => {
+    Organization.findByIdAndUpdate.mockResolvedValue({ name: 'Org' });
+    const res = await request(app).put('/api/organizations/1').send({ name: 'Org' });
+    expect(res.status).toBe(200);
+    expect(Organization.findByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  it('deletes organization', async () => {
+    Organization.findByIdAndDelete.mockResolvedValue({});
+    const res = await request(app).delete('/api/organizations/1');
+    expect(res.status).toBe(200);
+    expect(Organization.findByIdAndDelete).toHaveBeenCalledWith('1');
+  });
+});

--- a/server/tests/subDepartment.test.js
+++ b/server/tests/subDepartment.test.js
@@ -1,0 +1,57 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const SubDepartment = jest.fn().mockImplementation(() => ({ save: saveMock }));
+SubDepartment.find = jest.fn();
+SubDepartment.findByIdAndUpdate = jest.fn();
+SubDepartment.findByIdAndDelete = jest.fn();
+
+jest.mock('../src/models/SubDepartment.js', () => ({ default: SubDepartment }), { virtual: true });
+
+let app;
+let subDepartmentRoutes;
+
+beforeAll(async () => {
+  subDepartmentRoutes = (await import('../src/routes/subDepartmentRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/sub-departments', subDepartmentRoutes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  SubDepartment.find.mockReset();
+  SubDepartment.findByIdAndUpdate.mockReset();
+  SubDepartment.findByIdAndDelete.mockReset();
+});
+
+describe('SubDepartment API', () => {
+  it('lists sub-departments', async () => {
+    SubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
+    const res = await request(app).get('/api/sub-departments');
+    expect(res.status).toBe(200);
+  });
+
+  it('creates sub-department', async () => {
+    saveMock.mockResolvedValue();
+    const res = await request(app).post('/api/sub-departments').send({ name: 'Sub' });
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('updates sub-department', async () => {
+    SubDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'Sub' });
+    const res = await request(app).put('/api/sub-departments/1').send({ name: 'Sub' });
+    expect(res.status).toBe(200);
+    expect(SubDepartment.findByIdAndUpdate).toHaveBeenCalled();
+  });
+
+  it('deletes sub-department', async () => {
+    SubDepartment.findByIdAndDelete.mockResolvedValue({});
+    const res = await request(app).delete('/api/sub-departments/1');
+    expect(res.status).toBe(200);
+    expect(SubDepartment.findByIdAndDelete).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `Organization` 與 `SubDepartment` Mongoose 模型
- 新增對應的 controller 與 CRUD routes
- 在 `index.js` 掛載新路由，僅限 `admin` 角色
- 新增兩份 Jest 測試範例

## Testing
- `npm test` *(失敗：jest 指令不存在)*