### PR TITLE
refactor: centralize auth header

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,6 +1,13 @@
+import { getToken } from './utils/tokenService'
+
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
 
 export function apiFetch(path, options = {}) {
-  return fetch(`${API_BASE_URL}${path}`, options)
+  const token = getToken()
+  const headers = {
+    ...(options.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {})
+  }
+  return fetch(`${API_BASE_URL}${path}`, { ...options, headers })
 }

--- a/client/src/components/backComponents/AccountRoleSetting.vue
+++ b/client/src/components/backComponents/AccountRoleSetting.vue
@@ -76,20 +76,14 @@ function departmentLabel(id) {
 }
 
 async function fetchUsers() {
-  const token = localStorage.getItem('token') || ''
-  const res = await apiFetch('/api/users', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/users')
   if (res.ok) {
     userList.value = await res.json()
   }
 }
 
 async function fetchDepartments() {
-  const token = localStorage.getItem('token') || ''
-  const res = await apiFetch('/api/departments', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/departments')
   if (res.ok) {
     departmentList.value = await res.json()
   }
@@ -108,19 +102,18 @@ function openUserDialog(index = null) {
 
 async function saveUser() {
   const payload = { ...userForm.value }
-  const token = localStorage.getItem('token') || ''
   let res
   if (editUserIndex === null) {
     res = await apiFetch('/api/users', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     })
   } else {
     const id = userList.value[editUserIndex]._id
     res = await apiFetch(`/api/users/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     })
   }
@@ -131,11 +124,9 @@ async function saveUser() {
 }
 
 function deleteUser(index) {
-  const token = localStorage.getItem('token') || ''
   const id = userList.value[index]._id
   apiFetch(`/api/users/${id}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` }
+    method: 'DELETE'
   }).then(res => {
     if (res.ok) {
       userList.value.splice(index, 1)

--- a/client/src/components/backComponents/AttendanceManagementSetting.vue
+++ b/client/src/components/backComponents/AttendanceManagementSetting.vue
@@ -103,12 +103,9 @@ import { apiFetch } from '../../api'
   })
 
   const settingId = ref('')
-  const token = localStorage.getItem('token') || ''
 
   async function fetchSetting() {
-    const res = await apiFetch('/api/attendance-settings', {
-      headers: { Authorization: `Bearer ${token}` }
-    })
+    const res = await apiFetch('/api/attendance-settings')
     if (res.ok) {
       const data = await res.json()
       if (data.length) {
@@ -124,13 +121,13 @@ import { apiFetch } from '../../api'
     if (settingId.value) {
       res = await apiFetch(`/api/attendance-settings/${settingId.value}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
     } else {
       res = await apiFetch('/api/attendance-settings', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
     }

--- a/client/src/components/backComponents/AttendanceSetting.vue
+++ b/client/src/components/backComponents/AttendanceSetting.vue
@@ -126,12 +126,9 @@
   import { ref, onMounted } from 'vue'
   import { apiFetch } from '../../api'
 
-  const token = localStorage.getItem('token') || ''
 
 async function loadSettings() {
-  const res = await apiFetch('/api/attendance-settings', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/attendance-settings')
   if (res.ok) {
     const data = await res.json()
     if (data.abnormalRules) abnormalForm.value = { ...abnormalForm.value, ...data.abnormalRules }
@@ -141,9 +138,7 @@ async function loadSettings() {
 }
 
 async function loadShifts() {
-  const res = await apiFetch('/api/shifts', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/shifts')
   if (res.ok) {
     shiftList.value = await res.json()
   }
@@ -158,8 +153,7 @@ async function saveSettings() {
   await apiFetch('/api/attendance-settings', {
     method: 'PUT',
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(payload)
   })
@@ -201,8 +195,7 @@ const shiftList = ref([])
       const res = await apiFetch('/api/shifts', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(shiftForm.value)
       })
@@ -216,8 +209,7 @@ const shiftList = ref([])
       const res = await apiFetch(`/api/shifts/${id}`, {
         method: 'PUT',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(shiftForm.value)
       })
@@ -232,8 +224,7 @@ const shiftList = ref([])
   const deleteShift = async (index) => {
     const id = shiftList.value[index]._id
     const res = await apiFetch(`/api/shifts/${id}`, {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${token}` }
+      method: 'DELETE'
     })
     if (res.ok) {
       shiftList.value.splice(index, 1)

--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -510,7 +510,6 @@ const orgList = ref([])
 const employeeDialogVisible = ref(false)
 let editEmployeeIndex = null
 let editEmployeeId = ''
-const token = localStorage.getItem('token') || ''
 
 function departmentLabel(id) {
   const dept = departmentList.value.find(d => d._id === id)
@@ -519,15 +518,15 @@ function departmentLabel(id) {
 
 /* 取資料 ------------------------------------------------------------------- */
 async function fetchDepartments() {
-  const res = await apiFetch('/api/departments', { headers: { Authorization: `Bearer ${token}` } })
+  const res = await apiFetch('/api/departments')
   if (res.ok) departmentList.value = await res.json()
 }
 async function fetchOrganizations() {
-  const res = await apiFetch('/api/organizations', { headers: { Authorization: `Bearer ${token}` } })
+  const res = await apiFetch('/api/organizations')
   if (res.ok) orgList.value = await res.json()
 }
 async function fetchEmployees() {
-  const res = await apiFetch('/api/employees', { headers: { Authorization: `Bearer ${token}` } })
+  const res = await apiFetch('/api/employees')
   if (res.ok) employeeList.value = await res.json()
 }
 onMounted(() => {
@@ -684,13 +683,13 @@ async function saveEmployee() {
   if (editEmployeeIndex === null) {
     res = await apiFetch('/api/employees', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     })
   } else {
     res = await apiFetch(`/api/employees/${editEmployeeId}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     })
   }
@@ -703,8 +702,7 @@ async function saveEmployee() {
 async function deleteEmployee(index) {
   const emp = employeeList.value[index]
   const res = await apiFetch(`/api/employees/${emp._id}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` }
+    method: 'DELETE'
   })
   if (res.ok) employeeList.value.splice(index, 1)
 }

--- a/client/src/components/backComponents/OrgDepartmentSetting.vue
+++ b/client/src/components/backComponents/OrgDepartmentSetting.vue
@@ -218,15 +218,12 @@ function urlOf(type) {
 }
 
 async function fetchList(type, parentId) {
-  const token = localStorage.getItem('token') || ''
   let url = urlOf(type)
   if (parentId) {
     const key = type === 'dept' ? 'organization' : 'department'
     url += `?${key}=${parentId}`
   }
-  const res = await apiFetch(url, {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch(url)
   if (res.ok) {
     const data = await res.json()
     if (type === 'org') orgList.value = data
@@ -304,7 +301,6 @@ function openDialog(type, index = null) {
 }
 
 async function saveItem() {
-  const token = localStorage.getItem('token') || ''
   const url = urlOf(currentType.value)
   const list =
     currentType.value === 'org'
@@ -316,14 +312,14 @@ async function saveItem() {
   if (editIndex.value === null) {
     res = await apiFetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form.value)
     })
   } else {
     const id = list.value[editIndex.value]._id
     res = await apiFetch(`${url}/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form.value)
     })
   }
@@ -334,12 +330,10 @@ async function saveItem() {
 }
 
 function deleteItem(type, index) {
-  const token = localStorage.getItem('token') || ''
   const list = type === 'org' ? orgList : type === 'dept' ? deptList : subList
   const id = list.value[index]._id
   apiFetch(`${urlOf(type)}/${id}`, {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` }
+    method: 'DELETE'
   }).then(res => {
     if (res.ok) {
       list.value.splice(index, 1)

--- a/client/src/components/backComponents/SalaryManagementSetting.vue
+++ b/client/src/components/backComponents/SalaryManagementSetting.vue
@@ -202,7 +202,6 @@ import { apiFetch } from '../../api'
   
   // 目前所在的Tab
 const activeTab = ref('salaryItem')
-const token = localStorage.getItem('token') || ''
 const settingId = ref(null)
   
   // ============ (1) 薪資項目設定 ============
@@ -372,9 +371,7 @@ const settingId = ref(null)
   }
 
   async function fetchSetting() {
-    const res = await apiFetch('/api/salary-settings', {
-      headers: { Authorization: `Bearer ${token}` }
-    })
+    const res = await apiFetch('/api/salary-settings')
     if (res.ok) {
       const data = await res.json()
       if (data.length) {
@@ -404,8 +401,7 @@ const settingId = ref(null)
     const res = await apiFetch(url, {
       method,
       headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)
     })

--- a/client/src/stores/menu.js
+++ b/client/src/stores/menu.js
@@ -6,10 +6,7 @@ export const useMenuStore = defineStore('menu', () => {
   const items = ref([])
 
   async function fetchMenu() {
-    const token = localStorage.getItem('token')
-    const res = await apiFetch('/api/menu', {
-      headers: { Authorization: `Bearer ${token}` }
-    })
+    const res = await apiFetch('/api/menu')
     if (res.ok) {
       items.value = await res.json()
     }

--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -35,7 +35,6 @@
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
-import { getToken } from '../../utils/tokenService'
 
 // 將中文動作與後端定義的值互轉
 const actionMap = {
@@ -51,10 +50,7 @@ const reverseActionMap = Object.fromEntries(
 const records = ref([])
 
 async function fetchRecords() {
-  const token = getToken() || ''
-  const res = await apiFetch('/api/attendance', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/attendance')
   if (res.ok) {
     const data = await res.json()
     records.value = data.map(r => ({
@@ -85,12 +81,10 @@ async function addRecord(action) {
     remark: '',
     employee: localStorage.getItem('employeeId') || ''
   }
-  const token = getToken() || ''
   const res = await apiFetch('/api/attendance', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(payload)
   })

--- a/client/src/views/front/Leave.vue
+++ b/client/src/views/front/Leave.vue
@@ -62,7 +62,6 @@
 import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
-import { getToken } from '../../utils/tokenService'
   
   const leaveForm = ref({
     leaveType: '',
@@ -75,10 +74,7 @@ const leaveRecords = ref([])
 
 
 async function fetchLeaves() {
-  const token = getToken() || ''
-  const res = await apiFetch('/api/leaves', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/leaves')
   if (res.ok) {
     leaveRecords.value = await res.json()
   }
@@ -92,12 +88,10 @@ async function onSubmitLeave() {
     endDate: leaveForm.value.endDate,
     reason: leaveForm.value.reason
   }
-  const token = getToken() || ''
   const res = await apiFetch('/api/leaves', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(payload)
   })

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -37,7 +37,6 @@
 import { ref, computed, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { apiFetch } from '../../api'
-import { getToken } from '../../utils/tokenService'
 import { useAuthStore } from '../../stores/auth'
 
 const currentMonth = ref(dayjs().format('YYYY-MM'))
@@ -59,10 +58,7 @@ const days = computed(() => {
 })
 
 async function fetchShiftOptions() {
-  const token = getToken() || ''
-  const res = await apiFetch('/api/attendance-settings', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
+  const res = await apiFetch('/api/attendance-settings')
   if (res.ok) {
     const data = await res.json()
     console.log("data:",data)
@@ -79,12 +75,10 @@ async function fetchShiftOptions() {
 }
 
 async function fetchSchedules() {
-  const token = getToken() || ''
   const supervisorId = localStorage.getItem('employeeId') || ''
   try {
     const res = await apiFetch(
-      `/api/schedules/monthly?month=${currentMonth.value}&supervisor=${supervisorId}`,
-      { headers: { Authorization: `Bearer ${token}` } }
+      `/api/schedules/monthly?month=${currentMonth.value}&supervisor=${supervisorId}`
     )
     if (!res.ok) throw new Error('Failed to fetch schedules')
     const data = await res.json()
@@ -113,7 +107,6 @@ async function fetchSchedules() {
 }
 
 async function onSelect(empId, day, value) {
-  const token = getToken() || ''
   const dateStr = `${currentMonth.value}-${String(day).padStart(2, '0')}`
   const existing = scheduleMap.value[empId][day]
   const prev = existing.shiftType
@@ -121,7 +114,7 @@ async function onSelect(empId, day, value) {
     try {
       const res = await apiFetch(`/api/schedules/${existing.id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ shiftType: value })
       })
       if (!res.ok) {
@@ -136,7 +129,7 @@ async function onSelect(empId, day, value) {
     try {
       const res = await apiFetch('/api/schedules', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ employee: empId, date: dateStr, shiftType: value })
       })
       if (res.ok) {
@@ -154,12 +147,9 @@ async function onSelect(empId, day, value) {
 }
 
 async function fetchEmployees() {
-  const token = getToken() || ''
   const supervisorId = localStorage.getItem('employeeId') || ''
   try {
-    const res = await apiFetch(`/api/employees?supervisor=${supervisorId}`, {
-      headers: { Authorization: `Bearer ${token}` }
-    })
+    const res = await apiFetch(`/api/employees?supervisor=${supervisorId}`)
     if (!res.ok) throw new Error('Failed to fetch employees')
     console.log("employee:",res)
     employees.value = await res.json()


### PR DESCRIPTION
## Summary
- add token-based Authorization header in `apiFetch`
- remove duplicate Authorization handling across front-end modules

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d08ba4c48329ae0f216479b9e630