### PR TITLE
Add department fields to employee and user flows

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -78,7 +78,13 @@ async function seed() {
         title: 'Staff',
         status: '在職'
       });
-      await User.create({ ...data, employee: employee._id });
+      await User.create({
+        ...data,
+        organization: employee.organization,
+        department: employee.department,
+        subDepartment: employee.subDepartment,
+        employee: employee._id
+      });
       console.log(`Created user ${data.username}`);
     } else {
       console.log(`User ${data.username} already exists`);

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -12,7 +12,7 @@ export async function listEmployees(req, res) {
 
 export async function createEmployee(req, res) {
   try {
-    const { name, email, role, department, title, status, username, password, supervisor } = req.body;
+    const { name, email, role, organization, department, subDepartment, title, status, username, password, supervisor } = req.body;
     const sup = supervisor === '' ? undefined : supervisor;
     if (!name) {
       return res.status(400).json({ error: 'Name is required' });
@@ -36,9 +36,9 @@ export async function createEmployee(req, res) {
         return res.status(400).json({ error: 'Invalid role' });
       }
     }
-    const employee = new Employee({ name, email, role, department, title, status, supervisor: sup });
+    const employee = new Employee({ name, email, role, organization, department, subDepartment, title, status, supervisor: sup });
     await employee.save();
-    await User.create({ username, password, role, employee: employee._id, department, supervisor: sup });
+    await User.create({ username, password, role, organization, department, subDepartment, employee: employee._id, supervisor: sup });
     res.status(201).json(employee);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -61,7 +61,7 @@ export async function updateEmployee(req, res) {
     const employee = await Employee.findById(req.params.id);
     if (!employee) return res.status(404).json({ error: 'Not found' });
 
-    const { name, email, role, department, title, status, supervisor } = req.body;
+    const { name, email, role, organization, department, subDepartment, title, status, supervisor } = req.body;
     const sup = supervisor === '' ? undefined : supervisor;
     if (email !== undefined) {
       if (!email) {
@@ -81,14 +81,21 @@ export async function updateEmployee(req, res) {
     if (name !== undefined) employee.name = name;
     if (email !== undefined) employee.email = email;
     if (role !== undefined) employee.role = role;
+    if (organization !== undefined) employee.organization = organization;
     if (department !== undefined) employee.department = department;
+    if (subDepartment !== undefined) employee.subDepartment = subDepartment;
     if (title !== undefined) employee.title = title;
     if (status !== undefined) employee.status = status;
     if (sup !== undefined) employee.supervisor = sup;
 
     await employee.save();
-    if (sup !== undefined) {
-      await User.findOneAndUpdate({ employee: employee._id }, { supervisor: sup });
+    const updateObj = {};
+    if (sup !== undefined) updateObj.supervisor = sup;
+    if (organization !== undefined) updateObj.organization = organization;
+    if (department !== undefined) updateObj.department = department;
+    if (subDepartment !== undefined) updateObj.subDepartment = subDepartment;
+    if (Object.keys(updateObj).length > 0) {
+      await User.findOneAndUpdate({ employee: employee._id }, updateObj);
     }
     res.json(employee);
   } catch (err) {

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -11,8 +11,8 @@ export async function listUsers(req, res) {
 
 export async function createUser(req, res) {
   try {
-    const { username, password, role, department } = req.body;
-    const user = new User({ username, password, role, department });
+    const { username, password, role, organization, department, subDepartment } = req.body;
+    const user = new User({ username, password, role, organization, department, subDepartment });
     await user.save();
     const plain = user.toObject();
     delete plain.password;
@@ -29,7 +29,9 @@ export async function updateUser(req, res) {
     if (req.body.username !== undefined) user.username = req.body.username;
     if (req.body.password) user.password = req.body.password;
     if (req.body.role !== undefined) user.role = req.body.role;
+    if (req.body.organization !== undefined) user.organization = req.body.organization;
     if (req.body.department !== undefined) user.department = req.body.department;
+    if (req.body.subDepartment !== undefined) user.subDepartment = req.body.subDepartment;
     await user.save();
     const plain = user.toObject();
     delete plain.password;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -90,7 +90,13 @@ async function seedTestUsers() {
         title: 'Staff',
         status: '在職'
       });
-      await User.create({ ...data, employee: employee._id });
+      await User.create({
+        ...data,
+        organization: employee.organization,
+        department: employee.department,
+        subDepartment: employee.subDepartment,
+        employee: employee._id
+      });
       if (data.role === 'supervisor') supervisorId = employee._id;
       console.log(`Created test user ${data.username}`);
     }

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -10,7 +10,9 @@ const userSchema = new mongoose.Schema({
     default: 'employee'
   },
   employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
+  organization: String,
   department: String,
+  subDepartment: String,
   supervisor: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' }
 }, { timestamps: true });
 

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -55,7 +55,9 @@ describe('Employee API', () => {
     const newEmp = {
       name: 'Jane',
       email: 'jane@example.com',
+      organization: 'Org',
       department: 'HR',
+      subDepartment: 'Sub',
       title: 'Manager',
       status: '在職',
       username: 'jane',
@@ -72,14 +74,18 @@ describe('Employee API', () => {
       username: 'jane',
       password: 'secret',
       role: 'employee',
-      employee: undefined,
+      organization: 'Org',
       department: 'HR',
+      subDepartment: 'Sub',
+      employee: undefined,
       supervisor: 's1'
     });
     expect(res.body).toMatchObject({
       name: 'Jane',
       email: 'jane@example.com',
+      organization: 'Org',
       department: 'HR',
+      subDepartment: 'Sub',
       title: 'Manager',
       status: '在職',
       role: 'employee',


### PR DESCRIPTION
## Summary
- save `organization` and `subDepartment` when creating and updating employees
- persist these new department fields to `User` records
- include the extra fields when creating default users
- adapt employee tests for added data

## Testing
- `npm test` *(fails: jest not found)*