### PR TITLE
新增部門與機構關聯並完善測試

### DIFF
--- a/server/src/controllers/departmentController.js
+++ b/server/src/controllers/departmentController.js
@@ -2,7 +2,11 @@ import Department from '../models/Department.js';
 
 export async function listDepartments(req, res) {
   try {
-    const departments = await Department.find();
+    const filter = {};
+    if (req.query.organization) {
+      filter.organization = req.query.organization;
+    }
+    const departments = await Department.find(filter);
     res.json(departments);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -11,7 +15,24 @@ export async function listDepartments(req, res) {
 
 export async function createDepartment(req, res) {
   try {
-    const dept = new Department(req.body);
+    const {
+      name,
+      code,
+      unitName,
+      location,
+      phone,
+      manager,
+      organization
+    } = req.body;
+    const dept = new Department({
+      name,
+      code,
+      unitName,
+      location,
+      phone,
+      manager,
+      organization
+    });
     await dept.save();
     res.status(201).json(dept);
   } catch (err) {
@@ -21,7 +42,20 @@ export async function createDepartment(req, res) {
 
 export async function updateDepartment(req, res) {
   try {
-    const dept = await Department.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const {
+      name,
+      code,
+      unitName,
+      location,
+      phone,
+      manager,
+      organization
+    } = req.body;
+    const dept = await Department.findByIdAndUpdate(
+      req.params.id,
+      { name, code, unitName, location, phone, manager, organization },
+      { new: true }
+    );
     if (!dept) return res.status(404).json({ error: 'Not found' });
     res.json(dept);
   } catch (err) {

--- a/server/src/models/Department.js
+++ b/server/src/models/Department.js
@@ -12,7 +12,9 @@ const departmentSchema = new mongoose.Schema({
   // 連絡電話
   phone: String,
   // 部門主管
-  manager: String
+  manager: String,
+  // 所屬機構
+  organization: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true }
 }, { timestamps: true });
 
 export default mongoose.model('Department', departmentSchema);

--- a/server/src/routes/departmentRoutes.js
+++ b/server/src/routes/departmentRoutes.js
@@ -7,7 +7,7 @@ import {
 } from '../controllers/departmentController.js';
 
 const router = Router();
-
+// 可以在查詢字串帶入 ?organization=<id> 以篩選指定機構的部門
 router.get('/', listDepartments);
 router.post('/', createDepartment);
 router.put('/:id', updateDepartment);

--- a/server/tests/department.test.js
+++ b/server/tests/department.test.js
@@ -34,18 +34,42 @@ describe('Department API', () => {
     expect(res.status).toBe(200);
   });
 
+  it('filters departments by organization', async () => {
+    Department.find.mockResolvedValue([{ name: 'HR' }]);
+    const res = await request(app).get('/api/departments?organization=1');
+    expect(res.status).toBe(200);
+    expect(Department.find).toHaveBeenCalledWith({ organization: '1' });
+  });
+
   it('creates department', async () => {
     saveMock.mockResolvedValue();
-    const res = await request(app).post('/api/departments').send({ name: 'HR', code: 'D1' });
+    const res = await request(app)
+      .post('/api/departments')
+      .send({ name: 'HR', code: 'D1', organization: '1' });
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
+    expect(Department).toHaveBeenCalledWith(
+      expect.objectContaining({ organization: '1' })
+    );
+  });
+
+  it('fails when organization missing', async () => {
+    saveMock.mockRejectedValue(new Error('Validation'));
+    const res = await request(app).post('/api/departments').send({ name: 'HR' });
+    expect(res.status).toBe(400);
   });
 
   it('updates department', async () => {
     Department.findByIdAndUpdate.mockResolvedValue({ name: 'HR' });
-    const res = await request(app).put('/api/departments/1').send({ name: 'HR' });
+    const res = await request(app)
+      .put('/api/departments/1')
+      .send({ name: 'HR', organization: '1' });
     expect(res.status).toBe(200);
-    expect(Department.findByIdAndUpdate).toHaveBeenCalled();
+    expect(Department.findByIdAndUpdate).toHaveBeenCalledWith(
+      '1',
+      expect.objectContaining({ organization: '1' }),
+      expect.any(Object)
+    );
   });
 
   it('deletes department', async () => {


### PR DESCRIPTION
## Notes
- 測試環境缺乏套件導致 `npm test` 無法執行

## Summary
- 在 `Department` 模型加入 `organization` 欄位並設定關聯
- `departmentController` 支援依 `organization` 查詢並於建立/更新時接收該欄位
- `departmentRoutes` 新增查詢參數說明
- Jest 測試覆蓋欄位驗證與條件查詢行為