### PR TITLE
feat: support shift codes in scheduling

### DIFF
--- a/client/src/components/backComponents/ShiftScheduleSetting.vue
+++ b/client/src/components/backComponents/ShiftScheduleSetting.vue
@@ -56,6 +56,7 @@
           <div class="tab-content">
             <el-button type="primary" @click="openShiftDialog()">新增班別</el-button>
             <el-table :data="shiftList" style="margin-top: 20px;">
+              <el-table-column prop="code" label="代碼" width="100" />
               <el-table-column prop="name" label="班別名稱" width="160" />
               <el-table-column prop="startTime" label="上班時間" width="120" />
               <el-table-column prop="endTime" label="下班時間" width="120" />
@@ -72,6 +73,9 @@
             <!-- 新增/編輯 班別 Dialog -->
             <el-dialog v-model="shiftDialogVisible" title="班別資料" width="500px">
               <el-form :model="shiftForm" label-width="120px">
+                <el-form-item label="班別代碼">
+                  <el-input v-model="shiftForm.code" placeholder="如：A1" />
+                </el-form-item>
                 <el-form-item label="班別名稱">
                   <el-input v-model="shiftForm.name" placeholder="如：早班 / 夜班 / 彈性班" />
                 </el-form-item>
@@ -254,6 +258,7 @@ async function fetchHolidays() {
 
   const shiftForm = ref({
     name: '',
+    code: '',
     startTime: '',
     endTime: '',
     crossDay: false,
@@ -282,6 +287,7 @@ async function fetchShifts() {
       shiftEditIndex = null
       shiftForm.value = {
         name: '',
+        code: '',
         startTime: '',
         endTime: '',
         crossDay: false,

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -20,11 +20,26 @@
               <el-option
                 v-for="opt in shifts"
                 :key="opt._id"
-                :label="opt.name"
+                :label="opt.code"
                 :value="opt._id"
               />
             </el-select>
-            <span v-else>{{ shiftName(scheduleMap[row._id]?.[d]?.shiftId) || '' }}</span>
+            <el-popover
+              v-else
+              v-if="shiftInfo(scheduleMap[row._id][d].shiftId)"
+              placement="top"
+              trigger="click"
+            >
+              <p>上班：{{ shiftInfo(scheduleMap[row._id][d].shiftId).startTime }}</p>
+              <p>下班：{{ shiftInfo(scheduleMap[row._id][d].shiftId).endTime }}</p>
+              <p v-if="shiftInfo(scheduleMap[row._id][d].shiftId).remark">
+                備註：{{ shiftInfo(scheduleMap[row._id][d].shiftId).remark }}
+              </p>
+              <template #reference>
+                <span>{{ shiftInfo(scheduleMap[row._id][d].shiftId).code }}</span>
+              </template>
+            </el-popover>
+            <span v-else></span>
           </template>
           <span v-else>-</span>
         </template>
@@ -63,7 +78,13 @@ async function fetchShiftOptions() {
     const data = await res.json()
     const list = Array.isArray(data?.shifts) ? data.shifts : data
     if (Array.isArray(list)) {
-      shifts.value = list.map(s => ({ _id: s._id, name: s.name }))
+      shifts.value = list.map(s => ({
+        _id: s._id,
+        code: s.code,
+        startTime: s.startTime,
+        endTime: s.endTime,
+        remark: s.remark
+      }))
     }
   } else {
     if (res.status === 403) {
@@ -146,9 +167,8 @@ async function onSelect(empId, day, value) {
   }
 }
 
-function shiftName(id) {
-  const found = shifts.value.find(s => s._id === id)
-  return found?.name || ''
+function shiftInfo(id) {
+  return shifts.value.find(s => s._id === id)
 }
 
 async function fetchEmployees() {

--- a/server/src/models/AttendanceSetting.js
+++ b/server/src/models/AttendanceSetting.js
@@ -4,6 +4,7 @@ const attendanceSettingSchema = new mongoose.Schema({
   shifts: [
     {
       name: String,
+      code: String,
       startTime: String,
       endTime: String,
       breakTime: String,

--- a/server/tests/attendanceSetting.test.js
+++ b/server/tests/attendanceSetting.test.js
@@ -27,7 +27,7 @@ beforeEach(() => {
 
 describe('AttendanceSetting API', () => {
   it('gets settings', async () => {
-    const data = { shifts: [] };
+    const data = { shifts: [{ name: '早班', code: 'A', startTime: '09:00', endTime: '18:00' }] };
     mockAttendanceSetting.findOne.mockResolvedValue(data);
     const res = await request(app).get('/api/attendance-settings');
     expect(res.status).toBe(200);
@@ -42,7 +42,7 @@ describe('AttendanceSetting API', () => {
   });
 
   it('updates settings', async () => {
-    const payload = { shifts: [] };
+    const payload = { shifts: [{ name: '早班', code: 'A', startTime: '09:00', endTime: '18:00' }] };
     mockAttendanceSetting.findOneAndUpdate.mockResolvedValue(payload);
     const res = await request(app).put('/api/attendance-settings').send(payload);
     expect(res.status).toBe(200);

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -77,7 +77,7 @@ beforeEach(() => {
 /* --------------------------------- Tests -------------------------------- */
 describe('Schedule API', () => {
   it('lists schedules', async () => {
-    const fakeSchedules = [{ shiftId: 's1' }];
+    const fakeSchedules = [{ shiftId: 's1', code: 'A', startTime: '09:00', endTime: '18:00' }];
     mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
 
     const res = await request(app).get('/api/schedules');
@@ -159,7 +159,7 @@ describe('Schedule API', () => {
   });
 
   it('lists schedules by month (with employee filter)', async () => {
-    const fake = [{ shiftId: 'night' }];
+    const fake = [{ shiftId: 'night', code: 'N', startTime: '00:00', endTime: '08:00' }];
     mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fake) });
 
     const res = await request(app).get('/api/schedules/monthly?month=2023-01&employee=e1');
@@ -173,7 +173,10 @@ describe('Schedule API', () => {
     const fakeEmployees = [{ _id: 'e1' }, { _id: 'e2' }];
     mockEmployee.find.mockResolvedValue(fakeEmployees);
 
-    const fakeSchedules = [{ employee: 'e1' }, { employee: 'e2' }];
+    const fakeSchedules = [
+      { employee: 'e1', shiftId: 's1', code: 'A' },
+      { employee: 'e2', shiftId: 's2', code: 'B' }
+    ];
     mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeSchedules) });
 
     const res = await request(app).get('/api/schedules/monthly?month=2023-01&supervisor=s1');


### PR DESCRIPTION
## Summary
- add `code` to attendance shift model
- allow managing shift code in backend UI
- display shift code with time tooltip on schedule page
- adjust related tests for shift code

## Testing
- `npm test` *(fails: TypeError in approvalWorkflow.test.js; SyntaxError missing semicolon in schedule.test.js; ReferenceError require is not defined in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a647cdb918832988ac2e7d25524a71