### PR TITLE
在簽核流程設定新增簽核人下拉選單與選項 API

### DIFF
--- a/client/src/components/backComponents/ApprovalFlowSetting.vue
+++ b/client/src/components/backComponents/ApprovalFlowSetting.vue
@@ -100,7 +100,13 @@
               </el-table-column>
               <el-table-column label="Approver Value" width="200">
                 <template #default="{ row }">
-                  <el-input v-model="row.approver_value" placeholder="userId/標籤/角色..." />
+                  <el-select v-if="row.approver_type==='user'" v-model="row.approver_value" placeholder="選擇員工">
+                    <el-option v-for="e in employeeOptions" :key="e._id" :label="`${e.name}（${e.title || '無職稱'}）`" :value="e._id" />
+                  </el-select>
+                  <el-select v-else-if="row.approver_type==='role'" v-model="row.approver_value" placeholder="選擇角色">
+                    <el-option v-for="r in roleOptions" :key="r.id" :label="r.name" :value="r.id" />
+                  </el-select>
+                  <el-input v-else v-model="row.approver_value" placeholder="userId/標籤/角色..." />
                 </template>
               </el-table-column>
               <el-table-column label="Scope" width="120">
@@ -146,6 +152,8 @@ import { apiFetch } from '../../api'  // 你專案現有封裝
 const API = {
   forms: '/api/forms',
   workflow: (formId) => `/api/forms/${formId}/workflow`,
+  employees: '/api/employees/options',
+  roles: '/api/roles',
 }
 
 const CATEGORIES = ['人事類','總務類','請假類','其他']
