### PR TITLE
Refactor employee org fields

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -76,7 +76,7 @@
                 <el-tab-pane label="任職資訊" name="employment">
                   <el-form :model="employeeForm" label-width="100px">
                     <el-form-item label="機構">
-                      <el-select v-model="employeeForm.institution">
+                      <el-select v-model="employeeForm.organization">
                         <el-option
                           v-for="org in orgList"
                           :key="org._id"
@@ -96,7 +96,7 @@
                       </el-select>
                     </el-form-item>
                     <el-form-item label="子單位">
-                      <el-input v-model="employeeForm.subunit" />
+                      <el-input v-model="employeeForm.subDepartment" />
                     </el-form-item>
                     <el-form-item label="主管">
                       <el-select v-model="employeeForm.supervisor" placeholder="選擇主管">
@@ -370,10 +370,10 @@ function departmentLabel(id) {
     lineId: '',
     photoList: [],
     // 部門相關
-    institution: '',
+    organization: '',
     department: '',
     supervisor: null,
-    subunit: '',
+    subDepartment: '',
     permissionGrade: '',
     // 職業別
     title: '',
@@ -420,19 +420,19 @@ function departmentLabel(id) {
   const employeeForm = ref({ ...emptyEmployee })
 
   const filteredDepartments = computed(() =>
-    employeeForm.value.institution
+    employeeForm.value.organization
       ? departmentList.value.filter(
-          d => d.organization === employeeForm.value.institution
+          d => d.organization === employeeForm.value.organization
         )
       : []
   )
 
   const supervisorList = computed(() =>
-    employeeForm.value.institution && employeeForm.value.department
+    employeeForm.value.organization && employeeForm.value.department
       ? employeeList.value.filter(
           e =>
             e.role === 'supervisor' &&
-            e.institution === employeeForm.value.institution &&
+            e.organization === employeeForm.value.organization &&
             e.department === employeeForm.value.department
         )
       : []

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -22,19 +22,19 @@ describe('EmployeeManagement.vue', () => {
       { _id: 'd1', name: 'D1', organization: 'o1' },
       { _id: 'd2', name: 'D2', organization: 'o2' }
     ]
-    wrapper.vm.employeeForm.institution = 'o1'
+    wrapper.vm.employeeForm.organization = 'o1'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.filteredDepartments.length).toBe(1)
     expect(wrapper.vm.filteredDepartments[0]._id).toBe('d1')
   })
 
-  it('filters supervisor list by selected institution and department', async () => {
+  it('filters supervisor list by selected organization and department', async () => {
     const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
-    wrapper.vm.employeeForm.institution = 'o1'
+    wrapper.vm.employeeForm.organization = 'o1'
     wrapper.vm.employeeForm.department = 'd1'
     wrapper.vm.employeeList = [
-      { _id: 's1', name: 'SupA', role: 'supervisor', institution: 'o1', department: 'd1' },
-      { _id: 's2', name: 'SupB', role: 'supervisor', institution: 'o2', department: 'd2' }
+      { _id: 's1', name: 'SupA', role: 'supervisor', organization: 'o1', department: 'd1' },
+      { _id: 's2', name: 'SupB', role: 'supervisor', organization: 'o2', department: 'd2' }
     ]
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.supervisorList.length).toBe(1)


### PR DESCRIPTION
## Summary
- update field names in EmployeeManagement from `institution`/`subunit` to `organization`/`subDepartment`
- adjust computed properties and v-model bindings
- update tests accordingly

## Testing
- `npm test` *(fails: jest not found)*