### PR TITLE
Preserve workflow policy on updates

### DIFF
--- a/client/src/components/backComponents/ApprovalFlowSetting.vue
+++ b/client/src/components/backComponents/ApprovalFlowSetting.vue
@@ -290,6 +290,7 @@ function removeStep(i) {
 async function saveWorkflow() {
   const payload = {
     steps: workflowSteps.value.map((s, idx) => ({ ...s, step_order: idx + 1 })),
+    policy: policyForm.value,
   }
   await apiFetch(API.workflow(selectedFormId.value), {
     method: 'PUT',

--- a/server/src/controllers/approvalTemplateController.js
+++ b/server/src/controllers/approvalTemplateController.js
@@ -137,9 +137,11 @@ export async function getWorkflow(req, res) {
 export async function setWorkflow(req, res) {
   try {
     const { steps, policy } = req.body
+    const setObj = { steps: Array.isArray(steps) ? steps : [] }
+    if (policy !== undefined) setObj.policy = policy
     const wf = await ApprovalWorkflow.findOneAndUpdate(
       { form: req.params.formId },
-      { $set: { steps: Array.isArray(steps) ? steps : [], policy } },
+      { $set: setObj },
       { new: true, upsert: true }
     )
     res.json(wf)

--- a/server/tests/approvalTemplate.test.js
+++ b/server/tests/approvalTemplate.test.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals'
+
+const mockApprovalWorkflow = { findOneAndUpdate: jest.fn() }
+
+let setWorkflow
+
+beforeAll(async () => {
+  await jest.unstable_mockModule('../src/models/approval_workflow.js', () => ({ default: mockApprovalWorkflow }))
+  const mod = await import('../src/controllers/approvalTemplateController.js')
+  setWorkflow = mod.setWorkflow
+})
+
+beforeEach(() => {
+  mockApprovalWorkflow.findOneAndUpdate.mockReset()
+})
+
+function makeRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() }
+}
+
+describe('setWorkflow', () => {
+  it('keeps existing policy when none provided', async () => {
+    const existingPolicy = { allowDelegate: true }
+    mockApprovalWorkflow.findOneAndUpdate.mockResolvedValue({ steps: [], policy: existingPolicy })
+    const req = { params: { formId: 'f1' }, body: { steps: [] } }
+    const res = makeRes()
+
+    await setWorkflow(req, res)
+
+    expect(mockApprovalWorkflow.findOneAndUpdate).toHaveBeenCalledWith(
+      { form: 'f1' },
+      { $set: { steps: [] } },
+      { new: true, upsert: true }
+    )
+    expect(res.json).toHaveBeenCalledWith({ steps: [], policy: existingPolicy })
+  })
+
+  it('updates policy when provided', async () => {
+    const newPolicy = { allowDelegate: false }
+    mockApprovalWorkflow.findOneAndUpdate.mockResolvedValue({ steps: [], policy: newPolicy })
+    const req = { params: { formId: 'f1' }, body: { steps: [], policy: newPolicy } }
+    const res = makeRes()
+
+    await setWorkflow(req, res)
+
+    expect(mockApprovalWorkflow.findOneAndUpdate).toHaveBeenCalledWith(
+      { form: 'f1' },
+      { $set: { steps: [], policy: newPolicy } },
+      { new: true, upsert: true }
+    )
+    expect(res.json).toHaveBeenCalledWith({ steps: [], policy: newPolicy })
+  })
+})
+


### PR DESCRIPTION
## Summary
- retain existing workflow policy when updates omit policy
- send policy data from ApprovalFlowSetting when saving workflow
- cover setWorkflow policy handling with unit tests

## Testing
- `npm test` *(fails: TypeError in approvalWorkflow.test.js and other suites)*
- `npm --prefix client test` *(fails: missing component resolutions and TypeErrors)*
- `cd server && npm test -- tests/approvalTemplate.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a4c94b5dd88329b7b4df61b99c87e6