### PR TITLE
feat: add break and holiday move settings

### DIFF
--- a/client/src/components/backComponents/ShiftScheduleSetting.vue
+++ b/client/src/components/backComponents/ShiftScheduleSetting.vue
@@ -337,9 +337,20 @@
     allowMultiBreak: false
   })
   
-  function saveBreakSetting() {
-    console.log('儲存中場休息設定', breakSettingForm.value)
-    alert('已儲存「中場休息」設定')
+  async function saveBreakSetting() {
+    const method = breakSettingForm.value._id ? 'PUT' : 'POST'
+    let url = '/api/break-settings'
+    if (method === 'PUT') {
+      url += `/${breakSettingForm.value._id}`
+    }
+    const res = await apiFetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(breakSettingForm.value)
+    })
+    if (res.ok) {
+      alert('已儲存「中場休息」設定')
+    }
   }
   
   // =========== 5) 員工個人國定假日挪移設定 ===========
@@ -349,9 +360,20 @@
     needMakeup: false
   })
   
-  function saveHolidayMove() {
-    console.log('儲存國定假日挪移規則', holidayMoveForm.value)
-    alert('已儲存「國定假日挪移」設定')
+  async function saveHolidayMove() {
+    const method = holidayMoveForm.value._id ? 'PUT' : 'POST'
+    let url = '/api/holiday-move-settings'
+    if (method === 'PUT') {
+      url += `/${holidayMoveForm.value._id}`
+    }
+    const res = await apiFetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(holidayMoveForm.value)
+    })
+    if (res.ok) {
+      alert('已儲存「國定假日挪移」設定')
+    }
   }
   </script>
   

--- a/server/src/controllers/breakSettingController.js
+++ b/server/src/controllers/breakSettingController.js
@@ -1,0 +1,52 @@
+import BreakSetting from '../models/BreakSetting.js';
+
+export async function listSettings(req, res) {
+  try {
+    const settings = await BreakSetting.find();
+    res.json(settings);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createSetting(req, res) {
+  try {
+    const setting = new BreakSetting(req.body);
+    await setting.save();
+    res.status(201).json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getSetting(req, res) {
+  try {
+    const setting = await BreakSetting.findById(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateSetting(req, res) {
+  try {
+    const setting = await BreakSetting.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteSetting(req, res) {
+  try {
+    const setting = await BreakSetting.findByIdAndDelete(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/controllers/holidayMoveSettingController.js
+++ b/server/src/controllers/holidayMoveSettingController.js
@@ -1,0 +1,52 @@
+import HolidayMoveSetting from '../models/HolidayMoveSetting.js';
+
+export async function listSettings(req, res) {
+  try {
+    const settings = await HolidayMoveSetting.find();
+    res.json(settings);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function createSetting(req, res) {
+  try {
+    const setting = new HolidayMoveSetting(req.body);
+    await setting.save();
+    res.status(201).json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getSetting(req, res) {
+  try {
+    const setting = await HolidayMoveSetting.findById(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function updateSetting(req, res) {
+  try {
+    const setting = await HolidayMoveSetting.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function deleteSetting(req, res) {
+  try {
+    const setting = await HolidayMoveSetting.findByIdAndDelete(req.params.id);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -28,6 +28,8 @@ import holidayRoutes from './routes/holidayRoutes.js';
 import deptScheduleRoutes from './routes/deptScheduleRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
+import breakSettingRoutes from './routes/breakSettingRoutes.js';
+import holidayMoveSettingRoutes from './routes/holidayMoveSettingRoutes.js';
 
 import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
 import shiftRoutes from './routes/shiftRoutes.js';
@@ -190,6 +192,8 @@ app.use('/api/dept-schedules', authenticate, authorizeRoles('admin'), deptSchedu
 app.use('/api/holidays', authenticate, authorizeRoles('admin'), holidayRoutes);
 
 app.use('/api/salary-settings', authenticate, authorizeRoles('admin'), salarySettingRoutes);
+app.use('/api/break-settings', authenticate, authorizeRoles('admin'), breakSettingRoutes);
+app.use('/api/holiday-move-settings', authenticate, authorizeRoles('admin'), holidayMoveSettingRoutes);
 
 
 app.get('*', (req, res, next) => {

--- a/server/src/models/BreakSetting.js
+++ b/server/src/models/BreakSetting.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const breakSettingSchema = new mongoose.Schema(
+  {
+    enableGlobalBreak: { type: Boolean, default: false },
+    breakMinutes: { type: Number, default: 60 },
+    allowMultiBreak: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('BreakSetting', breakSettingSchema);

--- a/server/src/models/HolidayMoveSetting.js
+++ b/server/src/models/HolidayMoveSetting.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const holidayMoveSettingSchema = new mongoose.Schema(
+  {
+    enableHolidayMove: { type: Boolean, default: false },
+    needSignature: { type: Boolean, default: false },
+    needMakeup: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('HolidayMoveSetting', holidayMoveSettingSchema);

--- a/server/src/routes/breakSettingRoutes.js
+++ b/server/src/routes/breakSettingRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listSettings,
+  createSetting,
+  getSetting,
+  updateSetting,
+  deleteSetting
+} from '../controllers/breakSettingController.js';
+
+const router = Router();
+
+router.get('/', listSettings);
+router.post('/', createSetting);
+router.get('/:id', getSetting);
+router.put('/:id', updateSetting);
+router.delete('/:id', deleteSetting);
+
+export default router;

--- a/server/src/routes/holidayMoveSettingRoutes.js
+++ b/server/src/routes/holidayMoveSettingRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listSettings,
+  createSetting,
+  getSetting,
+  updateSetting,
+  deleteSetting
+} from '../controllers/holidayMoveSettingController.js';
+
+const router = Router();
+
+router.get('/', listSettings);
+router.post('/', createSetting);
+router.get('/:id', getSetting);
+router.put('/:id', updateSetting);
+router.delete('/:id', deleteSetting);
+
+export default router;


### PR DESCRIPTION
## Summary
- add BreakSetting and HolidayMoveSetting schemas with CRUD controllers
- expose /api/break-settings and /api/holiday-move-settings routes
- submit break/holiday move forms via apiFetch on front end

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb2d460c83299c39cf936d5d85f3