### PR TITLE
Fix Heroku build by pinning Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "scripts": {
     "start": "npm --prefix server start",
-    "install": "npm --prefix server install && npm --prefix client install",
+    "install": "npm --prefix server install && npm --prefix client install --include=dev",
     "test": "npm --prefix server test && npm --prefix client test",
     "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\"",
     "heroku-postbuild": "npm run build --prefix client"
-
+  },
+  "engines": {
+    "node": "20.x"
   },
   "devDependencies": {
     "concurrently": "^8.0.1"


### PR DESCRIPTION
## Summary
- specify Node 20.x in `package.json` so Heroku uses a compatible Node version

## Testing
- `npm test` *(fails: jest not found)*