### PR TITLE
feat: add form field settings

### DIFF
--- a/client/src/components/backComponents/ApprovalFlowSetting.vue
+++ b/client/src/components/backComponents/ApprovalFlowSetting.vue
@@ -141,17 +141,75 @@
           </el-dialog>
         </div>
       </el-tab-pane>
+      <el-tab-pane label="欄位設定" name="fields">
+        <div class="tab-content">
+          <div class="flex items-center gap-2 mb-2">
+            <el-select v-model="selectedFormId" placeholder="選擇表單樣板" style="width: 320px" @change="loadFields">
+              <el-option v-for="f in forms" :key="f._id" :label="`${f.name}（${f.category}）`" :value="f._id" />
+            </el-select>
+            <el-button type="primary" :disabled="!selectedFormId" @click="openFieldDialog()">新增欄位</el-button>
+          </div>
+
+          <el-table v-if="selectedFormId" :data="fields" border>
+            <el-table-column type="index" label="#" width="50" />
+            <el-table-column prop="label" label="欄位名稱" />
+            <el-table-column prop="type_1" label="型別1" width="120" />
+            <el-table-column prop="type_2" label="型別2" width="120" />
+            <el-table-column label="必填" width="80">
+              <template #default="{ row }">
+                <el-switch v-model="row.required" @change="updateField(row)" />
+              </template>
+            </el-table-column>
+            <el-table-column label="排序" width="140">
+              <template #default="{ $index }">
+                <el-button size="small" @click="moveField($index,-1)" :disabled="$index===0">上移</el-button>
+                <el-button size="small" @click="moveField($index,1)" :disabled="$index===fields.length-1">下移</el-button>
+              </template>
+            </el-table-column>
+            <el-table-column label="操作" width="180">
+              <template #default="{ row }">
+                <el-button size="small" @click="openFieldDialog('edit',row)">編輯</el-button>
+                <el-button size="small" type="danger" @click="removeField(row)">刪除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+          <div v-else class="text-gray-500">請先從上方選擇表單樣板。</div>
+        </div>
+
+        <el-dialog v-model="fieldDialogVisible" :title="fieldDialogMode==='edit' ? '編輯欄位' : '新增欄位'" width="520px">
+          <el-form :model="fieldDialog" label-width="120px">
+            <el-form-item label="標籤"><el-input v-model="fieldDialog.label" /></el-form-item>
+            <el-form-item label="型別1">
+              <el-select v-model="fieldDialog.type_1" placeholder="選擇型別">
+                <el-option v-for="t in FIELD_TYPES" :key="t" :label="t" :value="t" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="型別2"><el-input v-model="fieldDialog.type_2" /></el-form-item>
+            <el-form-item label="必填"><el-switch v-model="fieldDialog.required" /></el-form-item>
+            <el-form-item label="選項">
+              <el-input v-model="fieldDialog.optionsStr" type="textarea" :rows="2" placeholder="JSON 或以逗號分隔" />
+            </el-form-item>
+            <el-form-item label="提示文字"><el-input v-model="fieldDialog.placeholder" /></el-form-item>
+          </el-form>
+          <template #footer>
+            <el-button @click="fieldDialogVisible=false">取消</el-button>
+            <el-button type="primary" @click="saveField">儲存</el-button>
+          </template>
+        </el-dialog>
+      </el-tab-pane>
     </el-tabs>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { apiFetch } from '../../api'  // 你專案現有封裝
 
 const API = {
   forms: '/api/approvals/forms',
   workflow: (formId) => `/api/approvals/forms/${formId}/workflow`,
+  fields: (formId) => `/api/approvals/forms/${formId}/fields`,
+  field: (formId, fieldId) => `/api/approvals/forms/${formId}/fields/${fieldId}`,
   employees: '/api/employees/options',
   roles: '/api/roles',
 }
