### PR TITLE
修正主管篩選邏輯並更新測試

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -428,7 +428,14 @@ function departmentLabel(id) {
   )
 
   const supervisorList = computed(() =>
-    employeeList.value.filter(e => e.role === 'supervisor')
+    employeeForm.value.institution && employeeForm.value.department
+      ? employeeList.value.filter(
+          e =>
+            e.role === 'supervisor' &&
+            e.institution === employeeForm.value.institution &&
+            e.department === employeeForm.value.department
+        )
+      : []
   )
   
   function openEmployeeDialog(index = null) {

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -28,11 +28,13 @@ describe('EmployeeManagement.vue', () => {
     expect(wrapper.vm.filteredDepartments[0]._id).toBe('d1')
   })
 
-  it('computes supervisor list', async () => {
+  it('filters supervisor list by selected institution and department', async () => {
     const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.employeeForm.institution = 'o1'
+    wrapper.vm.employeeForm.department = 'd1'
     wrapper.vm.employeeList = [
-      { _id: 'e1', name: 'Emp', role: 'employee' },
-      { _id: 's1', name: 'Sup', role: 'supervisor' }
+      { _id: 's1', name: 'SupA', role: 'supervisor', institution: 'o1', department: 'd1' },
+      { _id: 's2', name: 'SupB', role: 'supervisor', institution: 'o2', department: 'd2' }
     ]
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.supervisorList.length).toBe(1)


### PR DESCRIPTION
## 變更內容
- `EmployeeManagement.vue` 的 `supervisorList` 現在會依照表單選取的機構與部門過濾主管
- `employeeManagement.spec.js` 更新測試，驗證僅回傳符合條件的主管

## 測試結果
- `npm test` 在本環境因缺少相依套件導致失敗（`jest: not found`）