### PR TITLE
新增 OrgDepartmentSetting 路由與選單

### DIFF
--- a/client/src/components/backComponents/OrgDepartmentSetting.vue
+++ b/client/src/components/backComponents/OrgDepartmentSetting.vue
@@ -1,0 +1,10 @@
+<!-- src/components/backComponents/OrgDepartmentSetting.vue -->
+<template>
+  <div class="org-department-setting">
+    <h2>權限&機構&部門設定</h2>
+  </div>
+</template>
+
+<script setup>
+// 此組件為示範頁面，可依需求擴充功能
+</script>

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -14,6 +14,7 @@ const ReportManagementSetting = () => import('@/components/backComponents/Report
 const SalaryManagementSetting = () => import('@/components/backComponents/SalaryManagementSetting.vue')
 const SocialInsuranceRetirementSetting = () => import('@/components/backComponents/SocialInsuranceRetirementSetting.vue')
 const HRManagementSystemSetting = () => import('@/components/backComponents/HRManagementSystemSetting.vue')
+const OrgDepartmentSetting = () => import('@/components/backComponents/OrgDepartmentSetting.vue')
 
 // ★ 錯誤頁面
 const Forbidden = () => import('@/views/Forbidden.vue')
@@ -54,6 +55,7 @@ const routes = [
       { path: 'salary-management-setting', name: 'SalaryManagementSetting', component: SalaryManagementSetting },
       { path: 'social-insurance-retirement-setting', name: 'SocialInsuranceRetirementSetting', component: SocialInsuranceRetirementSetting },
       { path: 'hr-management-system-setting', name: 'HRManagementSystemSetting', component: HRManagementSystemSetting },
+      { path: 'org-department-setting', name: 'OrgDepartmentSetting', component: OrgDepartmentSetting },
     ]
   },
 

--- a/client/tests/menuStore.spec.js
+++ b/client/tests/menuStore.spec.js
@@ -17,13 +17,13 @@ describe('menu store', () => {
   it('fetchMenu stores items', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ([{ name: 'a' }])
+      json: async () => ([{ name: 'a' }, { name: 'OrgDepartmentSetting' }])
     })
     const store = useMenuStore()
     await store.fetchMenu()
     expect(fetch).toHaveBeenCalledWith('/api/menu', expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer tok' })
     }))
-    expect(store.items).toEqual([{ name: 'a' }])
+    expect(store.items).toEqual([{ name: 'a' }, { name: 'OrgDepartmentSetting' }])
   })
 })

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -26,7 +26,8 @@ export function getMenu(req, res) {
       { name: 'ReportManagementSetting', label: '報表管理', icon: 'el-icon-document' },
       { name: 'SalaryManagementSetting', label: '薪資管理', icon: 'el-icon-money' },
       { name: 'SocialInsuranceRetirementSetting', label: '社保與退休', icon: 'el-icon-s-check' },
-      { name: 'HRManagementSystemSetting', label: '人資管理', icon: 'el-icon-user-solid' }
+      { name: 'HRManagementSystemSetting', label: '人資管理', icon: 'el-icon-user-solid' },
+      { name: 'OrgDepartmentSetting', label: '權限&機構&部門設定', icon: 'el-icon-s-grid' }
     ]
   };
   res.json(menus[role] || []);


### PR DESCRIPTION
## Summary
- 後端 menu 新增 OrgDepartmentSetting
- router 新增對應路由並引入新元件
- 新增 `OrgDepartmentSetting.vue` 示範頁面
- 測試更新以確認 menu 取得包含新項目

## Testing
- `npm test` *(失敗：jest 未安裝)*