### PR TITLE
Update tests for organization field

### DIFF
--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -22,19 +22,19 @@ describe('EmployeeManagement.vue', () => {
       { _id: 'd1', name: 'D1', organization: 'o1' },
       { _id: 'd2', name: 'D2', organization: 'o2' }
     ]
-    wrapper.vm.employeeForm.institution = 'o1'
+    wrapper.vm.employeeForm.organization = 'o1'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.filteredDepartments.length).toBe(1)
     expect(wrapper.vm.filteredDepartments[0]._id).toBe('d1')
   })
 
-  it('filters supervisor list by selected institution and department', async () => {
+  it('filters supervisor list by selected organization and department', async () => {
     const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
-    wrapper.vm.employeeForm.institution = 'o1'
+    wrapper.vm.employeeForm.organization = 'o1'
     wrapper.vm.employeeForm.department = 'd1'
     wrapper.vm.employeeList = [
-      { _id: 's1', name: 'SupA', role: 'supervisor', institution: 'o1', department: 'd1' },
-      { _id: 's2', name: 'SupB', role: 'supervisor', institution: 'o2', department: 'd2' }
+      { _id: 's1', name: 'SupA', role: 'supervisor', organization: 'o1', department: 'd1' },
+      { _id: 's2', name: 'SupB', role: 'supervisor', organization: 'o2', department: 'd2' }
     ]
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.supervisorList.length).toBe(1)


### PR DESCRIPTION
## Summary
- 修正 `employeeManagement.spec.js`，將 `employeeForm` 的 `institution` 欄位更名為 `organization`
- 更新模擬員工資料中的欄位名稱
- 測試描述同步調整，確保仍檢驗 `filteredDepartments` 與 `supervisorList`

## Testing
- `npm test` *(失敗：jest: not found)*