### PR TITLE
調整簽核路由權限設定

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -184,7 +184,7 @@ app.use('/api/schedules', authenticate, authorizeRoles('supervisor', 'admin'), s
 app.use('/api/payroll', authenticate, authorizeRoles('admin'), payrollRoutes);
 app.use('/api/reports', authenticate, authorizeRoles('admin'), reportRoutes);
 app.use('/api/insurance', authenticate, authorizeRoles('admin'), insuranceRoutes);
-app.use('/api/approvals', authenticate, authorizeRoles('supervisor', 'admin'), approvalRoutes);
+app.use('/api/approvals', authenticate, approvalRoutes);
 app.use('/api/menu', authenticate, menuRoutes);
 app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
 app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);

--- a/server/src/routes/approvalRoutes.js
+++ b/server/src/routes/approvalRoutes.js
@@ -9,30 +9,32 @@ import {
   createApprovalRequest, getApprovalRequest, myApprovalRequests, inboxApprovals, actOnApproval,
 } from '../controllers/approvalRequestController.js'
 
+import { authorizeRoles } from '../middleware/auth.js'
+
 const router = Router()
 
 // Form Template
-router.get('/forms', listFormTemplates)
-router.post('/forms', createFormTemplate)
-router.get('/forms/:id', getFormTemplate)
-router.put('/forms/:id', updateFormTemplate)
-router.delete('/forms/:id', deleteFormTemplate)
+router.get('/forms', authorizeRoles('employee', 'supervisor', 'admin'), listFormTemplates)
+router.post('/forms', authorizeRoles('admin'), createFormTemplate)
+router.get('/forms/:id', authorizeRoles('employee', 'supervisor', 'admin'), getFormTemplate)
+router.put('/forms/:id', authorizeRoles('admin'), updateFormTemplate)
+router.delete('/forms/:id', authorizeRoles('admin'), deleteFormTemplate)
 
 // Fields
-router.get('/forms/:formId/fields', listFields)
-router.post('/forms/:formId/fields', addField)
-router.put('/forms/:formId/fields/:fieldId', updateField)
-router.delete('/forms/:formId/fields/:fieldId', deleteField)
+router.get('/forms/:formId/fields', authorizeRoles('employee', 'supervisor', 'admin'), listFields)
+router.post('/forms/:formId/fields', authorizeRoles('admin'), addField)
+router.put('/forms/:formId/fields/:fieldId', authorizeRoles('admin'), updateField)
+router.delete('/forms/:formId/fields/:fieldId', authorizeRoles('admin'), deleteField)
 
 // Workflow
-router.get('/forms/:formId/workflow', getWorkflow)
-router.put('/forms/:formId/workflow', setWorkflow)
+router.get('/forms/:formId/workflow', authorizeRoles('employee', 'supervisor', 'admin'), getWorkflow)
+router.put('/forms/:formId/workflow', authorizeRoles('admin'), setWorkflow)
 
 // Requests
-router.post('/approvals', createApprovalRequest)           // 建立送審單
-router.get('/approvals/:id', getApprovalRequest)           // 單筆
-router.get('/approvals', myApprovalRequests)               // 申請者列表 ?employee_id=
-router.get('/inbox', inboxApprovals)                       // 審核者待辦 ?employee_id=
-router.post('/approvals/:id/act', actOnApproval)           // { decision:'approve'|'reject'|'return', comment?, employee_id? }
+router.post('/approvals', authorizeRoles('employee', 'supervisor', 'admin'), createApprovalRequest)
+router.get('/approvals/:id', authorizeRoles('employee', 'supervisor', 'admin'), getApprovalRequest)
+router.get('/approvals', authorizeRoles('employee', 'supervisor', 'admin'), myApprovalRequests)
+router.get('/inbox', authorizeRoles('employee', 'supervisor', 'admin'), inboxApprovals)
+router.post('/approvals/:id/act', authorizeRoles('employee', 'supervisor', 'admin'), actOnApproval)
 
 export default router


### PR DESCRIPTION
## Summary
- 僅保留 `/api/approvals` 驗證登入，不在伺服器入口限制角色
- `approvalRoutes` 依路由細部加入角色授權：管理表單需 admin，其餘查詢與申請允許 employee/supervisor/admin

## Testing
- `npm test` *(failed: ReferenceError: require is not defined, SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d12c3e7083299a4339664fa5bd9b