### PR TITLE
feat: add attendance shift API

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -62,8 +62,8 @@ async function fetchShiftOptions() {
   })
   if (res.ok) {
     const data = await res.json()
-    if (Array.isArray(data.shifts)) {
-      shiftOptions.value = data.shifts.map(s => s.name)
+    if (Array.isArray(data)) {
+      shiftOptions.value = data.map(s => s.name)
     }
   }
 }

--- a/server/src/controllers/attendanceShiftController.js
+++ b/server/src/controllers/attendanceShiftController.js
@@ -1,0 +1,10 @@
+import AttendanceSetting from '../models/AttendanceSetting.js';
+
+export async function getAttendanceSettings(req, res) {
+  try {
+    const setting = await AttendanceSetting.findOne();
+    res.json(setting?.shifts || []);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -27,7 +27,7 @@ import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
-import attendanceSettingRoutes from './routes/attendanceSettingRoutes.js';
+import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
 
 async function seedSampleData() {
   let org = await Organization.findOne({ name: '示範機構' });
@@ -146,7 +146,17 @@ app.use(
   employeeRoutes
 );
 app.use('/api/attendance', authenticate, authorizeRoles('employee', 'supervisor', 'admin'), attendanceRoutes);
-app.use('/api/attendance-settings', authenticate, authorizeRoles('admin'), attendanceSettingRoutes);
+app.use(
+  '/api/attendance-settings',
+  authenticate,
+  (req, res, next) => {
+    if (req.method === 'GET') {
+      return authorizeRoles('supervisor', 'admin')(req, res, next);
+    }
+    return authorizeRoles('admin')(req, res, next);
+  },
+  attendanceShiftRoutes
+);
 
 
 app.use('/api/leaves', authenticate, authorizeRoles('employee', 'supervisor', 'admin'), leaveRoutes);

--- a/server/src/routes/attendanceShiftRoutes.js
+++ b/server/src/routes/attendanceShiftRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getAttendanceSettings } from '../controllers/attendanceShiftController.js';
+
+const router = Router();
+
+router.get('/', getAttendanceSettings);
+
+export default router;


### PR DESCRIPTION
## Summary
- expose attendance shift options via new endpoint
- allow supervisors to view attendance settings
- adjust frontend schedule parsing for shift API

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1a6a098832993e66c25b0b01629