### PR TITLE
Fix jest mock variable names in tests

### DIFF
--- a/server/tests/approval.test.js
+++ b/server/tests/approval.test.js
@@ -2,12 +2,12 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
-const Approval = {
+const mockApproval = {
   find: jest.fn(),
   findByIdAndUpdate: jest.fn()
 };
 
-jest.mock('../src/models/Approval.js', () => ({ default: Approval }), { virtual: true });
+jest.mock('../src/models/Approval.js', () => ({ default: mockApproval }), { virtual: true });
 
 let app;
 let approvalRoutes;
@@ -20,37 +20,37 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  Approval.find.mockReset();
-  Approval.findByIdAndUpdate.mockReset();
+  mockApproval.find.mockReset();
+  mockApproval.findByIdAndUpdate.mockReset();
 });
 
 describe('Approval API', () => {
   it('lists approvals', async () => {
     const fakeApprovals = [{ type: 'leave' }];
-    Approval.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeApprovals) });
+    mockApproval.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeApprovals) });
     const res = await request(app).get('/api/approvals');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeApprovals);
   });
 
   it('returns 500 if listing fails', async () => {
-    Approval.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockApproval.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/approvals');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
   });
 
   it('approves request', async () => {
-    Approval.findByIdAndUpdate.mockResolvedValue({ status: 'approved' });
+    mockApproval.findByIdAndUpdate.mockResolvedValue({ status: 'approved' });
     const res = await request(app).post('/api/approvals/123/approve');
     expect(res.status).toBe(200);
-    expect(Approval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'approved' }, { new: true });
+    expect(mockApproval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'approved' }, { new: true });
   });
 
   it('rejects request', async () => {
-    Approval.findByIdAndUpdate.mockResolvedValue({ status: 'rejected' });
+    mockApproval.findByIdAndUpdate.mockResolvedValue({ status: 'rejected' });
     const res = await request(app).post('/api/approvals/123/reject');
     expect(res.status).toBe(200);
-    expect(Approval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'rejected' }, { new: true });
+    expect(mockApproval.findByIdAndUpdate).toHaveBeenCalledWith('123', { status: 'rejected' }, { new: true });
   });
 });

--- a/server/tests/attendance.test.js
+++ b/server/tests/attendance.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const AttendanceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
-AttendanceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+const mockAttendanceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockAttendanceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
-jest.mock('../src/models/AttendanceRecord.js', () => ({ default: AttendanceRecord }), { virtual: true });
+jest.mock('../src/models/AttendanceRecord.js', () => ({ default: mockAttendanceRecord }), { virtual: true });
 
 let app;
 let attendanceRoutes;
