### PR TITLE
新增排班等測試帳號與簽核標籤

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -36,7 +36,7 @@ import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
 import shiftRoutes from './routes/shiftRoutes.js';
 import deptManagerRoutes from './routes/deptManagerRoutes.js';
 
-async function seedSampleData() {
+export async function seedSampleData() {
   let org = await Organization.findOne({ name: '示範機構' });
   if (!org) {
     org = await Organization.create({
@@ -80,11 +80,16 @@ async function seedSampleData() {
     console.log('Created sample sub-department');
   }
 }
-async function seedTestUsers() {
+export async function seedTestUsers() {
   const users = [
     { username: 'user', password: 'password', role: 'employee' },
     { username: 'supervisor', password: 'password', role: 'supervisor' },
-    { username: 'admin', password: 'password', role: 'admin' }
+    { username: 'admin', password: 'password', role: 'admin' },
+    { username: 'scheduler', password: 'password', role: 'supervisor', signTags: ['排班負責人'] },
+    { username: 'supportHead', password: 'password', role: 'supervisor', signTags: ['支援單位主管'] },
+    { username: 'salesHead', password: 'password', role: 'supervisor', signTags: ['業務主管'] },
+    { username: 'salesManager', password: 'password', role: 'supervisor', signTags: ['業務負責人'] },
+    { username: 'hr', password: 'password', role: 'admin', signTags: ['人資'] }
   ];
   let supervisorId = null;
   for (const data of users) {
@@ -98,7 +103,8 @@ async function seedTestUsers() {
         department: '人力資源部',
         subDepartment: '招聘組',
         title: 'Staff',
-        status: '在職'
+        status: '在職',
+        signTags: data.signTags ?? []
       });
       await User.create({
         ...data,
@@ -223,4 +229,6 @@ async function start() {
   }
 }
 
-start();
+if (process.env.NODE_ENV !== 'test') {
+  start();
+}

--- a/server/tests/seedUsers.test.js
+++ b/server/tests/seedUsers.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+const mockUserFindOne = jest.fn();
+const mockUserCreate = jest.fn();
+
+jest.mock('../src/models/User.js', () => ({ default: { findOne: mockUserFindOne, create: mockUserCreate } }), { virtual: true });
+
+const mockEmpCreate = jest.fn(async (data) => ({ _id: `${data.name}_id`, ...data }));
+const mockEmpUpdateMany = jest.fn();
+
+jest.mock('../src/models/Employee.js', () => ({ default: { create: mockEmpCreate, updateMany: mockEmpUpdateMany } }), { virtual: true });
+
+beforeAll(() => {
+  process.env.PORT = '3000';
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  process.env.JWT_SECRET = 'secret';
+  process.env.NODE_ENV = 'test';
+});
+
+describe('seedTestUsers', () => {
+  it('creates specialized accounts with signTags', async () => {
+    mockUserFindOne.mockResolvedValue(null);
+    mockUserCreate.mockResolvedValue({});
+    const { seedTestUsers } = await import('../src/index.js');
+    await seedTestUsers();
+    expect(mockEmpCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'scheduler', signTags: ['\u6392\u73ed\u8cac\u4efb\u4eba'] }));
+    expect(mockEmpCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'supportHead', signTags: ['\u652f\u63f4\u55ae\u4f4d\u4e3b\u7ba1'] }));
+    expect(mockEmpCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'salesHead', signTags: ['\u696d\u52d9\u4e3b\u7ba1'] }));
+    expect(mockEmpCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'salesManager', signTags: ['\u696d\u52d9\u8cac\u4efb\u4eba'] }));
+    expect(mockEmpCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'hr', signTags: ['\u4eba\u8cc7'] }));
+  });
+});


### PR DESCRIPTION
## Summary
- 擴充 `seedTestUsers` 加入排班負責人、支援單位主管、業務主管、業務負責人與人資帳號，並寫入對應 `signTags`
- 新增 `seedUsers` 測試以驗證新增帳號的 `signTags`

## Testing
- `npm --prefix server test tests/seedUsers.test.js` *(失敗：require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a61c67d6dc8329b623780c02d0729e