### PR TITLE
在排班設定載入時處理權限錯誤

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -65,6 +65,12 @@ async function fetchShiftOptions() {
     if (Array.isArray(data)) {
       shiftOptions.value = data.map(s => s.name)
     }
+  } else {
+    if (res.status === 403) {
+      alert('缺少權限，請重新登入或聯絡管理員')
+    } else {
+      console.error('取得班表設定失敗', res.status)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- 在 `fetchShiftOptions` 增加 `else` 區塊以處理非 200 回應
- 若回應 403，提示使用者缺少權限並要求重新登入或聯絡管理員

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b4f525388329a7c800df2d49b80e