### PR TITLE
feat: add approval menu for employees

### DIFF
--- a/client/tests/menuStore.spec.js
+++ b/client/tests/menuStore.spec.js
@@ -7,6 +7,7 @@ describe('menu store', () => {
     setActivePinia(createPinia())
     vi.stubGlobal('fetch', vi.fn())
     localStorage.setItem('token', 'tok')
+    localStorage.setItem('role', 'employee')
   })
 
   afterEach(() => {
@@ -17,13 +18,14 @@ describe('menu store', () => {
   it('fetchMenu stores items', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ([{ name: 'a' }, { name: 'OrgDepartmentSetting' }])
+      json: async () => ([{ name: 'Approval' }, { name: 'OrgDepartmentSetting' }])
     })
     const store = useMenuStore()
     await store.fetchMenu()
-    expect(fetch).toHaveBeenCalledWith('/api/menu', expect.objectContaining({
+    expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/menu', expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer tok' })
     }))
-    expect(store.items).toEqual([{ name: 'a' }, { name: 'OrgDepartmentSetting' }])
+    expect(store.items).toEqual([{ name: 'Approval' }, { name: 'OrgDepartmentSetting' }])
+    expect(store.items.find(i => i.name === 'Approval')).toBeDefined()
   })
 })

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -3,7 +3,8 @@ export function getMenu(req, res) {
   const menus = {
     employee: [
       { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
-      { name: 'Leave', label: '請假申請', icon: 'el-icon-date' }
+      { name: 'Leave', label: '請假申請', icon: 'el-icon-date' },
+      { name: 'Approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     supervisor: [
       { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -2,12 +2,10 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
-const mockAuth = {
+jest.unstable_mockModule('../src/middleware/auth.js', () => ({
   authenticate: (req, res, next) => { req.user = { role: 'employee' }; next(); },
   authorizeRoles: () => (req, res, next) => next()
-};
-
-jest.mock('../src/middleware/auth.js', () => mockAuth, { virtual: true });
+}));
 
 let app;
 let menuRoutes;
@@ -24,12 +22,14 @@ describe('Menu API', () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.find(i => i.name === 'Attendance')).toBeDefined();
+    expect(res.body.find(i => i.name === 'Approval')).toBeDefined();
   });
 
   it('menu names exist in frontend routes', async () => {
     const res = await request(app).get('/api/menu');
     const fs = await import('fs');
     const path = await import('path');
+    const __dirname = path.dirname(new URL(import.meta.url).pathname);
     const routerPath = path.resolve(__dirname, '../../client/src/router/index.js');
     const content = fs.readFileSync(routerPath, 'utf-8');
     const matches = Array.from(content.matchAll(/name:\s*'([^']+)'/g)).map(m => m[1]);


### PR DESCRIPTION
## Summary
- add Approval menu to employee role
- verify employee menu includes Approval in server and client tests

## Testing
- `cd server && NODE_OPTIONS=--experimental-vm-modules npx jest tests/menu.test.js`
- `cd client && npx vitest run tests/menuStore.spec.js`
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a64607044083298b768eece2096c2f