### PR TITLE
fix schedule shift fetching

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -61,8 +61,9 @@ async function fetchShiftOptions() {
   const res = await apiFetch('/api/attendance-settings')
   if (res.ok) {
     const data = await res.json()
-    if (Array.isArray(data?.shifts)) {
-      shifts.value = data.shifts.map(s => ({ _id: s._id, name: s.name }))
+    const list = Array.isArray(data?.shifts) ? data.shifts : data
+    if (Array.isArray(list)) {
+      shifts.value = list.map(s => ({ _id: s._id, name: s.name }))
     }
   } else {
     if (res.status === 403) {

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -32,6 +32,30 @@ describe('Schedule.vue', () => {
     })
   }
 
+  function flush() {
+    return new Promise(resolve => setTimeout(resolve))
+  }
+
+  it('loads shift options when API returns array directly', async () => {
+    apiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: 's1', name: 'S1' }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+    expect(wrapper.vm.shifts).toEqual([{ _id: 's1', name: 'S1' }])
+  })
+
+  it('loads shift options when API returns object with shifts', async () => {
+    apiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ shifts: [{ _id: 's1', name: 'S1' }] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+    expect(wrapper.vm.shifts).toEqual([{ _id: 's1', name: 'S1' }])
+  })
+
   it('reverts change when update fails', async () => {
     apiFetch
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
@@ -41,6 +65,7 @@ describe('Schedule.vue', () => {
 
     localStorage.setItem('employeeId', 's1')
     const wrapper = mountSchedule()
+    await flush()
     wrapper.vm.scheduleMap = { e1: { 1: { id: 'sch1', shiftId: 's1' } } }
     await wrapper.vm.onSelect('e1', 1, 's2')
     expect(wrapper.vm.scheduleMap.e1[1].shiftId).toBe('s1')
@@ -56,6 +81,7 @@ describe('Schedule.vue', () => {
 
     localStorage.setItem('employeeId', 's1')
     const wrapper = mountSchedule()
+    await flush()
     wrapper.vm.scheduleMap = { e1: { 2: { shiftId: '' } } }
     await wrapper.vm.onSelect('e1', 2, 's1')
     expect(wrapper.vm.scheduleMap.e1[2].shiftId).toBe('')


### PR DESCRIPTION
## Summary
- handle attendance-settings API returning arrays directly when populating shift options
- add tests for both array and object responses

## Testing
- `npm test` *(fails: SyntaxError in server/tests and various ReferenceError: require is not defined)*
- `(cd client && npx vitest run tests/schedule.spec.js)`

------
https://chatgpt.com/codex/tasks/task_e_68a4bebcdb04832981cba0b8c0f969ea