### PR TITLE
test: 新增 User API 角色授權測試

### DIFF
--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
+import { authorizeRoles } from '../src/middleware/auth.js';
 
 const saveMock = jest.fn();
 const mockUser = jest.fn().mockImplementation(() => ({ save: saveMock }));
@@ -12,22 +13,29 @@ jest.mock('../src/models/User.js', () => ({ default: mockUser }), { virtual: tru
 
 let app;
 let userRoutes;
+let currentRole = 'admin';
+
+const authenticate = (req, res, next) => {
+  req.user = { role: currentRole };
+  next();
+};
 
 beforeAll(async () => {
   userRoutes = (await import('../src/routes/userRoutes.js')).default;
   app = express();
   app.use(express.json());
-  app.use('/api/users', userRoutes);
+  app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
 });
 
-beforeEach(() => {
-  saveMock.mockReset();
-  mockUser.find.mockReset();
-  mockUser.findById.mockReset();
-  mockUser.findByIdAndDelete.mockReset();
-});
+describe('User API as admin', () => {
+  beforeEach(() => {
+    currentRole = 'admin';
+    saveMock.mockReset();
+    mockUser.find.mockReset();
+    mockUser.findById.mockReset();
+    mockUser.findByIdAndDelete.mockReset();
+  });
 
-describe('User API', () => {
   it('lists users', async () => {
     const fake = [{ username: 'a' }];
     mockUser.find.mockResolvedValue(fake);
@@ -57,5 +65,39 @@ describe('User API', () => {
     const res = await request(app).delete('/api/users/1');
     expect(res.status).toBe(200);
     expect(mockUser.findByIdAndDelete).toHaveBeenCalledWith('1');
+  });
+});
+
+describe('User API as non-admin', () => {
+  beforeEach(() => {
+    currentRole = 'user';
+    saveMock.mockReset();
+    mockUser.find.mockReset();
+    mockUser.findById.mockReset();
+    mockUser.findByIdAndDelete.mockReset();
+  });
+
+  it('denies listing users', async () => {
+    const res = await request(app).get('/api/users');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
+  });
+
+  it('denies creating user', async () => {
+    const res = await request(app).post('/api/users').send({});
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
+  });
+
+  it('denies updating user', async () => {
+    const res = await request(app).put('/api/users/1').send({});
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
+  });
+
+  it('denies deleting user', async () => {
+    const res = await request(app).delete('/api/users/1');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
   });
 });


### PR DESCRIPTION
## Summary
- 為 User API 建立含 authenticate 與 authorizeRoles('admin') 的測試應用
- 驗證 admin 角色可成功執行 CRUD
- 驗證非 admin 角色操作時回傳 403

## Testing
- `npm --prefix server test -- server/tests/user.test.js` *(失敗：ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab30468c83298f21c3e4f1bc71b0