### PR TITLE
docs: add agent guidance

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,3 +1,8 @@
 # Agent Instructions
 
 This repository contains a simple HR system. Future contributors can add additional instructions here to guide automated agents.
+
+- 回答需簡潔，避免重複或無限迴圈。
+- 提交任何程式碼變更前必須新增或更新測試並確保通過。
+
+若日後有子模組，可視需要在子資料夾放置覆寫指引的 `AGENTS.md`。


### PR DESCRIPTION
## Summary
- detail global rules for concise responses and test updates

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a49874236883298993afec49fdeb3f