### PR TITLE
Add supervisor schedule support

### DIFF
--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -1,16 +1,24 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+import dayjs from 'dayjs'
 import Schedule from '../src/views/front/Schedule.vue'
 
-vi.mock('../src/api', () => ({
-  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
-}))
+vi.mock('../src/api', () => {
+  const apiFetch = vi.fn()
+  apiFetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ([{ _id: 'e1', name: 'E1' }]) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ([] ) })
+  return { apiFetch }
+})
 vi.mock('../src/utils/tokenService', () => ({ getToken: () => 'tok' }))
 
 describe('Schedule.vue', () => {
-  it('fetches schedule on mount', () => {
+  it('fetches employees and schedules on mount', () => {
     const { apiFetch } = require('../src/api')
+    localStorage.setItem('employeeId', 's1')
     mount(Schedule)
-    expect(apiFetch).toHaveBeenCalled()
+    const month = dayjs().format('YYYY-MM')
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/employees?supervisor=s1', expect.any(Object))
+    expect(apiFetch).toHaveBeenNthCalledWith(2, `/api/schedules/monthly?month=${month}&supervisor=s1`, expect.any(Object))
   })
 })


### PR DESCRIPTION
## Summary
- show schedules for supervisor's employees
- adjust schedule map to nested by employee and day
- update fetch logic to load employees and schedules in one go
- adapt schedule tests to expect employee and schedule requests

## Testing
- `npm test --prefix client` *(fails: vitest not found)*