### PR TITLE
允許 employee 存取前台簽核頁面

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -100,7 +100,7 @@ const routes = [
         path: 'approval',
         name: 'Approval',
         component: Approval,
-        meta: { roles: ['supervisor', 'admin'] }
+        meta: { roles: ['employee', 'supervisor', 'admin'] }
       }
     ]
   },

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-let capturedGuard
+var capturedGuard
 vi.mock('vue-router', () => ({
   createRouter: ({ routes }) => ({
     getRoutes: () => routes,
@@ -36,7 +36,7 @@ describe('router', () => {
     expect(childRoles.find(c => c.name === 'Attendance').roles).toEqual(['employee', 'supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Leave').roles).toEqual(['employee', 'supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Schedule').roles).toEqual(['supervisor', 'admin'])
-    expect(childRoles.find(c => c.name === 'Approval').roles).toEqual(['supervisor', 'admin'])
+    expect(childRoles.find(c => c.name === 'Approval').roles).toEqual(['employee', 'supervisor', 'admin'])
   })
 
   it('role guard blocks unauthorized user', () => {
@@ -46,10 +46,10 @@ describe('router', () => {
     expect(next).toHaveBeenCalledWith({ name: 'Forbidden' })
   })
 
-  it('role guard allows authorized user', () => {
-    localStorage.setItem('role', 'supervisor')
+  it('role guard allows employee when permitted', () => {
+    localStorage.setItem('role', 'employee')
     const next = vi.fn()
-    capturedGuard({ meta: { roles: ['supervisor', 'admin'] } }, {}, next)
+    capturedGuard({ meta: { roles: ['employee', 'supervisor', 'admin'] } }, {}, next)
     expect(next).toHaveBeenCalled()
     expect(next.mock.calls[0][0]).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- 前台簽核路由加入 employee 權限
- 調整路由測試，確認 employee 通行

## Testing
- `npm test` (client) *(失敗：多個既有測試失敗)*
- `npm test tests/router.spec.js`
- `npm test` (server) *(失敗：多個既有測試失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68a6239535b883298b738b7946aa788e