@@ -172,11 +180,23 @@ const formDialog = ref({ _id: '', name: '', category: '其他', is_active: true,
 /* 流程 Dialog */
 const workflowDialogVisible = ref(false)
 const workflowSteps = ref([])
+const employeeOptions = ref([])
+const roleOptions = ref([])
 
 /* 讀取樣板列表 */
 async function loadForms() {
   const res = await apiFetch(API.forms)
   if (res.ok) forms.value = await res.json()
+}
+
+async function loadEmployeeOptions() {
+  const res = await apiFetch(API.employees)
+  if (res.ok) employeeOptions.value = await res.json()
+}
+
+async function loadRoleOptions() {
+  const res = await apiFetch(API.roles)
+  if (res.ok) roleOptions.value = await res.json()
 }
 
 /* 切換樣板時，同步讀 workflow.policy */
@@ -284,6 +304,8 @@ onMounted(async () => {
   await loadForms()
   selectedFormId.value = forms.value[0]?._id || ''
   if (selectedFormId.value) await loadWorkflow()
+  await loadEmployeeOptions()
+  await loadRoleOptions()
 })
 </script>
 

--- a/client/tests/approvalFlowSetting.spec.js
+++ b/client/tests/approvalFlowSetting.spec.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import ApprovalFlowSetting from '../src/components/backComponents/ApprovalFlowSetting.vue'
+
+const employees = [{ _id: 'e1', name: 'Alice', title: 'Manager' }]
+const workflowData = { steps: [{ step_order: 1, approver_type: 'user', approver_value: 'e1' }] }
+
+const apiFetch = vi.fn((url, opts) => {
+  if (url === '/api/forms') return Promise.resolve({ ok: true, json: async () => [] })
+  if (url === '/api/employees/options') return Promise.resolve({ ok: true, json: async () => employees })
+  if (url === '/api/roles') return Promise.resolve({ ok: true, json: async () => [] })
+  if (url === '/api/forms/f1/workflow' && !opts) return Promise.resolve({ ok: true, json: async () => workflowData })
+  if (url === '/api/forms/f1/workflow' && opts?.method === 'PUT') return Promise.resolve({ ok: true })
+  return Promise.resolve({ ok: true, json: async () => ({}) })
+})
+
+vi.mock('../src/api', () => ({ apiFetch }))
+
+describe('ApprovalFlowSetting approver select', () => {
+  it('loads options and saves selected id', async () => {
+    const wrapper = mount(ApprovalFlowSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/api/employees/options')
+    await wrapper.vm.openWorkflowDialog({ _id: 'f1' })
+    await flushPromises()
+    expect(wrapper.vm.workflowSteps[0].approver_value).toBe('e1')
+    wrapper.vm.workflowSteps[0].approver_value = 'e1'
+    wrapper.vm.selectedFormId = 'f1'
+    await wrapper.vm.saveWorkflow()
+    const call = apiFetch.mock.calls.find(c => c[0] === '/api/forms/f1/workflow' && c[1]?.method === 'PUT')
+    const body = JSON.parse(call[1].body)
+    expect(body.steps[0].approver_value).toBe('e1')
+  })
+})

--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -379,6 +379,15 @@ export async function listEmployees(req, res) {
   }
 }
 
+export async function listEmployeeOptions(req, res) {
+  try {
+    const employees = await Employee.find({}, 'name title')
+    res.json(employees)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+}
+
 /** POST /api/employees */
 export async function createEmployee(req, res) {
   try {

--- a/server/src/controllers/roleController.js
+++ b/server/src/controllers/roleController.js
@@ -1,0 +1,8 @@
+export function listRoles(req, res) {
+  const roles = [
+    { id: 'employee', name: '員工' },
+    { id: 'supervisor', name: '主管' },
+    { id: 'admin', name: '管理員' }
+  ]
+  res.json(roles)
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,6 +26,7 @@ import organizationRoutes from './routes/organizationRoutes.js';
 import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 import holidayRoutes from './routes/holidayRoutes.js';
 import deptScheduleRoutes from './routes/deptScheduleRoutes.js';
+import roleRoutes from './routes/roleRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 import breakSettingRoutes from './routes/breakSettingRoutes.js';
@@ -152,6 +153,7 @@ app.use(
   employeeRoutes
 );
 app.use('/api/attendance', authenticate, authorizeRoles('employee', 'supervisor', 'admin'), attendanceRoutes);
+app.use('/api/roles', authenticate, authorizeRoles('admin', 'supervisor'), roleRoutes);
 app.use(
   '/api/attendance-settings',
   authenticate,

--- a/server/src/routes/employeeRoutes.js
+++ b/server/src/routes/employeeRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   listEmployees,
+  listEmployeeOptions,
   createEmployee,
   getEmployee,
   updateEmployee,
@@ -10,6 +11,7 @@ import {
 const router = Router();
 
 router.get('/', listEmployees);
+router.get('/options', listEmployeeOptions);
 router.post('/', createEmployee);
 router.get('/:id', getEmployee);
 router.put('/:id', updateEmployee);

--- a/server/src/routes/roleRoutes.js
+++ b/server/src/routes/roleRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { listRoles } from '../controllers/roleController.js'
+
+const router = Router()
+
+router.get('/', listRoles)
+
+export default router

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -52,6 +52,15 @@ describe('Employee API', () => {
     expect(res.body).toEqual(fakeEmployees);
   });
 
+  it('lists employee options', async () => {
+    const opts = [{ _id: '1', name: 'A', title: 'T' }];
+    mockEmployee.find.mockResolvedValue(opts);
+    const res = await request(app).get('/api/employees/options');
+    expect(res.status).toBe(200);
+    expect(mockEmployee.find).toHaveBeenCalledWith({}, 'name title');
+    expect(res.body).toEqual(opts);
+  });
+
   it('returns 500 if listing fails', async () => {
     mockEmployee.find.mockRejectedValue(new Error('fail'));
     const res = await request(app).get('/api/employees');

--- a/server/tests/role.test.js
+++ b/server/tests/role.test.js
@@ -1,0 +1,24 @@
+import request from 'supertest'
+import express from 'express'
+
+let app
+let roleRoutes
+
+beforeAll(async () => {
+  roleRoutes = (await import('../src/routes/roleRoutes.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/roles', roleRoutes)
+})
+
+describe('Role API', () => {
+  it('lists roles', async () => {
+    const res = await request(app).get('/api/roles')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([
+      { id: 'employee', name: '員工' },
+      { id: 'supervisor', name: '主管' },
+      { id: 'admin', name: '管理員' }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- 將簽核流程設定中的 approver_value 改用下拉選單並載入員工與角色選項
- 新增 `/api/employees/options` 與 `/api/roles` 端點提供簽核人選項
- 補上前後端測試以涵蓋簽核人選擇與儲存流程

## Testing
- `npm test` *(失敗：現有測試環境錯誤)*
- `npm --prefix client test` *(失敗：部分前端測試缺少元件與資料)*

------
https://chatgpt.com/codex/tasks/task_e_68a49cdf279c8329b071f65471f5f92b