### PR TITLE
調整版面寬度與新增測試

### DIFF
--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -1,8 +1,7 @@
 @import './base.css';
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
   font-weight: normal;
 }

--- a/client/src/views/Layout.vue
+++ b/client/src/views/Layout.vue
@@ -1,7 +1,7 @@
 <!-- src/views/Layout.vue (示例) -->
 <template>
   <div class="layout-container">
-    <el-aside width="200px" class="sidebar">
+    <el-aside class="layout-aside">
       <el-menu default-active="Settings" class="el-menu-vertical-demo">
         <el-menu-item
           v-for="item in menuItems"
@@ -14,7 +14,7 @@
         </el-menu-item>
       </el-menu>
     </el-aside>
-    <el-main>
+    <el-main class="layout-main">
       <router-view />
     </el-main>
   </div>
@@ -46,7 +46,13 @@ const gotoPage = (name) => {
   display: flex;
   height: 100vh;
 }
-.sidebar {
+.layout-aside {
   border-right: 1px solid #ebeef5;
+  flex: 0 0 25%;
+  width: 25%;
+}
+.layout-main {
+  flex: 0 0 75%;
+  width: 75%;
 }
 </style>

--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -7,7 +7,7 @@
       <el-button type="danger" @click="logout" class="logout-btn">登出</el-button>
     </el-header>
     <el-container>
-      <el-aside :width="isCollapse ? '64px' : '200px'" class="layout-aside">
+      <el-aside class="layout-aside">
         <el-menu :default-active="active" :collapse="isCollapse">
           <el-menu-item
             v-for="item in menuItems"
@@ -84,10 +84,14 @@ function logout() {
 .layout-aside {
   overflow: auto;
   border-right: 1px solid #ebeef5;
+  flex: 0 0 25%;
+  width: 25%;
 }
 .layout-main {
   padding: 20px;
   overflow: auto;
+  flex: 0 0 75%;
+  width: 75%;
 }
 @media (max-width: 768px) {
   .layout-aside {

--- a/client/tests/layoutWidth.spec.js
+++ b/client/tests/layoutWidth.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import ModernLayout from '../src/views/ModernLayout.vue'
+import Layout from '../src/views/Layout.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+vi.mock('../src/stores/menu', () => ({
+  useMenuStore: () => ({
+    fetchMenu: vi.fn(),
+    items: []
+  })
+}))
+
+describe('layout widths', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('ModernLayout aside and main flex to 25/75', () => {
+    const wrapper = mount(ModernLayout, { global: { plugins: [ElementPlus] } })
+    const asideStyle = getComputedStyle(wrapper.find('.layout-aside').element)
+    const mainStyle = getComputedStyle(wrapper.find('.layout-main').element)
+    expect(asideStyle.flexBasis || asideStyle.width).toBe('25%')
+    expect(mainStyle.flexBasis || mainStyle.width).toBe('75%')
+  })
+
+  it('Layout aside and main flex to 25/75', () => {
+    const wrapper = mount(Layout, { global: { plugins: [ElementPlus] } })
+    const asideStyle = getComputedStyle(wrapper.find('.layout-aside').element)
+    const mainStyle = getComputedStyle(wrapper.find('.layout-main').element)
+    expect(asideStyle.flexBasis || asideStyle.width).toBe('25%')
+    expect(mainStyle.flexBasis || mainStyle.width).toBe('75%')
+  })
+})


### PR DESCRIPTION
## Summary
- 調整 ModernLayout.vue 與 Layout.vue 的 Aside/Main 寬度為 25% 與 75%
- 移除全域寬度限制
- 新增 layoutWidth 測試驗證版面配置

## Testing
- `npm test` *(失敗：jest、vitest 未安裝)*