### PR TITLE
refactor schedule role retrieval via pinia store

### DIFF
--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -1,0 +1,23 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { getToken } from '../utils/tokenService'
+
+export const useAuthStore = defineStore('auth', () => {
+  const role = ref('employee')
+
+  function loadUser() {
+    const token = getToken()
+    if (token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]))
+        role.value = payload.role || 'employee'
+      } catch (e) {
+        role.value = 'employee'
+      }
+    } else {
+      role.value = 'employee'
+    }
+  }
+
+  return { role, loadUser }
+})

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -38,15 +38,18 @@ import { ref, computed, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
 import { getToken } from '../../utils/tokenService'
+import { useAuthStore } from '../../stores/auth'
 
 const currentMonth = ref(dayjs().format('YYYY-MM'))
 const scheduleMap = ref({})
 const shiftOptions = ref([])
 const employees = ref([])
 
+const authStore = useAuthStore()
+authStore.loadUser()
+
 const canEdit = computed(() => {
-  const role = localStorage.getItem('role') || 'employee'
-  return ['supervisor', 'admin'].includes(role)
+  return ['supervisor', 'admin'].includes(authStore.role)
 })
 
 const days = computed(() => {


### PR DESCRIPTION
## Summary
- add auth pinia store decoding token for user role
- use auth store in Schedule view instead of localStorage

## Testing
- `npm test` (fails: ReferenceError: require is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a0b4f146c0832992d2f852dec1ce99