### PR TITLE
feat: integrate leave approvals into schedules

### DIFF
--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -8,7 +8,8 @@ import {
   exportSchedules,
   listMonthlySchedules,
   createSchedulesBatch,
-  deleteOldSchedules
+  deleteOldSchedules,
+  listLeaveApprovals
 } from '../controllers/scheduleController.js';
 import { verifySupervisor } from '../middleware/supervisor.js';
 
@@ -16,6 +17,7 @@ const router = Router();
 
 router.get('/', listSchedules);
 router.get('/monthly', listMonthlySchedules);
+router.get('/leave-approvals', listLeaveApprovals);
 router.get('/export', exportSchedules);
 router.post('/batch', verifySupervisor, createSchedulesBatch);
 router.post('/', verifySupervisor, createSchedule);

--- a/server/tests/leave.test.js
+++ b/server/tests/leave.test.js
@@ -6,21 +6,33 @@ const saveMock = jest.fn();
 const mockLeaveRequest = jest.fn().mockImplementation(() => ({ save: saveMock }));
 mockLeaveRequest.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
 
+const mockApprovalRequest = {
+  find: jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }))
+};
+const mockEmployee = { find: jest.fn() };
+
 jest.mock('../src/models/LeaveRequest.js', () => ({ default: mockLeaveRequest }), { virtual: true });
+jest.mock('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }), { virtual: true });
+jest.mock('../src/models/Employee.js', () => ({ default: mockEmployee }), { virtual: true });
 
 let app;
 let leaveRoutes;
+let scheduleRoutes;
 
 beforeAll(async () => {
   leaveRoutes = (await import('../src/routes/leaveRoutes.js')).default;
+  scheduleRoutes = (await import('../src/routes/scheduleRoutes.js')).default;
   app = express();
   app.use(express.json());
   app.use('/api/leaves', leaveRoutes);
+  app.use('/api/schedules', scheduleRoutes);
 });
 
 beforeEach(() => {
   saveMock.mockReset();
   mockLeaveRequest.find.mockReset();
+  mockApprovalRequest.find.mockReset();
+  mockEmployee.find.mockReset();
 });
 
 describe('Leave API', () => {
@@ -46,5 +58,25 @@ describe('Leave API', () => {
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
     expect(res.body).toMatchObject(payload);
+  });
+
+  it('lists leaves and approvals by employee', async () => {
+    const fakeLeaves = [{ employee: 'e1', leaveType: 'sick', status: 'approved' }];
+    const fakeApprovals = [{ applicant_employee: { name: 'A' }, status: 'pending', form_data: { leaveType: 'sick' } }];
+    mockLeaveRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeLeaves) });
+    mockApprovalRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeApprovals) });
+    const res = await request(app).get('/api/schedules/leave-approvals?month=2023-01&employee=e1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ leaves: fakeLeaves, approvals: fakeApprovals });
+  });
+
+  it('filters by supervisor when listing leave approvals', async () => {
+    mockEmployee.find.mockResolvedValue([{ _id: 'e1' }]);
+    mockLeaveRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+    mockApprovalRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) });
+    await request(app).get('/api/schedules/leave-approvals?month=2023-01&supervisor=s1');
+    expect(mockEmployee.find).toHaveBeenCalledWith({ supervisor: 's1' });
+    const called = mockLeaveRequest.find.mock.calls[0][0];
+    expect(called.employee).toEqual({ $in: ['e1'] });
   });
 });


### PR DESCRIPTION
## Summary
- expose API to fetch monthly leave requests and approval records
- show approved leave and approval list in schedule view
- add tests for leave approval API

## Testing
- `npm test` (fails: Cannot read properties or require is not defined)
- `npm test` (client) (fails: Vue component resolution errors)

------
https://chatgpt.com/codex/tasks/task_e_68a6550f4510832991d1087e44d08b69