### PR TITLE
feat: 新增班別 CRUD API 路由

### DIFF
--- a/server/src/controllers/shiftController.js
+++ b/server/src/controllers/shiftController.js
@@ -1,0 +1,55 @@
+import AttendanceSetting from '../models/AttendanceSetting.js';
+
+export async function getShifts(req, res) {
+  try {
+    const setting = await AttendanceSetting.findOne();
+    res.json(setting?.shifts || []);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createShift(req, res) {
+  try {
+    let setting = await AttendanceSetting.findOne();
+    if (!setting) {
+      setting = await AttendanceSetting.create({ shifts: [] });
+    }
+    setting.shifts.push(req.body);
+    await setting.save();
+    const newShift = setting.shifts[setting.shifts.length - 1];
+    res.status(201).json(newShift);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function updateShift(req, res) {
+  try {
+    const { id } = req.params;
+    const setting = await AttendanceSetting.findOne();
+    if (!setting) return res.status(404).json({ error: 'Attendance setting not found' });
+    const shift = setting.shifts.id(id);
+    if (!shift) return res.status(404).json({ error: 'Shift not found' });
+    Object.assign(shift, req.body);
+    await setting.save();
+    res.json(shift);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function deleteShift(req, res) {
+  try {
+    const { id } = req.params;
+    const setting = await AttendanceSetting.findOne();
+    if (!setting) return res.status(404).json({ error: 'Attendance setting not found' });
+    const shift = setting.shifts.id(id);
+    if (!shift) return res.status(404).json({ error: 'Shift not found' });
+    shift.deleteOne();
+    await setting.save();
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -28,6 +28,7 @@ import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
 import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
+import shiftRoutes from './routes/shiftRoutes.js';
 
 async function seedSampleData() {
   let org = await Organization.findOne({ name: '示範機構' });
@@ -156,6 +157,18 @@ app.use(
     return authorizeRoles('admin')(req, res, next);
   },
   attendanceShiftRoutes
+);
+
+app.use(
+  '/api/shifts',
+  authenticate,
+  (req, res, next) => {
+    if (req.method === 'GET') {
+      return authorizeRoles('supervisor', 'admin')(req, res, next);
+    }
+    return authorizeRoles('admin')(req, res, next);
+  },
+  shiftRoutes
 );
 
 

--- a/server/src/models/AttendanceSetting.js
+++ b/server/src/models/AttendanceSetting.js
@@ -6,7 +6,9 @@ const attendanceSettingSchema = new mongoose.Schema({
       name: String,
       startTime: String,
       endTime: String,
-      breakTime: String
+      breakTime: String,
+      crossDay: Boolean,
+      remark: String
     }
   ],
   abnormalRules: {

--- a/server/src/routes/shiftRoutes.js
+++ b/server/src/routes/shiftRoutes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { getShifts, createShift, updateShift, deleteShift } from '../controllers/shiftController.js';
+
+const router = Router();
+
+router.get('/', getShifts);
+router.post('/', createShift);
+router.put('/:id', updateShift);
+router.delete('/:id', deleteShift);
+
+export default router;


### PR DESCRIPTION
## Summary
- 擴充 AttendanceSetting 模型支援 crossDay 與 remark 欄位
- 新增 shiftController 與 shiftRoutes 實作班別 CRUD API
- 在 index.js 註冊 /api/shifts 路由

## Testing
- `npm test` （測試失敗：ReferenceError: require is not defined）

------
https://chatgpt.com/codex/tasks/task_e_68a0c365d5d88329890f60e4e192aa51