@@ -20,20 +20,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  AttendanceRecord.find.mockReset();
+  mockAttendanceRecord.find.mockReset();
 });
 
 describe('Attendance API', () => {
   it('lists records', async () => {
     const fakeRecords = [{ action: 'clockIn' }];
-    AttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    mockAttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
     const res = await request(app).get('/api/attendance');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeRecords);
   });
 
   it('returns 500 if listing fails', async () => {
-    AttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockAttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/attendance');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });

--- a/server/tests/attendanceSetting.test.js
+++ b/server/tests/attendanceSetting.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 
-const AttendanceSetting = {
+const mockAttendanceSetting = {
   findOne: jest.fn(),
   findOneAndUpdate: jest.fn()
 };
 
-jest.mock('../src/models/AttendanceSetting.js', () => ({ default: AttendanceSetting }), { virtual: true });
+jest.mock('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }), { virtual: true });
 
 let app;
 let settingRoutes;
@@ -21,21 +21,21 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  AttendanceSetting.findOne.mockReset();
-  AttendanceSetting.findOneAndUpdate.mockReset();
+  mockAttendanceSetting.findOne.mockReset();
+  mockAttendanceSetting.findOneAndUpdate.mockReset();
 });
 
 describe('AttendanceSetting API', () => {
   it('gets settings', async () => {
     const data = { shifts: [] };
-    AttendanceSetting.findOne.mockResolvedValue(data);
+    mockAttendanceSetting.findOne.mockResolvedValue(data);
     const res = await request(app).get('/api/attendance-settings');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(data);
   });
 
   it('returns 500 if listing fails', async () => {
-    AttendanceSetting.findOne.mockRejectedValue(new Error('fail'));
+    mockAttendanceSetting.findOne.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/attendance-settings');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
@@ -43,10 +43,10 @@ describe('AttendanceSetting API', () => {
 
   it('updates settings', async () => {
     const payload = { shifts: [] };
-    AttendanceSetting.findOneAndUpdate.mockResolvedValue(payload);
+    mockAttendanceSetting.findOneAndUpdate.mockResolvedValue(payload);
     const res = await request(app).put('/api/attendance-settings').send(payload);
     expect(res.status).toBe(200);
-    expect(AttendanceSetting.findOneAndUpdate).toHaveBeenCalledWith({}, payload, { new: true, upsert: true });
+    expect(mockAttendanceSetting.findOneAndUpdate).toHaveBeenCalledWith({}, payload, { new: true, upsert: true });
 
   });
 });

--- a/server/tests/department.test.js
+++ b/server/tests/department.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const Department = jest.fn().mockImplementation(() => ({ save: saveMock }));
-Department.find = jest.fn();
-Department.findByIdAndUpdate = jest.fn();
-Department.findByIdAndDelete = jest.fn();
+const mockDepartment = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockDepartment.find = jest.fn();
+mockDepartment.findByIdAndUpdate = jest.fn();
+mockDepartment.findByIdAndDelete = jest.fn();
 
-jest.mock('../src/models/Department.js', () => ({ default: Department }), { virtual: true });
+jest.mock('../src/models/Department.js', () => ({ default: mockDepartment }), { virtual: true });
 
 let app;
 let departmentRoutes;
@@ -22,23 +22,23 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  Department.find.mockReset();
-  Department.findByIdAndUpdate.mockReset();
-  Department.findByIdAndDelete.mockReset();
+  mockDepartment.find.mockReset();
+  mockDepartment.findByIdAndUpdate.mockReset();
+  mockDepartment.findByIdAndDelete.mockReset();
 });
 
 describe('Department API', () => {
   it('lists departments', async () => {
-    Department.find.mockResolvedValue([{ name: 'HR' }]);
+    mockDepartment.find.mockResolvedValue([{ name: 'HR' }]);
     const res = await request(app).get('/api/departments');
     expect(res.status).toBe(200);
   });
 
   it('filters departments by organization', async () => {
-    Department.find.mockResolvedValue([{ name: 'HR' }]);
+    mockDepartment.find.mockResolvedValue([{ name: 'HR' }]);
     const res = await request(app).get('/api/departments?organization=1');
     expect(res.status).toBe(200);
-    expect(Department.find).toHaveBeenCalledWith({ organization: '1' });
+    expect(mockDepartment.find).toHaveBeenCalledWith({ organization: '1' });
   });
 
   it('creates department', async () => {
@@ -48,7 +48,7 @@ describe('Department API', () => {
 
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
-    expect(Department).toHaveBeenCalledWith(
+    expect(mockDepartment).toHaveBeenCalledWith(
       expect.objectContaining({ organization: '1' })
     );
   });
@@ -60,12 +60,12 @@ describe('Department API', () => {
   });
 
   it('updates department', async () => {
-    Department.findByIdAndUpdate.mockResolvedValue({ name: 'HR' });
+    mockDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'HR' });
 
     const res = await request(app).put('/api/departments/1').send({ name: 'HR', organization: 'org1' });
 
     expect(res.status).toBe(200);
-    expect(Department.findByIdAndUpdate).toHaveBeenCalledWith(
+    expect(mockDepartment.findByIdAndUpdate).toHaveBeenCalledWith(
       '1',
       expect.objectContaining({ organization: '1' }),
       expect.any(Object)
@@ -73,9 +73,9 @@ describe('Department API', () => {
   });
 
   it('deletes department', async () => {
-    Department.findByIdAndDelete.mockResolvedValue({});
+    mockDepartment.findByIdAndDelete.mockResolvedValue({});
     const res = await request(app).delete('/api/departments/1');
     expect(res.status).toBe(200);
-    expect(Department.findByIdAndDelete).toHaveBeenCalledWith('1');
+    expect(mockDepartment.findByIdAndDelete).toHaveBeenCalledWith('1');
   });
 });

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const Employee = jest.fn().mockImplementation(() => ({ save: saveMock }));
-Employee.find = jest.fn();
-Employee.findById = jest.fn();
-Employee.findByIdAndDelete = jest.fn();
+const mockEmployee = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockEmployee.find = jest.fn();
+mockEmployee.findById = jest.fn();
+mockEmployee.findByIdAndDelete = jest.fn();
 
-jest.mock('../src/models/Employee.js', () => ({ default: Employee }), { virtual: true });
+jest.mock('../src/models/Employee.js', () => ({ default: mockEmployee }), { virtual: true });
 
 let app;
 let employeeRoutes;
@@ -22,9 +22,9 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  Employee.find.mockReset();
-  Employee.findById.mockReset();
-  Employee.findByIdAndDelete.mockReset();
+  mockEmployee.find.mockReset();
+  mockEmployee.findById.mockReset();
+  mockEmployee.findByIdAndDelete.mockReset();
 });
 
 describe('Employee API', () => {
@@ -32,14 +32,14 @@ describe('Employee API', () => {
 
     const fakeEmployees = [{ name: 'John', department: 'Sales', title: 'Staff', status: '在職' }];
 
-    Employee.find.mockResolvedValue(fakeEmployees);
+    mockEmployee.find.mockResolvedValue(fakeEmployees);
     const res = await request(app).get('/api/employees');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeEmployees);
   });
 
   it('returns 500 if listing fails', async () => {
-    Employee.find.mockRejectedValue(new Error('fail'));
+    mockEmployee.find.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/employees');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
@@ -70,28 +70,28 @@ describe('Employee API', () => {
 
   it('gets employee', async () => {
     const fake = { _id: '1', name: 'John' };
-    Employee.findById.mockResolvedValue(fake);
+    mockEmployee.findById.mockResolvedValue(fake);
     const res = await request(app).get('/api/employees/1');
     expect(res.status).toBe(200);
-    expect(Employee.findById).toHaveBeenCalledWith('1');
+    expect(mockEmployee.findById).toHaveBeenCalledWith('1');
     expect(res.body).toEqual(fake);
   });
 
   it('updates employee', async () => {
-    Employee.findById.mockResolvedValue({ _id: '1', name: 'John', save: saveMock });
+    mockEmployee.findById.mockResolvedValue({ _id: '1', name: 'John', save: saveMock });
     saveMock.mockResolvedValue();
     const res = await request(app)
       .put('/api/employees/1')
       .send({ name: 'Updated' });
     expect(res.status).toBe(200);
-    expect(Employee.findById).toHaveBeenCalledWith('1');
+    expect(mockEmployee.findById).toHaveBeenCalledWith('1');
     expect(saveMock).toHaveBeenCalled();
     expect(res.body).toMatchObject({ _id: '1', name: 'Updated' });
 
   });
 
   it('fails updating with invalid email or role', async () => {
-    Employee.findById.mockResolvedValue({ _id: '1', name: 'John', save: saveMock });
+    mockEmployee.findById.mockResolvedValue({ _id: '1', name: 'John', save: saveMock });
     const res = await request(app)
       .put('/api/employees/1')
       .send({ email: 'bad', role: 'x' });
@@ -99,10 +99,10 @@ describe('Employee API', () => {
   });
 
   it('deletes employee', async () => {
-    Employee.findByIdAndDelete.mockResolvedValue({ _id: '1' });
+    mockEmployee.findByIdAndDelete.mockResolvedValue({ _id: '1' });
     const res = await request(app).delete('/api/employees/1');
     expect(res.status).toBe(200);
-    expect(Employee.findByIdAndDelete).toHaveBeenCalledWith('1');
+    expect(mockEmployee.findByIdAndDelete).toHaveBeenCalledWith('1');
     expect(res.body).toEqual({ success: true });
   });
 });

--- a/server/tests/insurance.test.js
+++ b/server/tests/insurance.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const InsuranceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
-InsuranceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+const mockInsuranceRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockInsuranceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
-jest.mock('../src/models/InsuranceRecord.js', () => ({ default: InsuranceRecord }), { virtual: true });
+jest.mock('../src/models/InsuranceRecord.js', () => ({ default: mockInsuranceRecord }), { virtual: true });
 
 let app;
 let insuranceRoutes;
@@ -20,20 +20,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  InsuranceRecord.find.mockReset();
+  mockInsuranceRecord.find.mockReset();
 });
 
 describe('Insurance API', () => {
   it('lists insurance records', async () => {
     const fakeRecords = [{ provider: 'InsureCo' }];
-    InsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    mockInsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
     const res = await request(app).get('/api/insurance');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeRecords);
   });
 
   it('returns 500 if listing fails', async () => {
-    InsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockInsuranceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/insurance');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });

--- a/server/tests/leave.test.js
+++ b/server/tests/leave.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const LeaveRequest = jest.fn().mockImplementation(() => ({ save: saveMock }));
-LeaveRequest.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+const mockLeaveRequest = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockLeaveRequest.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
-jest.mock('../src/models/LeaveRequest.js', () => ({ default: LeaveRequest }), { virtual: true });
+jest.mock('../src/models/LeaveRequest.js', () => ({ default: mockLeaveRequest }), { virtual: true });
 
 let app;
 let leaveRoutes;
@@ -20,20 +20,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  LeaveRequest.find.mockReset();
+  mockLeaveRequest.find.mockReset();
 });
 
 describe('Leave API', () => {
   it('lists leaves', async () => {
     const fakeLeaves = [{ leaveType: 'vacation' }];
-    LeaveRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeLeaves) });
+    mockLeaveRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeLeaves) });
     const res = await request(app).get('/api/leaves');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeLeaves);
   });
 
   it('returns 500 if listing fails', async () => {
-    LeaveRequest.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockLeaveRequest.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/leaves');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -2,10 +2,12 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
-jest.mock('../src/middleware/auth.js', () => ({
+const mockAuth = {
   authenticate: (req, res, next) => { req.user = { role: 'employee' }; next(); },
   authorizeRoles: () => (req, res, next) => next()
-}), { virtual: true });
+};
+
+jest.mock('../src/middleware/auth.js', () => mockAuth, { virtual: true });
 
 let app;
 let menuRoutes;

--- a/server/tests/organization.test.js
+++ b/server/tests/organization.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const Organization = jest.fn().mockImplementation(() => ({ save: saveMock }));
-Organization.find = jest.fn();
-Organization.findByIdAndUpdate = jest.fn();
-Organization.findByIdAndDelete = jest.fn();
+const mockOrganization = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockOrganization.find = jest.fn();
+mockOrganization.findByIdAndUpdate = jest.fn();
+mockOrganization.findByIdAndDelete = jest.fn();
 
-jest.mock('../src/models/Organization.js', () => ({ default: Organization }), { virtual: true });
+jest.mock('../src/models/Organization.js', () => ({ default: mockOrganization }), { virtual: true });
 
 let app;
 let organizationRoutes;
@@ -22,14 +22,14 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  Organization.find.mockReset();
-  Organization.findByIdAndUpdate.mockReset();
-  Organization.findByIdAndDelete.mockReset();
+  mockOrganization.find.mockReset();
+  mockOrganization.findByIdAndUpdate.mockReset();
+  mockOrganization.findByIdAndDelete.mockReset();
 });
 
 describe('Organization API', () => {
   it('lists organizations', async () => {
-    Organization.find.mockResolvedValue([{ name: 'Org' }]);
+    mockOrganization.find.mockResolvedValue([{ name: 'Org' }]);
     const res = await request(app).get('/api/organizations');
     expect(res.status).toBe(200);
   });
@@ -42,16 +42,16 @@ describe('Organization API', () => {
   });
 
   it('updates organization', async () => {
-    Organization.findByIdAndUpdate.mockResolvedValue({ name: 'Org' });
+    mockOrganization.findByIdAndUpdate.mockResolvedValue({ name: 'Org' });
     const res = await request(app).put('/api/organizations/1').send({ name: 'Org' });
     expect(res.status).toBe(200);
-    expect(Organization.findByIdAndUpdate).toHaveBeenCalled();
+    expect(mockOrganization.findByIdAndUpdate).toHaveBeenCalled();
   });
 
   it('deletes organization', async () => {
-    Organization.findByIdAndDelete.mockResolvedValue({});
+    mockOrganization.findByIdAndDelete.mockResolvedValue({});
     const res = await request(app).delete('/api/organizations/1');
     expect(res.status).toBe(200);
-    expect(Organization.findByIdAndDelete).toHaveBeenCalledWith('1');
+    expect(mockOrganization.findByIdAndDelete).toHaveBeenCalledWith('1');
   });
 });

--- a/server/tests/payroll.test.js
+++ b/server/tests/payroll.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const PayrollRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
-PayrollRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+const mockPayrollRecord = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockPayrollRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
-jest.mock('../src/models/PayrollRecord.js', () => ({ default: PayrollRecord }), { virtual: true });
+jest.mock('../src/models/PayrollRecord.js', () => ({ default: mockPayrollRecord }), { virtual: true });
 
 let app;
 let payrollRoutes;
@@ -20,20 +20,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  PayrollRecord.find.mockReset();
+  mockPayrollRecord.find.mockReset();
 });
 
 describe('Payroll API', () => {
   it('lists payroll records', async () => {
     const fakeRecords = [{ amount: 100 }];
-    PayrollRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    mockPayrollRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
     const res = await request(app).get('/api/payroll');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeRecords);
   });
 
   it('returns 500 if listing fails', async () => {
-    PayrollRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockPayrollRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/payroll');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const Report = jest.fn().mockImplementation(() => ({ save: saveMock }));
-Report.find = jest.fn();
+const mockReport = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockReport.find = jest.fn();
 
-jest.mock('../src/models/Report.js', () => ({ default: Report }), { virtual: true });
+jest.mock('../src/models/Report.js', () => ({ default: mockReport }), { virtual: true });
 
 let app;
 let reportRoutes;
@@ -20,20 +20,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  Report.find.mockReset();
+  mockReport.find.mockReset();
 });
 
 describe('Report API', () => {
   it('lists reports', async () => {
     const fakeReports = [{ name: 'Monthly' }];
-    Report.find.mockResolvedValue(fakeReports);
+    mockReport.find.mockResolvedValue(fakeReports);
     const res = await request(app).get('/api/reports');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeReports);
   });
 
   it('returns 500 if listing fails', async () => {
-    Report.find.mockRejectedValue(new Error('fail'));
+    mockReport.find.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/reports');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });

--- a/server/tests/salarySetting.test.js
+++ b/server/tests/salarySetting.test.js
@@ -3,11 +3,11 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const SalarySetting = jest.fn().mockImplementation(() => ({ save: saveMock }));
-SalarySetting.find = jest.fn();
-SalarySetting.findByIdAndUpdate = jest.fn();
+const mockSalarySetting = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockSalarySetting.find = jest.fn();
+mockSalarySetting.findByIdAndUpdate = jest.fn();
 
-jest.mock('../src/models/SalarySetting.js', () => ({ default: SalarySetting }), { virtual: true });
+jest.mock('../src/models/SalarySetting.js', () => ({ default: mockSalarySetting }), { virtual: true });
 
 let app;
 let salaryRoutes;
@@ -21,21 +21,21 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  SalarySetting.find.mockReset();
-  SalarySetting.findByIdAndUpdate.mockReset();
+  mockSalarySetting.find.mockReset();
+  mockSalarySetting.findByIdAndUpdate.mockReset();
 });
 
 describe('SalarySetting API', () => {
   it('lists settings', async () => {
     const fake = [{ salaryItems: [] }];
-    SalarySetting.find.mockResolvedValue(fake);
+    mockSalarySetting.find.mockResolvedValue(fake);
     const res = await request(app).get('/api/salary-settings');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fake);
   });
 
   it('returns 500 if listing fails', async () => {
-    SalarySetting.find.mockRejectedValue(new Error('fail'));
+    mockSalarySetting.find.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/salary-settings');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
@@ -51,9 +51,9 @@ describe('SalarySetting API', () => {
   });
 
   it('updates setting', async () => {
-    SalarySetting.findByIdAndUpdate.mockResolvedValue({ _id: '1', salaryItems: [] });
+    mockSalarySetting.findByIdAndUpdate.mockResolvedValue({ _id: '1', salaryItems: [] });
     const res = await request(app).put('/api/salary-settings/1').send({ salaryItems: [] });
     expect(res.status).toBe(200);
-    expect(SalarySetting.findByIdAndUpdate).toHaveBeenCalled();
+    expect(mockSalarySetting.findByIdAndUpdate).toHaveBeenCalled();
   });
 });

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const ShiftSchedule = jest.fn().mockImplementation(() => ({ save: saveMock }));
-ShiftSchedule.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+const mockShiftSchedule = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockShiftSchedule.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
 const pdfPipe = jest.fn();
 const pdfEnd = jest.fn();
-const PDFDocumentMock = jest.fn().mockImplementation(() => ({
+const mockPDFDocument = jest.fn().mockImplementation(() => ({
   pipe: pdfPipe,
   end: pdfEnd,
   fontSize: jest.fn().mockReturnThis(),
@@ -21,12 +21,12 @@ const workbookMock = {
   addWorksheet: jest.fn(() => worksheetMock),
   xlsx: { writeBuffer: jest.fn().mockResolvedValue(Buffer.from('test')) }
 };
-const ExcelJSMock = { Workbook: jest.fn(() => workbookMock) };
+const mockExcelJS = { Workbook: jest.fn(() => workbookMock) };
 
-jest.mock('pdfkit', () => ({ default: PDFDocumentMock }), { virtual: true });
-jest.mock('exceljs', () => ({ default: ExcelJSMock }), { virtual: true });
+jest.mock('pdfkit', () => ({ default: mockPDFDocument }), { virtual: true });
+jest.mock('exceljs', () => ({ default: mockExcelJS }), { virtual: true });
 
-jest.mock('../src/models/ShiftSchedule.js', () => ({ default: ShiftSchedule }), { virtual: true });
+jest.mock('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }), { virtual: true });
 jest.mock('../src/middleware/supervisor.js', () => ({ verifySupervisor: (req, res, next) => next() }), { virtual: true });
 
 let app;
@@ -41,20 +41,20 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  ShiftSchedule.find.mockReset();
+  mockShiftSchedule.find.mockReset();
 });
 
 describe('Schedule API', () => {
   it('lists schedules', async () => {
     const fakeSchedules = [{ shiftType: 'morning' }];
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
     const res = await request(app).get('/api/schedules');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeSchedules);
   });
 
   it('returns 500 if listing fails', async () => {
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
     const res = await request(app).get('/api/schedules');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
@@ -70,14 +70,14 @@ describe('Schedule API', () => {
   });
 
   it('exports schedules to pdf', async () => {
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
     const res = await request(app).get('/api/schedules/export?format=pdf');
     expect(res.status).toBe(200);
     expect(pdfPipe).toHaveBeenCalled();
   });
 
   it('exports schedules to excel', async () => {
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
     const res = await request(app).get('/api/schedules/export?format=excel');
     expect(res.status).toBe(200);
     expect(workbookMock.xlsx.writeBuffer).toHaveBeenCalled();
@@ -85,18 +85,18 @@ describe('Schedule API', () => {
 
   it('lists schedules by month', async () => {
     const fake = [{ shiftType: 'night' }];
-    ShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fake) });
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fake) });
     const res = await request(app).get('/api/schedules/monthly?month=2023-01&employee=e1');
     expect(res.status).toBe(200);
-    expect(ShiftSchedule.find).toHaveBeenCalled();
+    expect(mockShiftSchedule.find).toHaveBeenCalled();
     expect(res.body).toEqual(fake);
   });
 
   it('creates schedules batch', async () => {
-    ShiftSchedule.insertMany = jest.fn().mockResolvedValue([{ _id: '1' }]);
+    mockShiftSchedule.insertMany = jest.fn().mockResolvedValue([{ _id: '1' }]);
     const payload = { schedules: [{ employee: 'e1', date: '2023-01-01', shiftType: 'day' }] };
     const res = await request(app).post('/api/schedules/batch').send(payload);
     expect(res.status).toBe(201);
-    expect(ShiftSchedule.insertMany).toHaveBeenCalled();
+    expect(mockShiftSchedule.insertMany).toHaveBeenCalled();
   });
 });

--- a/server/tests/subDepartment.test.js
+++ b/server/tests/subDepartment.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const SubDepartment = jest.fn().mockImplementation(() => ({ save: saveMock }));
-SubDepartment.find = jest.fn();
-SubDepartment.findByIdAndUpdate = jest.fn();
-SubDepartment.findByIdAndDelete = jest.fn();
+const mockSubDepartment = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockSubDepartment.find = jest.fn();
+mockSubDepartment.findByIdAndUpdate = jest.fn();
+mockSubDepartment.findByIdAndDelete = jest.fn();
 
-jest.mock('../src/models/SubDepartment.js', () => ({ default: SubDepartment }), { virtual: true });
+jest.mock('../src/models/SubDepartment.js', () => ({ default: mockSubDepartment }), { virtual: true });
 
 let app;
 let subDepartmentRoutes;
@@ -22,14 +22,14 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  SubDepartment.find.mockReset();
-  SubDepartment.findByIdAndUpdate.mockReset();
-  SubDepartment.findByIdAndDelete.mockReset();
+  mockSubDepartment.find.mockReset();
+  mockSubDepartment.findByIdAndUpdate.mockReset();
+  mockSubDepartment.findByIdAndDelete.mockReset();
 });
 
 describe('SubDepartment API', () => {
   it('lists sub-departments', async () => {
-    SubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
+    mockSubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
     const res = await request(app).get('/api/sub-departments');
     expect(res.status).toBe(200);
   });
@@ -42,16 +42,16 @@ describe('SubDepartment API', () => {
   });
 
   it('updates sub-department', async () => {
-    SubDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'Sub' });
+    mockSubDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'Sub' });
     const res = await request(app).put('/api/sub-departments/1').send({ name: 'Sub', department: 'dept1' });
     expect(res.status).toBe(200);
-    expect(SubDepartment.findByIdAndUpdate).toHaveBeenCalled();
+    expect(mockSubDepartment.findByIdAndUpdate).toHaveBeenCalled();
   });
 
   it('deletes sub-department', async () => {
-    SubDepartment.findByIdAndDelete.mockResolvedValue({});
+    mockSubDepartment.findByIdAndDelete.mockResolvedValue({});
     const res = await request(app).delete('/api/sub-departments/1');
     expect(res.status).toBe(200);
-    expect(SubDepartment.findByIdAndDelete).toHaveBeenCalledWith('1');
+    expect(mockSubDepartment.findByIdAndDelete).toHaveBeenCalledWith('1');
   });
 });

--- a/server/tests/tokenBlacklist.test.js
+++ b/server/tests/tokenBlacklist.test.js
@@ -3,9 +3,9 @@ import express from 'express'
 import { jest } from '@jest/globals'
 import jwt from 'jsonwebtoken'
 
-const BlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
+const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
 
-jest.mock('../src/models/BlacklistedToken.js', () => ({ default: BlacklistedToken }), { virtual: true });
+jest.mock('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }), { virtual: true });
 
 let blacklistUtils;
 let authenticate;
@@ -15,19 +15,19 @@ beforeEach(async () => {
   jest.resetModules();
   blacklistUtils = await import('../src/utils/tokenBlacklist.js');
   ({ authenticate } = await import('../src/middleware/auth.js'));
-  BlacklistedToken.create.mockReset();
-  BlacklistedToken.findOne.mockReset();
+  mockBlacklistedToken.create.mockReset();
+  mockBlacklistedToken.findOne.mockReset();
 });
 
 test('blacklisted token rejected after server restart', async () => {
   const token = jwt.sign({ id: 1 }, 'secret', { expiresIn: '1h' });
-  BlacklistedToken.create.mockResolvedValue();
+  mockBlacklistedToken.create.mockResolvedValue();
   await blacklistUtils.blacklistToken(token);
 
   jest.resetModules();
   blacklistUtils = await import('../src/utils/tokenBlacklist.js');
   ({ authenticate } = await import('../src/middleware/auth.js'));
-  BlacklistedToken.findOne.mockResolvedValue({ token, expiresAt: new Date(Date.now() + 3600000) });
+  mockBlacklistedToken.findOne.mockResolvedValue({ token, expiresAt: new Date(Date.now() + 3600000) });
 
   const app = express();
   app.get('/protected', authenticate, (req, res) => res.sendStatus(200));

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const User = jest.fn().mockImplementation(() => ({ save: saveMock }));
-User.find = jest.fn();
-User.findById = jest.fn();
-User.findByIdAndDelete = jest.fn();
+const mockUser = jest.fn().mockImplementation(() => ({ save: saveMock }));
+mockUser.find = jest.fn();
+mockUser.findById = jest.fn();
+mockUser.findByIdAndDelete = jest.fn();
 
-jest.mock('../src/models/User.js', () => ({ default: User }), { virtual: true });
+jest.mock('../src/models/User.js', () => ({ default: mockUser }), { virtual: true });
 
 let app;
 let userRoutes;
@@ -22,15 +22,15 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
-  User.find.mockReset();
-  User.findById.mockReset();
-  User.findByIdAndDelete.mockReset();
+  mockUser.find.mockReset();
+  mockUser.findById.mockReset();
+  mockUser.findByIdAndDelete.mockReset();
 });
 
 describe('User API', () => {
   it('lists users', async () => {
     const fake = [{ username: 'a' }];
-    User.find.mockResolvedValue(fake);
+    mockUser.find.mockResolvedValue(fake);
     const res = await request(app).get('/api/users');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fake);
@@ -45,17 +45,17 @@ describe('User API', () => {
   });
 
   it('updates user', async () => {
-    User.findById.mockResolvedValue({ save: saveMock, username: 'u' });
+    mockUser.findById.mockResolvedValue({ save: saveMock, username: 'u' });
     saveMock.mockResolvedValue();
     const res = await request(app).put('/api/users/1').send({ username: 'b' });
     expect(res.status).toBe(200);
-    expect(User.findById).toHaveBeenCalledWith('1');
+    expect(mockUser.findById).toHaveBeenCalledWith('1');
   });
 
   it('deletes user', async () => {
-    User.findByIdAndDelete.mockResolvedValue({});
+    mockUser.findByIdAndDelete.mockResolvedValue({});
     const res = await request(app).delete('/api/users/1');
     expect(res.status).toBe(200);
-    expect(User.findByIdAndDelete).toHaveBeenCalledWith('1');
+    expect(mockUser.findByIdAndDelete).toHaveBeenCalledWith('1');
   });
 });


### PR DESCRIPTION
## Summary
- rename mock variables in all server tests to follow `mock` prefix
- adjust references accordingly
- mock auth middleware in menu tests with `mockAuth`

## Testing
- `npm --prefix server test` *(fails: jest not found)*