### PR TITLE
實作機構與部門下拉選擇

### DIFF
--- a/client/tests/orgDepartmentSetting.spec.js
+++ b/client/tests/orgDepartmentSetting.spec.js
@@ -34,4 +34,18 @@ describe('OrgDepartmentSetting.vue', () => {
     await wrapper.vm.saveItem()
     expect(apiFetch).toHaveBeenCalledWith('/api/organizations', expect.objectContaining({ method: 'POST' }))
   })
+
+  it('shows organization select in dept form', () => {
+    const wrapper = mount(OrgDepartmentSetting, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.openDialog('dept')
+    expect(wrapper.findComponent({ name: 'ElSelect' }).exists()).toBe(true)
+    expect(wrapper.vm.form).toHaveProperty('organization')
+  })
+
+  it('fetchList adds parent id query', async () => {
+    const wrapper = mount(OrgDepartmentSetting, { global: { plugins: [ElementPlus] } })
+    apiFetch.mockClear()
+    await wrapper.vm.fetchList('dept', '123')
+    expect(apiFetch).toHaveBeenCalledWith('/api/departments?organization=123', expect.anything())
+  })
 })


### PR DESCRIPTION
## Summary
- 部門與小單位表單加入上層機構或部門的 `<el-select>`
- 列表依選擇的機構或部門篩選
- `fetchList` 新增上層 ID 參數以組合查詢字串
- `defaultForm` 加入 `organization` 與 `department` 欄位
- 新增測試驗證下拉選單與 API 請求

## Testing
- `npm test` *(失敗：sh: 1: jest: not found)*