### PR TITLE
調整員工在職狀態名稱

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -77,7 +77,7 @@ async function seed() {
         department: '人力資源部',
         subDepartment: '招聘組',
         title: 'Staff',
-        status: '在職'
+        status: '正職員工'
       });
       await User.create({
         ...data,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -106,7 +106,7 @@ export async function seedTestUsers() {
         department: '人力資源部',
         subDepartment: '招聘組',
         title: 'Staff',
-        status: '在職',
+        status: '正職員工',
         signTags: data.signTags ?? []
       });
       await User.create({

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -35,7 +35,7 @@ beforeEach(() => {
 describe('Employee API', () => {
   it('lists employees', async () => {
 
-    const fakeEmployees = [{ name: 'John', department: 'Sales', title: 'Staff', status: '在職' }];
+    const fakeEmployees = [{ name: 'John', department: 'Sales', title: 'Staff', status: '正職員工' }];
 
     mockEmployee.find.mockResolvedValue(fakeEmployees);
     const res = await request(app).get('/api/employees');
@@ -77,7 +77,7 @@ describe('Employee API', () => {
       department: 'HR',
       subDepartment: 'Sub',
       title: 'Manager',
-      status: '在職',
+      status: '正職員工',
       username: 'jane',
       password: 'secret',
       role: 'employee',
@@ -105,7 +105,7 @@ describe('Employee API', () => {
       department: 'HR',
       subDepartment: 'Sub',
       title: 'Manager',
-      status: '在職',
+      status: '正職員工',
       role: 'employee',
       supervisor: 's1'
     });


### PR DESCRIPTION
## Summary
- 種子腳本與測試用戶建立流程改用 enum 中的「正職員工」
- 更新員工 API 測試資料中的在職狀態

## Testing
- `npm --prefix server test -- tests/employee.test.js` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a634b241b083299d09e5e5cba7bbe6