### PR TITLE
fix: prevent duplicate schedules

### DIFF
--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -49,8 +49,12 @@ export async function listSchedules(req, res) {
 
 export async function createSchedule(req, res) {
   try {
-    const schedule = new ShiftSchedule(req.body);
-    await schedule.save();
+    const { employee, date, shiftType } = req.body;
+    const schedule = await ShiftSchedule.findOneAndUpdate(
+      { employee, date },
+      { shiftType },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
     res.status(201).json(schedule);
   } catch (err) {
     res.status(400).json({ error: err.message });


### PR DESCRIPTION
## Summary
- upsert schedules by employee and date
- test duplicate schedule updates existing entry

## Testing
- `npm test` *(fails: ReferenceError require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b98909508329945decdf5904f225