@@ -163,6 +221,7 @@ const APPROVER_TYPES = ['manager','tag','user','role','department','org','group'
 const activeTab = ref('commonRule')
 const forms = ref([])
 const selectedFormId = ref('')
+const fields = ref([])
 
 /* 通用規則 policy */
 const policyForm = ref({
@@ -182,6 +241,100 @@ const workflowDialogVisible = ref(false)
 const workflowSteps = ref([])
 const employeeOptions = ref([])
 const roleOptions = ref([])
+
+const fieldDialogVisible = ref(false)
+const fieldDialogMode = ref('create')
+const fieldDialog = ref({ _id: '', label: '', type_1: 'text', type_2: '', required: false, optionsStr: '', placeholder: '', order: 0 })
+const FIELD_TYPES = ['text','textarea','number','select','checkbox','date','time','datetime','file','user','department','org']
+
+watch([activeTab, selectedFormId], () => {
+  if (activeTab.value === 'fields' && selectedFormId.value) loadFields()
+})
+
+function parseOptions(str) {
+  if (!str) return undefined
+  try { return JSON.parse(str) } catch { return str.split(',').map(s => s.trim()).filter(Boolean) }
+}
+
+async function loadFields() {
+  if (!selectedFormId.value) return
+  const res = await apiFetch(API.fields(selectedFormId.value))
+  if (res.ok) {
+    const arr = await res.json()
+    fields.value = Array.isArray(arr) ? arr.sort((a,b)=> (a.order??0)-(b.order??0)) : []
+  }
+}
+
+function openFieldDialog(mode='create', row=null) {
+  fieldDialogMode.value = mode
+  if (mode === 'edit' && row) {
+    fieldDialog.value = { ...row, optionsStr: row.options ? JSON.stringify(row.options) : '' }
+  } else {
+    fieldDialog.value = { _id: '', label: '', type_1: 'text', type_2: '', required: false, optionsStr: '', placeholder: '', order: fields.value.length }
+  }
+  fieldDialogVisible.value = true
+}
+
+async function saveField() {
+  if (!selectedFormId.value) return
+  const payload = {
+    label: fieldDialog.value.label,
+    type_1: fieldDialog.value.type_1,
+    type_2: fieldDialog.value.type_2,
+    required: fieldDialog.value.required,
+    options: parseOptions(fieldDialog.value.optionsStr),
+    placeholder: fieldDialog.value.placeholder,
+    order: fieldDialog.value.order ?? fields.value.length,
+  }
+  let res
+  if (fieldDialogMode.value === 'edit' && fieldDialog.value._id) {
+    res = await apiFetch(API.field(selectedFormId.value, fieldDialog.value._id), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  } else {
+    res = await apiFetch(API.fields(selectedFormId.value), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  }
+  if (res.ok) {
+    fieldDialogVisible.value = false
+    await loadFields()
+  }
+}
+
+async function updateField(row) {
+  const payload = { label: row.label, type_1: row.type_1, type_2: row.type_2, required: row.required, options: row.options, placeholder: row.placeholder, order: row.order }
+  await apiFetch(API.field(selectedFormId.value, row._id), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+}
+
+async function removeField(row) {
+  await apiFetch(API.field(selectedFormId.value, row._id), { method: 'DELETE' })
+  await loadFields()
+}
+
+async function moveField(index, offset) {
+  const newIndex = index + offset
+  if (newIndex < 0 || newIndex >= fields.value.length) return
+  const arr = fields.value
+  const [item] = arr.splice(index, 1)
+  arr.splice(newIndex, 0, item)
+  for (let i = 0; i < arr.length; i++) {
+    arr[i].order = i
+    await apiFetch(API.field(selectedFormId.value, arr[i]._id), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: i })
+    })
+  }
+}
 
 /* 讀取樣板列表 */
 async function loadForms() {

--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -328,10 +328,10 @@ async function onSelectForm() {
   applyState.formData = {}
   fileBuffers.value = {}
   if (!applyState.formId) return
-  const res = await apiFetch(`/api/approvals/forms/${applyState.formId}`)
+  const res = await apiFetch(`/api/approvals/forms/${applyState.formId}/fields`)
   if (res.ok) {
-    const data = await res.json()
-    fieldList.value = (data.fields || []).sort((a,b)=> (a.order||0)-(b.order||0))
+    const arr = await res.json()
+    fieldList.value = (arr || []).sort((a,b)=> (a.order||0)-(b.order||0))
     // 初始化表單資料
     fieldList.value.forEach(f => {
       if (f.type_1 === 'checkbox') applyState.formData[f._id] = []

--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -1,12 +1,23 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import Approval from '../src/views/front/Approval.vue'
 
 describe('Approval.vue', () => {
   it('fetches list on mount', async () => {
     vi.spyOn(window, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
     mount(Approval)
+    await flushPromises()
     expect(window.fetch).toHaveBeenCalledWith('/api/approvals/approvals', expect.any(Object))
+    window.fetch.mockRestore()
+  })
+
+  it('loads fields for selected form', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+    const wrapper = mount(Approval)
+    wrapper.vm.applyState.formId = 'f1'
+    window.fetch.mockClear()
+    await wrapper.vm.onSelectForm()
+    expect(window.fetch).toHaveBeenCalledWith('/api/approvals/forms/f1/fields', undefined)
     window.fetch.mockRestore()
   })
 })

--- a/client/tests/fieldSetting.spec.js
+++ b/client/tests/fieldSetting.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import ApprovalFlowSetting from '../src/components/backComponents/ApprovalFlowSetting.vue'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+import { apiFetch } from '../src/api'
+global.ElMessage = { success: vi.fn() }
+
+describe('ApprovalFlowSetting field tab', () => {
+  beforeEach(() => {
+    apiFetch.mockReset()
+  })
+
+  it('loads fields and adds new field', async () => {
+    const fields = []
+    apiFetch.mockImplementation((url, opts) => {
+      if (url === '/api/approvals/forms') return Promise.resolve({ ok: true, json: async () => [{ _id:'f1', name:'F1', category:'', is_active:true }] })
+      if (url === '/api/employees/options') return Promise.resolve({ ok: true, json: async () => [] })
+      if (url === '/api/roles') return Promise.resolve({ ok: true, json: async () => [] })
+      if (url === '/api/approvals/forms/f1/fields' && !opts) return Promise.resolve({ ok: true, json: async () => fields })
+      if (url === '/api/approvals/forms/f1/fields' && opts?.method === 'POST') {
+        fields.push({ _id:'fld1', ...JSON.parse(opts.body) })
+        return Promise.resolve({ ok: true, json: async () => fields[0] })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const wrapper = mount(ApprovalFlowSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+    wrapper.vm.selectedFormId = 'f1'
+    await wrapper.vm.loadFields()
+    expect(apiFetch).toHaveBeenCalledWith('/api/approvals/forms/f1/fields', undefined)
+    wrapper.vm.openFieldDialog()
+    wrapper.vm.fieldDialog.label = 'Name'
+    await wrapper.vm.saveField()
+    const call = apiFetch.mock.calls.find(c => c[0] === '/api/approvals/forms/f1/fields' && c[1].method === 'POST')
+    expect(call).toBeTruthy()
+  })
+
+  it('moves field and updates order', async () => {
+    const fields = [
+      { _id:'a', label:'A', type_1:'text', order:0, required:false },
+      { _id:'b', label:'B', type_1:'text', order:1, required:false }
+    ]
+    apiFetch.mockImplementation((url, opts) => {
+      if (url === '/api/approvals/forms') return Promise.resolve({ ok: true, json: async () => [{ _id:'f1', name:'F1', category:'', is_active:true }] })
+      if (url === '/api/employees/options') return Promise.resolve({ ok: true, json: async () => [] })
+      if (url === '/api/roles') return Promise.resolve({ ok: true, json: async () => [] })
+      if (url === '/api/approvals/forms/f1/fields' && !opts) return Promise.resolve({ ok: true, json: async () => fields })
+      if (url.startsWith('/api/approvals/forms/f1/fields/') && opts?.method === 'PUT') return Promise.resolve({ ok: true })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const wrapper = mount(ApprovalFlowSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+    wrapper.vm.selectedFormId = 'f1'
+    await wrapper.vm.loadFields()
+    await wrapper.vm.moveField(1, -1)
+    const call = apiFetch.mock.calls.find(c => c[0] === '/api/approvals/forms/f1/fields/a' && c[1].method === 'PUT')
+    expect(call).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add field management tab for form templates
- fetch fields for approvals from dedicated endpoint
- test field operations

## Testing
- `npm test` *(fails: TypeError in server tests)*
- `npm --prefix client test -- --run` *(fails: unresolved components and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d1313f0c8329a61e8271a5f34068