### PR TITLE
Fix Heroku build by installing client dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "start": "npm --prefix server start",
-    "install": "npm --prefix server install && npm --prefix client install",
+    "install": "npm --prefix server install && npm --prefix client install --include=dev",
     "test": "npm --prefix server test && npm --prefix client test",
     "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\"",
     "heroku-postbuild": "npm run build --prefix client"


### PR DESCRIPTION
## Summary
- ensure client devDependencies (like Vite) are installed when deploying

## Testing
- `npm test` *(fails: jest not found)*