### PR TITLE
Fix shift options in schedule view

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -41,7 +41,7 @@ import { getToken } from '../../utils/tokenService'
 
 const currentMonth = ref(dayjs().format('YYYY-MM'))
 const scheduleMap = ref({})
-const shiftOptions = ['早班', '中班', '晚班']
+const shiftOptions = ref([])
 const employees = ref([])
 
 const canEdit = computed(() => {
@@ -54,6 +54,19 @@ const days = computed(() => {
   const end = dt.endOf('month').date()
   return Array.from({ length: end }, (_, i) => i + 1)
 })
+
+async function fetchShiftOptions() {
+  const token = getToken() || ''
+  const res = await apiFetch('/api/attendance-settings', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (res.ok) {
+    const data = await res.json()
+    if (Array.isArray(data.shifts)) {
+      shiftOptions.value = data.shifts.map(s => s.name)
+    }
+  }
+}
 
 async function fetchSchedules() {
   const token = getToken() || ''
@@ -115,6 +128,7 @@ async function fetchEmployees() {
 }
 
 onMounted(async () => {
+  await fetchShiftOptions()
   await fetchEmployees()
   await fetchSchedules()
 })

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -7,6 +7,7 @@ vi.mock('../src/api', () => {
   const apiFetch = vi.fn()
   apiFetch
     .mockResolvedValueOnce({ ok: true, json: async () => ([{ _id: 'e1', name: 'E1' }]) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ shifts: [{ name: '早班' }] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ([] ) })
   return { apiFetch }
 })
@@ -18,7 +19,8 @@ describe('Schedule.vue', () => {
     localStorage.setItem('employeeId', 's1')
     mount(Schedule)
     const month = dayjs().format('YYYY-MM')
-    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/employees?supervisor=s1', expect.any(Object))
-    expect(apiFetch).toHaveBeenNthCalledWith(2, `/api/schedules/monthly?month=${month}&supervisor=s1`, expect.any(Object))
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/attendance-settings', expect.any(Object))
+    expect(apiFetch).toHaveBeenNthCalledWith(2, '/api/employees?supervisor=s1', expect.any(Object))
+    expect(apiFetch).toHaveBeenNthCalledWith(3, `/api/schedules/monthly?month=${month}&supervisor=s1`, expect.any(Object))
   })
 })


### PR DESCRIPTION
## Summary
- load shift dropdown options from backend attendance settings
- adjust schedule tests for the new API call order

## Testing
- `npm test` *(fails: jest not found)*