### PR TITLE
feat: add department schedule routes

### DIFF
--- a/server/src/controllers/deptScheduleController.js
+++ b/server/src/controllers/deptScheduleController.js
@@ -1,0 +1,49 @@
+import DeptSchedule from '../models/DeptSchedule.js';
+
+export async function listDeptSchedules(req, res) {
+  try {
+    const schedules = await DeptSchedule.find().populate('department');
+    res.json(schedules);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createDeptSchedule(req, res) {
+  try {
+    const schedule = await DeptSchedule.create(req.body);
+    res.status(201).json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getDeptSchedule(req, res) {
+  try {
+    const schedule = await DeptSchedule.findById(req.params.id).populate('department');
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateDeptSchedule(req, res) {
+  try {
+    const schedule = await DeptSchedule.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json(schedule);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteDeptSchedule(req, res) {
+  try {
+    const schedule = await DeptSchedule.findByIdAndDelete(req.params.id);
+    if (!schedule) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -25,6 +25,7 @@ import departmentRoutes from './routes/departmentRoutes.js';
 import organizationRoutes from './routes/organizationRoutes.js';
 import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 import holidayRoutes from './routes/holidayRoutes.js';
+import deptScheduleRoutes from './routes/deptScheduleRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
@@ -184,6 +185,7 @@ app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
 app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);
 app.use('/api/organizations', authenticate, authorizeRoles('admin'), organizationRoutes);
 app.use('/api/sub-departments', authenticate, authorizeRoles('admin'), subDepartmentRoutes);
+app.use('/api/dept-schedules', authenticate, authorizeRoles('admin'), deptScheduleRoutes);
 
 app.use('/api/holidays', authenticate, authorizeRoles('admin'), holidayRoutes);
 

--- a/server/src/models/DeptSchedule.js
+++ b/server/src/models/DeptSchedule.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const deptScheduleSchema = new mongoose.Schema(
+  {
+    department: { type: mongoose.Schema.Types.ObjectId, ref: 'Department', required: true },
+    rules: [
+      {
+        dayOfWeek: Number,
+        shiftType: String
+      }
+    ]
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('DeptSchedule', deptScheduleSchema);

--- a/server/src/routes/deptScheduleRoutes.js
+++ b/server/src/routes/deptScheduleRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listDeptSchedules,
+  createDeptSchedule,
+  getDeptSchedule,
+  updateDeptSchedule,
+  deleteDeptSchedule
+} from '../controllers/deptScheduleController.js';
+
+const router = Router();
+
+router.get('/', listDeptSchedules);
+router.post('/', createDeptSchedule);
+router.get('/:id', getDeptSchedule);
+router.put('/:id', updateDeptSchedule);
+router.delete('/:id', deleteDeptSchedule);
+
+export default router;


### PR DESCRIPTION
## Summary
- add DeptSchedule model and CRUD controller for managing department schedule rules
- expose dept schedule routes supporting list, create, update, and delete operations
- register `/api/dept-schedules` with admin-only access in server startup

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c96fdf2c8329954425a84675a454