### PR TITLE
Integrate user creation on employee signup

### DIFF
--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -1,4 +1,5 @@
 import Employee from '../models/Employee.js';
+import User from '../models/User.js';
 
 export async function listEmployees(req, res) {
   try {
@@ -11,12 +12,18 @@ export async function listEmployees(req, res) {
 
 export async function createEmployee(req, res) {
   try {
-    const { name, email, role, department, title, status } = req.body;
+    const { name, email, role, department, title, status, username, password } = req.body;
     if (!name) {
       return res.status(400).json({ error: 'Name is required' });
     }
     if (!email) {
       return res.status(400).json({ error: 'Email is required' });
+    }
+    if (!username) {
+      return res.status(400).json({ error: 'Username is required' });
+    }
+    if (!password) {
+      return res.status(400).json({ error: 'Password is required' });
     }
     const emailRegex = /^\S+@\S+\.\S+$/;
     if (!emailRegex.test(email)) {
@@ -30,6 +37,7 @@ export async function createEmployee(req, res) {
     }
     const employee = new Employee({ name, email, role, department, title, status });
     await employee.save();
+    await User.create({ username, password, role, employee: employee._id, department });
     res.status(201).json(employee);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -8,7 +8,10 @@ mockEmployee.find = jest.fn();
 mockEmployee.findById = jest.fn();
 mockEmployee.findByIdAndDelete = jest.fn();
 
+const mockUser = { create: jest.fn() };
+
 jest.mock('../src/models/Employee.js', () => ({ default: mockEmployee }), { virtual: true });
+jest.mock('../src/models/User.js', () => ({ default: mockUser }), { virtual: true });
 
 let app;
 let employeeRoutes;
@@ -25,6 +28,7 @@ beforeEach(() => {
   mockEmployee.find.mockReset();
   mockEmployee.findById.mockReset();
   mockEmployee.findByIdAndDelete.mockReset();
+  mockUser.create.mockReset();
 });
 
 describe('Employee API', () => {
@@ -53,13 +57,30 @@ describe('Employee API', () => {
       department: 'HR',
       title: 'Manager',
       status: '在職',
+      username: 'jane',
+      password: 'secret',
+      role: 'employee'
     };
 
     saveMock.mockResolvedValue();
     const res = await request(app).post('/api/employees').send(newEmp);
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
-    expect(res.body).toMatchObject(newEmp);
+    expect(mockUser.create).toHaveBeenCalledWith({
+      username: 'jane',
+      password: 'secret',
+      role: 'employee',
+      employee: undefined,
+      department: 'HR'
+    });
+    expect(res.body).toMatchObject({
+      name: 'Jane',
+      email: 'jane@example.com',
+      department: 'HR',
+      title: 'Manager',
+      status: '在職',
+      role: 'employee'
+    });
   });
 
   it('fails on invalid email or role', async () => {


### PR DESCRIPTION
## Summary
- create employee along with corresponding user account
- test employee controller with user creation mock

## Testing
- `npm test --prefix server` *(fails: jest not found)*