### PR TITLE
Refactor approval API endpoints

### DIFF
--- a/client/src/components/backComponents/ApprovalFlowSetting.vue
+++ b/client/src/components/backComponents/ApprovalFlowSetting.vue
@@ -150,8 +150,8 @@ import { ref, onMounted } from 'vue'
 import { apiFetch } from '../../api'  // 你專案現有封裝
 
 const API = {
-  forms: '/api/forms',
-  workflow: (formId) => `/api/forms/${formId}/workflow`,
+  forms: '/api/approvals/forms',
+  workflow: (formId) => `/api/approvals/forms/${formId}/workflow`,
   employees: '/api/employees/options',
   roles: '/api/roles',
 }

--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -319,7 +319,7 @@ async function fetchOrgs() {
 }
 
 async function loadFormTemplates() {
-  const res = await apiFetch('/api/forms')
+  const res = await apiFetch('/api/approvals/forms')
   if (res.ok) formTemplates.value = await res.json()
 }
 
@@ -328,7 +328,7 @@ async function onSelectForm() {
   applyState.formData = {}
   fileBuffers.value = {}
   if (!applyState.formId) return
-  const res = await apiFetch(`/api/forms/${applyState.formId}`)
+  const res = await apiFetch(`/api/approvals/forms/${applyState.formId}`)
   if (res.ok) {
     const data = await res.json()
     fieldList.value = (data.fields || []).sort((a,b)=> (a.order||0)-(b.order||0))
@@ -367,7 +367,7 @@ async function submitApply() {
       payloadData[fid] = files.map(f => f.name)
     })
 
-    const res = await apiFetch('/api/approvals', {
+    const res = await apiFetch('/api/approvals/approvals', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -392,7 +392,7 @@ async function submitApply() {
 const inboxList = ref([])
 
 async function fetchInbox() {
-  const res = await apiFetch('/api/inbox')
+  const res = await apiFetch('/api/approvals/inbox')
   if (res.ok) {
     const arr = await res.json()
     inboxList.value = arr
@@ -420,7 +420,7 @@ async function doAction() {
   if (!actionDlg.target) return
   actionDlg.loading = true
   try {
-    const res = await apiFetch(`/api/approvals/${actionDlg.target._id}/act`, {
+    const res = await apiFetch(`/api/approvals/approvals/${actionDlg.target._id}/act`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ decision: actionDlg.decision, comment: actionDlg.comment })
@@ -443,14 +443,14 @@ const myList = ref([])
 const formNameCache = reactive({})
 
 async function fetchMyList() {
-  const res = await apiFetch('/api/approvals')
+  const res = await apiFetch('/api/approvals/approvals')
   if (res.ok) {
     myList.value = await res.json()
     // 取每筆的 form 名稱（明細才有 populate）
     await Promise.all(
       myList.value.map(async (row) => {
         if (!row.form || !row.form.name) {
-          const r = await apiFetch(`/api/approvals/${row._id}`)
+          const r = await apiFetch(`/api/approvals/approvals/${row._id}`)
           if (r.ok) {
             const full = await r.json()
             formNameCache[row._id] = full?.form?.name || ''
@@ -465,7 +465,7 @@ async function fetchMyList() {
 const detail = reactive({ visible: false, doc: null })
 
 async function openDetail(id) {
-  const res = await apiFetch(`/api/approvals/${id}`)
+  const res = await apiFetch(`/api/approvals/approvals/${id}`)
   if (res.ok) {
     detail.doc = await res.json()
     detail.visible = true

--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -6,7 +6,7 @@ describe('Approval.vue', () => {
   it('fetches list on mount', async () => {
     vi.spyOn(window, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
     mount(Approval)
-    expect(window.fetch).toHaveBeenCalledWith('/api/approvals', expect.any(Object))
+    expect(window.fetch).toHaveBeenCalledWith('/api/approvals/approvals', expect.any(Object))
     window.fetch.mockRestore()
   })
 })

--- a/client/tests/approvalFlowSetting.spec.js
+++ b/client/tests/approvalFlowSetting.spec.js
@@ -7,11 +7,11 @@ const employees = [{ _id: 'e1', name: 'Alice', title: 'Manager' }]
 const workflowData = { steps: [{ step_order: 1, approver_type: 'user', approver_value: 'e1' }] }
 
 const apiFetch = vi.fn((url, opts) => {
-  if (url === '/api/forms') return Promise.resolve({ ok: true, json: async () => [] })
+  if (url === '/api/approvals/forms') return Promise.resolve({ ok: true, json: async () => [] })
   if (url === '/api/employees/options') return Promise.resolve({ ok: true, json: async () => employees })
   if (url === '/api/roles') return Promise.resolve({ ok: true, json: async () => [] })
-  if (url === '/api/forms/f1/workflow' && !opts) return Promise.resolve({ ok: true, json: async () => workflowData })
-  if (url === '/api/forms/f1/workflow' && opts?.method === 'PUT') return Promise.resolve({ ok: true })
+  if (url === '/api/approvals/forms/f1/workflow' && !opts) return Promise.resolve({ ok: true, json: async () => workflowData })
+  if (url === '/api/approvals/forms/f1/workflow' && opts?.method === 'PUT') return Promise.resolve({ ok: true })
   return Promise.resolve({ ok: true, json: async () => ({}) })
 })
 
@@ -28,7 +28,7 @@ describe('ApprovalFlowSetting approver select', () => {
     wrapper.vm.workflowSteps[0].approver_value = 'e1'
     wrapper.vm.selectedFormId = 'f1'
     await wrapper.vm.saveWorkflow()
-    const call = apiFetch.mock.calls.find(c => c[0] === '/api/forms/f1/workflow' && c[1]?.method === 'PUT')
+    const call = apiFetch.mock.calls.find(c => c[0] === '/api/approvals/forms/f1/workflow' && c[1]?.method === 'PUT')
     const body = JSON.parse(call[1].body)
     expect(body.steps[0].approver_value).toBe('e1')
   })


### PR DESCRIPTION
## Summary
- Point approval flow settings to `/api/approvals/forms`
- Update front-end approval view to new `/api/approvals/*` routes
- Adjust unit tests for updated approval API paths

## Testing
- `npm test` *(fails: Cannot read properties of undefined, ReferenceError: require is not defined)*
- `npm --prefix client test` *(fails: TypeError: Cannot read properties of undefined, component resolution warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c5522074832984fb7305c320a782