### PR TITLE
Check schedule conflicts and handle front-end errors

### DIFF
--- a/server/src/models/ShiftSchedule.js
+++ b/server/src/models/ShiftSchedule.js
@@ -3,7 +3,9 @@ import mongoose from 'mongoose';
 const shiftScheduleSchema = new mongoose.Schema({
   employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
   date: { type: Date, required: true },
-  shiftId: { type: mongoose.Schema.Types.ObjectId, required: true }
+  shiftId: { type: mongoose.Schema.Types.ObjectId, required: true },
+  department: { type: mongoose.Schema.Types.ObjectId, ref: 'Department' },
+  subDepartment: { type: mongoose.Schema.Types.ObjectId, ref: 'SubDepartment' }
 }, { timestamps: true });
 
 shiftScheduleSchema.index({ employee: 1, date: 1 }, { unique: true });

--- a/server/tests/schedule.unit.test.js
+++ b/server/tests/schedule.unit.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const mockShiftSchedule = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  insertMany: jest.fn()
+};
+const mockLeaveRequest = { findOne: jest.fn() };
+
+jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
+jest.unstable_mockModule('../src/models/LeaveRequest.js', () => ({ default: mockLeaveRequest }));
+
+const { createSchedule, createSchedulesBatch } = await import('../src/controllers/scheduleController.js');
+
+describe('createSchedule validations', () => {
+  beforeEach(() => {
+    mockShiftSchedule.findOne.mockReset();
+    mockShiftSchedule.create.mockReset();
+    mockLeaveRequest.findOne.mockReset();
+  });
+
+  it('returns department overlap when existing schedule in other dept', async () => {
+    mockShiftSchedule.findOne.mockResolvedValue({ department: 'd1' });
+    const req = { body: { employee: 'e1', date: '2023-01-01', shiftId: 's1', department: 'd2' } };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+    await createSchedule(req, res);
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'department overlap' });
+  });
+});
+
+describe('createSchedulesBatch validations', () => {
+  beforeEach(() => {
+    mockShiftSchedule.findOne.mockReset();
+    mockShiftSchedule.insertMany.mockReset();
+    mockLeaveRequest.findOne.mockReset();
+  });
+
+  it('returns leave conflict when batch has approved leave', async () => {
+    mockShiftSchedule.findOne.mockResolvedValue(null);
+    mockLeaveRequest.findOne.mockResolvedValue({ _id: 'l1' });
+    const req = { body: { schedules: [{ employee: 'e1', date: '2023-01-01', shiftId: 's1' }] } };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+    await createSchedulesBatch(req, res);
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'leave conflict' });
+  });
+});


### PR DESCRIPTION
## Summary
- validate existing schedules and leaves when creating single or batch schedules
- warn on cross-department scheduling conflicts
- show conflict alerts in schedule page

## Testing
- `npm --prefix server test schedule.test.js schedule.unit.test.js`
- `npm --prefix client test` *(fails: Failed to resolve component: el-popover)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a279b6a88329b0e2d954b9e76db0