### PR TITLE
Implement department label lookup

### DIFF
--- a/client/src/components/backComponents/AccountRoleSetting.vue
+++ b/client/src/components/backComponents/AccountRoleSetting.vue
@@ -6,7 +6,11 @@
       <el-table :data="userList" style="margin-top: 20px;">
         <el-table-column prop="username" label="帳號" width="150" />
         <el-table-column prop="role" label="角色" width="120" />
-        <el-table-column prop="department" label="所屬部門" width="120" />
+        <el-table-column label="所屬部門" width="120">
+          <template #default="{ row }">
+            {{ departmentLabel(row.department) }}
+          </template>
+        </el-table-column>
         <el-table-column label="操作" width="180">
           <template #default="{ row, $index }">
             <el-button type="primary" @click="openUserDialog($index)">編輯</el-button>
@@ -65,6 +69,11 @@ const userForm = ref({
   department: ''
 })
 const departmentList = ref([])
+
+function departmentLabel(id) {
+  const dept = departmentList.value.find(d => d._id === id)
+  return dept ? `${dept.name}(${dept.code})` : id
+}
 
 async function fetchUsers() {
   const token = localStorage.getItem('token') || ''

--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -5,7 +5,11 @@
             <el-button type="primary" @click="openEmployeeDialog()">新增員工</el-button>
             <el-table :data="employeeList" style="margin-top: 20px;">
               <el-table-column prop="name" label="員工姓名" width="120" />
-              <el-table-column prop="department" label="部門" width="100" />
+              <el-table-column label="部門" width="100">
+                <template #default="{ row }">
+                  {{ departmentLabel(row.department) }}
+                </template>
+              </el-table-column>
               <el-table-column prop="title" label="職稱" width="100" />
               <el-table-column prop="status" label="在職狀態" width="100" />
               <el-table-column label="操作" width="200">
@@ -300,6 +304,11 @@ const employeeDialogVisible = ref(false)
 let editEmployeeIndex = null
 let editEmployeeId = ''
 const token = localStorage.getItem('token') || ''
+
+function departmentLabel(id) {
+  const dept = departmentList.value.find(d => d._id === id)
+  return dept ? `${dept.name}(${dept.code})` : id
+}
 
   async function fetchDepartments() {
     const token = localStorage.getItem('token') || ''


### PR DESCRIPTION
## Summary
- show department names in EmployeeManagement table via slot
- show department names in AccountRoleSetting table via slot
- add reusable `departmentLabel()` helper in both components

## Testing
- `npm test` *(fails: jest not found)*