### PR TITLE
新增主管欄位功能

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -95,6 +95,16 @@
                     <el-form-item label="子單位">
                       <el-input v-model="employeeForm.subunit" />
                     </el-form-item>
+                    <el-form-item label="主管">
+                      <el-select v-model="employeeForm.supervisor" placeholder="選擇主管">
+                        <el-option
+                          v-for="sup in supervisorList"
+                          :key="sup._id"
+                          :label="sup.name"
+                          :value="sup._id"
+                        />
+                      </el-select>
+                    </el-form-item>
                     <el-form-item label="職稱">
                       <el-input v-model="employeeForm.title" />
                     </el-form-item>
@@ -354,6 +364,7 @@ const token = localStorage.getItem('token') || ''
     // 部門相關
     institution: '',
     department: '',
+    supervisor: '',
     subunit: '',
     permissionGrade: '',
     // 職業別
@@ -406,6 +417,10 @@ const token = localStorage.getItem('token') || ''
           d => d.organization === employeeForm.value.institution
         )
       : []
+  )
+
+  const supervisorList = computed(() =>
+    employeeList.value.filter(e => e.role === 'supervisor')
   )
   
   function openEmployeeDialog(index = null) {

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -27,4 +27,15 @@ describe('EmployeeManagement.vue', () => {
     expect(wrapper.vm.filteredDepartments.length).toBe(1)
     expect(wrapper.vm.filteredDepartments[0]._id).toBe('d1')
   })
+
+  it('computes supervisor list', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.employeeList = [
+      { _id: 'e1', name: 'Emp', role: 'employee' },
+      { _id: 's1', name: 'Sup', role: 'supervisor' }
+    ]
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.supervisorList.length).toBe(1)
+    expect(wrapper.vm.supervisorList[0]._id).toBe('s1')
+  })
 })

--- a/client/tests/hrManagement.spec.js
+++ b/client/tests/hrManagement.spec.js
@@ -40,11 +40,12 @@ describe('HRManagementSystemSetting.vue', () => {
     fetch.mockClear()
     fetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
     const emp = wrapper.findComponent(EmployeeManagement)
-    emp.vm.employeeForm = { ...emp.vm.employeeForm, name: 'n', username: 'u', experiences: [{ unit: 'a' }] }
+    emp.vm.employeeForm = { ...emp.vm.employeeForm, name: 'n', username: 'u', supervisor: 's1', experiences: [{ unit: 'a' }] }
     emp.vm.editEmployeeIndex = null
     await emp.vm.saveEmployee()
     const body = JSON.parse(fetch.mock.calls[0][1].body)
     expect(body.experiences).toBeDefined()
+    expect(body.supervisor).toBe('s1')
     expect(fetch).toHaveBeenCalledWith('/api/employees', expect.objectContaining({ method: 'POST' }))
   })
 })

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -12,7 +12,7 @@ export async function listEmployees(req, res) {
 
 export async function createEmployee(req, res) {
   try {
-    const { name, email, role, department, title, status, username, password } = req.body;
+    const { name, email, role, department, title, status, username, password, supervisor } = req.body;
     if (!name) {
       return res.status(400).json({ error: 'Name is required' });
     }
@@ -35,9 +35,9 @@ export async function createEmployee(req, res) {
         return res.status(400).json({ error: 'Invalid role' });
       }
     }
-    const employee = new Employee({ name, email, role, department, title, status });
+    const employee = new Employee({ name, email, role, department, title, status, supervisor });
     await employee.save();
-    await User.create({ username, password, role, employee: employee._id, department });
+    await User.create({ username, password, role, employee: employee._id, department, supervisor });
     res.status(201).json(employee);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -60,7 +60,7 @@ export async function updateEmployee(req, res) {
     const employee = await Employee.findById(req.params.id);
     if (!employee) return res.status(404).json({ error: 'Not found' });
 
-    const { name, email, role, department, title, status } = req.body;
+    const { name, email, role, department, title, status, supervisor } = req.body;
     if (email !== undefined) {
       if (!email) {
         return res.status(400).json({ error: 'Email is required' });
@@ -82,8 +82,12 @@ export async function updateEmployee(req, res) {
     if (department !== undefined) employee.department = department;
     if (title !== undefined) employee.title = title;
     if (status !== undefined) employee.status = status;
+    if (supervisor !== undefined) employee.supervisor = supervisor;
 
     await employee.save();
+    if (supervisor !== undefined) {
+      await User.findOneAndUpdate({ employee: employee._id }, { supervisor });
+    }
     res.json(employee);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -10,7 +10,8 @@ const userSchema = new mongoose.Schema({
     default: 'employee'
   },
   employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
-  department: String
+  department: String,
+  supervisor: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' }
 }, { timestamps: true });
 
 userSchema.pre('save', async function(next) {

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -8,7 +8,7 @@ mockEmployee.find = jest.fn();
 mockEmployee.findById = jest.fn();
 mockEmployee.findByIdAndDelete = jest.fn();
 
-const mockUser = { create: jest.fn() };
+const mockUser = { create: jest.fn(), findOneAndUpdate: jest.fn() };
 
 jest.mock('../src/models/Employee.js', () => ({ default: mockEmployee }), { virtual: true });
 jest.mock('../src/models/User.js', () => ({ default: mockUser }), { virtual: true });
@@ -29,6 +29,7 @@ beforeEach(() => {
   mockEmployee.findById.mockReset();
   mockEmployee.findByIdAndDelete.mockReset();
   mockUser.create.mockReset();
+  mockUser.findOneAndUpdate.mockReset();
 });
 
 describe('Employee API', () => {
@@ -59,7 +60,8 @@ describe('Employee API', () => {
       status: '在職',
       username: 'jane',
       password: 'secret',
-      role: 'employee'
+      role: 'employee',
+      supervisor: 's1'
     };
 
     saveMock.mockResolvedValue();
@@ -71,7 +73,8 @@ describe('Employee API', () => {
       password: 'secret',
       role: 'employee',
       employee: undefined,
-      department: 'HR'
+      department: 'HR',
+      supervisor: 's1'
     });
     expect(res.body).toMatchObject({
       name: 'Jane',
@@ -79,7 +82,8 @@ describe('Employee API', () => {
       department: 'HR',
       title: 'Manager',
       status: '在職',
-      role: 'employee'
+      role: 'employee',
+      supervisor: 's1'
     });
   });
 
@@ -103,11 +107,12 @@ describe('Employee API', () => {
     saveMock.mockResolvedValue();
     const res = await request(app)
       .put('/api/employees/1')
-      .send({ name: 'Updated' });
+      .send({ name: 'Updated', supervisor: 's2' });
     expect(res.status).toBe(200);
     expect(mockEmployee.findById).toHaveBeenCalledWith('1');
     expect(saveMock).toHaveBeenCalled();
-    expect(res.body).toMatchObject({ _id: '1', name: 'Updated' });
+    expect(mockUser.findOneAndUpdate).toHaveBeenCalledWith({ employee: '1' }, { supervisor: 's2' });
+    expect(res.body).toMatchObject({ _id: '1', name: 'Updated', supervisor: 's2' });
 
   });
 


### PR DESCRIPTION
## Summary
- 後端 `Employee` 與 `User` 模型與 controller 支援 `supervisor` 欄位
- 前端 `EmployeeManagement` 新增主管選擇與相應的計算屬性
- 更新前後端測試以涵蓋新欄位

## Testing
- `npm test` *(失敗：jest 未安裝)*