### PR TITLE
Add dynamic department filtering in employee form

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -85,10 +85,10 @@
                     <el-form-item label="部門">
                       <el-select v-model="employeeForm.department">
                         <el-option
-                          v-for="dept in departmentList"
-                          :key="dept.value"
-                          :label="dept.label"
-                          :value="dept.value"
+                          v-for="dept in filteredDepartments"
+                          :key="dept._id"
+                          :label="dept.name"
+                          :value="dept._id"
                         />
                       </el-select>
                     </el-form-item>
@@ -283,7 +283,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { apiFetch } from '../../api'
 
 const employeeDialogTab = ref('account')
@@ -402,6 +402,14 @@ const token = localStorage.getItem('token') || ''
   }
 
   const employeeForm = ref({ ...emptyEmployee })
+
+  const filteredDepartments = computed(() =>
+    employeeForm.value.institution
+      ? departmentList.value.filter(
+          d => d.organization === employeeForm.value.institution
+        )
+      : []
+  )
   
   function openEmployeeDialog(index = null) {
     if (index !== null) {
@@ -415,6 +423,7 @@ const token = localStorage.getItem('token') || ''
       employeeDialogTab.value = 'account'
       employeeForm.value = { ...emptyEmployee }
     }
+    fetchDepartments()
     employeeDialogVisible.value = true
   }
 

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import EmployeeManagement from '../src/components/backComponents/EmployeeManagement.vue'
+
+vi.mock('../src/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }))
+}))
+
+describe('EmployeeManagement.vue', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('filters departments by organization', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.departmentList = [
+      { _id: 'd1', name: 'D1', organization: 'o1' },
+      { _id: 'd2', name: 'D2', organization: 'o2' }
+    ]
+    wrapper.vm.employeeForm.institution = 'o1'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.filteredDepartments.length).toBe(1)
+    expect(wrapper.vm.filteredDepartments[0]._id).toBe('d1')
+  })
+})


### PR DESCRIPTION
## Summary
- filter departments by selected organization in EmployeeManagement
- fetch department list when opening employee dialog
- test department filter logic

## Testing
- `npm test` *(fails: jest not found)*