### PR TITLE
refactor: use shift id for schedules

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -13,18 +13,18 @@
           <template v-if="scheduleMap[row._id]?.[d]">
             <el-select
               v-if="canEdit"
-              v-model="scheduleMap[row._id][d].shiftType"
+              v-model="scheduleMap[row._id][d].shiftId"
               placeholder=""
               @change="val => onSelect(row._id, d, val)"
             >
               <el-option
-                v-for="opt in shiftOptions"
-                :key="opt"
-                :label="opt"
-                :value="opt"
+                v-for="opt in shifts"
+                :key="opt._id"
+                :label="opt.name"
+                :value="opt._id"
               />
             </el-select>
-            <span v-else>{{ scheduleMap[row._id]?.[d]?.shiftType || '' }}</span>
+            <span v-else>{{ shiftName(scheduleMap[row._id]?.[d]?.shiftId) || '' }}</span>
           </template>
           <span v-else>-</span>
         </template>
@@ -41,7 +41,7 @@ import { useAuthStore } from '../../stores/auth'
 
 const currentMonth = ref(dayjs().format('YYYY-MM'))
 const scheduleMap = ref({})
-const shiftOptions = ref([])
+const shifts = ref([])
 const employees = ref([])
 
 const authStore = useAuthStore()
@@ -61,9 +61,8 @@ async function fetchShiftOptions() {
   const res = await apiFetch('/api/attendance-settings')
   if (res.ok) {
     const data = await res.json()
-    console.log("data:",data)
-    if (Array.isArray(data)) {
-      shiftOptions.value = data.map(s => s.name)
+    if (Array.isArray(data?.shifts)) {
+      shifts.value = data.shifts.map(s => ({ _id: s._id, name: s.name }))
     }
   } else {
     if (res.status === 403) {
@@ -92,13 +91,13 @@ async function fetchSchedules() {
     employees.value.forEach(emp => {
       scheduleMap.value[emp._id] = {}
       ds.forEach(d => {
-        scheduleMap.value[emp._id][d] = { shiftType: '' }
+        scheduleMap.value[emp._id][d] = { shiftId: '' }
       })
     })
     data.forEach((s) => {
       const empId = s.employee?._id || s.employee
       const d = dayjs(s.date).date()
-      scheduleMap.value[empId][d] = { id: s._id, shiftType: s.shiftType }
+      scheduleMap.value[empId][d] = { id: s._id, shiftId: s.shiftId }
     })
   } catch (err) {
     console.error(err)
@@ -109,20 +108,20 @@ async function fetchSchedules() {
 async function onSelect(empId, day, value) {
   const dateStr = `${currentMonth.value}-${String(day).padStart(2, '0')}`
   const existing = scheduleMap.value[empId][day]
-  const prev = existing.shiftType
+  const prev = existing.shiftId
   if (existing && existing.id) {
     try {
       const res = await apiFetch(`/api/schedules/${existing.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ shiftType: value })
+        body: JSON.stringify({ shiftId: value })
       })
       if (!res.ok) {
-        scheduleMap.value[empId][day].shiftType = prev
+        scheduleMap.value[empId][day].shiftId = prev
         ElMessage.error('更新排班失敗')
       }
     } catch (err) {
-      scheduleMap.value[empId][day].shiftType = prev
+      scheduleMap.value[empId][day].shiftId = prev
       ElMessage.error('更新排班失敗')
     }
   } else {
@@ -130,20 +129,25 @@ async function onSelect(empId, day, value) {
       const res = await apiFetch('/api/schedules', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ employee: empId, date: dateStr, shiftType: value })
+        body: JSON.stringify({ employee: empId, date: dateStr, shiftId: value })
       })
       if (res.ok) {
         const saved = await res.json()
-        scheduleMap.value[empId][day] = { id: saved._id, shiftType: saved.shiftType }
+        scheduleMap.value[empId][day] = { id: saved._id, shiftId: saved.shiftId }
       } else {
-        scheduleMap.value[empId][day].shiftType = prev
+        scheduleMap.value[empId][day].shiftId = prev
         ElMessage.error('新增排班失敗')
       }
     } catch (err) {
-      scheduleMap.value[empId][day].shiftType = prev
+      scheduleMap.value[empId][day].shiftId = prev
       ElMessage.error('新增排班失敗')
     }
   }
+}
+
+function shiftName(id) {
+  const found = shifts.value.find(s => s._id === id)
+  return found?.name || ''
 }
 
 async function fetchEmployees() {

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -41,10 +41,9 @@ describe('Schedule.vue', () => {
 
     localStorage.setItem('employeeId', 's1')
     const wrapper = mountSchedule()
-    wrapper.vm.scheduleMap = { e1: { 1: { id: 'sch1', shiftType: '早班' } } }
-    wrapper.vm.scheduleMap.e1[1].shiftType = '晚班'
-    await wrapper.vm.onSelect('e1', 1, '晚班')
-    expect(wrapper.vm.scheduleMap.e1[1].shiftType).toBe('早班')
+    wrapper.vm.scheduleMap = { e1: { 1: { id: 'sch1', shiftId: 's1' } } }
+    await wrapper.vm.onSelect('e1', 1, 's2')
+    expect(wrapper.vm.scheduleMap.e1[1].shiftId).toBe('s1')
     expect(ElMessage.error).toHaveBeenCalled()
   })
 
@@ -57,10 +56,9 @@ describe('Schedule.vue', () => {
 
     localStorage.setItem('employeeId', 's1')
     const wrapper = mountSchedule()
-    wrapper.vm.scheduleMap = { e1: { 2: { shiftType: '' } } }
-    wrapper.vm.scheduleMap.e1[2].shiftType = '早班'
-    await wrapper.vm.onSelect('e1', 2, '早班')
-    expect(wrapper.vm.scheduleMap.e1[2].shiftType).toBe('')
+    wrapper.vm.scheduleMap = { e1: { 2: { shiftId: '' } } }
+    await wrapper.vm.onSelect('e1', 2, 's1')
+    expect(wrapper.vm.scheduleMap.e1[2].shiftId).toBe('')
     expect(ElMessage.error).toHaveBeenCalled()
   })
 })

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -49,10 +49,10 @@ export async function listSchedules(req, res) {
 
 export async function createSchedule(req, res) {
   try {
-    const { employee, date, shiftType } = req.body;
+    const { employee, date, shiftId } = req.body;
     const schedule = await ShiftSchedule.findOneAndUpdate(
       { employee, date },
-      { shiftType },
+      { shiftId },
       { upsert: true, new: true, setDefaultsOnInsert: true }
     );
     res.status(201).json(schedule);
@@ -120,13 +120,13 @@ export async function exportSchedules(req, res) {
       ws.columns = [
         { header: 'Employee', key: 'employee' },
         { header: 'Date', key: 'date' },
-        { header: 'Shift Type', key: 'shiftType' }
+        { header: 'Shift ID', key: 'shiftId' }
       ];
       schedules.forEach((s) => {
         ws.addRow({
           employee: s.employee?.name ?? '',
           date: new Date(s.date).toISOString().split('T')[0],
-          shiftType: s.shiftType
+          shiftId: s.shiftId
         });
       });
       res.setHeader(
@@ -154,7 +154,7 @@ export async function exportSchedules(req, res) {
           .text(
             `${s.employee?.name ?? ''}\t${new Date(s.date)
               .toISOString()
-              .split('T')[0]}\t${s.shiftType}`
+              .split('T')[0]}\t${s.shiftId}`
           );
       });
       doc.pipe(res);

--- a/server/src/models/ShiftSchedule.js
+++ b/server/src/models/ShiftSchedule.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const shiftScheduleSchema = new mongoose.Schema({
   employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
   date: { type: Date, required: true },
-  shiftType: { type: String, required: true }
+  shiftId: { type: mongoose.Schema.Types.ObjectId, required: true }
 }, { timestamps: true });
 
 shiftScheduleSchema.index({ employee: 1, date: 1 }, { unique: true });


### PR DESCRIPTION
## Summary
- use `shiftId` reference in shift schedules and controller
- adjust Schedule.vue to send `shiftId` and show shift names
- update related tests to use `shiftId`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and other require errors)*
- `npm --prefix client test schedule.spec.js` *(fails: expected spy to be called and undefined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b4141e108329888b340453f52b6f