### PR TITLE
Add supervisor filter for employee listing

### DIFF
--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -59,7 +59,7 @@ function logout() {
   clearToken()
   localStorage.removeItem('role')
   localStorage.removeItem('employeeId')
-  router.push({ name: 'Login' })
+  router.push('/')
 }
 </script>
 

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -17,7 +17,7 @@ const logout = () => {
   clearToken()
   localStorage.removeItem('role')
   localStorage.removeItem('employeeId')
-  router.push({ name: 'Login' })
+  router.push('/')
 }
   </script>
   

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -3,7 +3,10 @@ import User from '../models/User.js';
 
 export async function listEmployees(req, res) {
   try {
-    const employees = await Employee.find();
+    const filter = req.query.supervisor
+      ? { supervisor: req.query.supervisor }
+      : {};
+    const employees = await Employee.find(filter);
     res.json(employees);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -43,6 +43,15 @@ describe('Employee API', () => {
     expect(res.body).toEqual(fakeEmployees);
   });
 
+  it('lists employees filtered by supervisor', async () => {
+    const fakeEmployees = [{ name: 'Bob' }];
+    mockEmployee.find.mockResolvedValue(fakeEmployees);
+    const res = await request(app).get('/api/employees?supervisor=s1');
+    expect(res.status).toBe(200);
+    expect(mockEmployee.find).toHaveBeenCalledWith({ supervisor: 's1' });
+    expect(res.body).toEqual(fakeEmployees);
+  });
+
   it('returns 500 if listing fails', async () => {
     mockEmployee.find.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/employees');


### PR DESCRIPTION
## Summary
- support `?supervisor=` query when listing employees
- test listing employees by supervisor
- redirect admin logout to root

## Testing
- `npm --prefix server test` *(fails: jest not found)*