### PR TITLE
feat: show workflow approvers

### DIFF
--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -11,13 +11,36 @@ describe('Approval.vue', () => {
     window.fetch.mockRestore()
   })
 
-  it('loads fields for selected form', async () => {
-    vi.spyOn(window, 'fetch').mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+  it('loads fields and workflow for selected form', async () => {
+    let employeeCall = 0
+    vi.spyOn(window, 'fetch').mockImplementation((url) => {
+      if (url.includes('/forms/f1/fields')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      if (url.includes('/forms/f1/workflow')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ steps: [{ approver_type: 'user', approver_value: ['u1'] }] })
+        })
+      }
+      if (url.includes('/employees')) {
+        employeeCall++
+        if (employeeCall === 1) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([{ _id: 'u1', name: 'Alice' }]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
     const wrapper = mount(Approval)
+    await flushPromises()
     wrapper.vm.applyState.formId = 'f1'
     window.fetch.mockClear()
     await wrapper.vm.onSelectForm()
     expect(window.fetch).toHaveBeenCalledWith('/api/approvals/forms/f1/fields', undefined)
+    expect(window.fetch).toHaveBeenCalledWith('/api/approvals/forms/f1/workflow', undefined)
+    expect(window.fetch).toHaveBeenCalledWith('/api/employees', undefined)
+    expect(wrapper.vm.workflowSteps[0].approvers).toBe('Alice')
     window.fetch.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- fetch and display workflow approvers when selecting a form
- map approver IDs to employee names via `/api/employees`
- test Approval.vue workflow fetch behavior

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading '_id'), require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6221590f4832991343541e08df8df