### PR TITLE
feat: 新增部門管理者 API

### DIFF
--- a/server/src/controllers/deptManagerController.js
+++ b/server/src/controllers/deptManagerController.js
@@ -1,0 +1,13 @@
+import Employee from '../models/Employee.js';
+
+export async function listDeptManagers(req, res) {
+  try {
+    // 找出具有主管或管理員角色的員工
+    const managers = await Employee.find({ role: { $in: ['supervisor', 'admin'] } }).select('name');
+    // 轉換為前端需要的 { label, value } 格式
+    const result = managers.map(mgr => ({ label: mgr.name, value: mgr._id }));
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -30,6 +30,7 @@ import salarySettingRoutes from './routes/salarySettingRoutes.js';
 
 import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
 import shiftRoutes from './routes/shiftRoutes.js';
+import deptManagerRoutes from './routes/deptManagerRoutes.js';
 
 async function seedSampleData() {
   let org = await Organization.findOne({ name: '示範機構' });
@@ -184,6 +185,8 @@ app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
 app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);
 app.use('/api/organizations', authenticate, authorizeRoles('admin'), organizationRoutes);
 app.use('/api/sub-departments', authenticate, authorizeRoles('admin'), subDepartmentRoutes);
+
+app.use('/api/dept-managers', authenticate, authorizeRoles('admin'), deptManagerRoutes);
 
 app.use('/api/holidays', authenticate, authorizeRoles('admin'), holidayRoutes);
 

--- a/server/src/routes/deptManagerRoutes.js
+++ b/server/src/routes/deptManagerRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listDeptManagers } from '../controllers/deptManagerController.js';
+
+const router = Router();
+
+// 取得部門管理者列表
+router.get('/', listDeptManagers);
+
+export default router;


### PR DESCRIPTION
## Summary
- 新增 `deptManagerController` 與 `deptManagerRoutes`
- 提供 `GET /api/dept-managers` 以取得部門管理者清單
- 於 `index.js` 匯入並註冊新路由

## Testing
- `npm test` *(失敗：Missing semicolon 等語法錯誤)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c80277c883299e876527bf6b2f9a