### PR TITLE
feat: improve supervisor verification and login info

### DIFF
--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -13,8 +13,13 @@ router.post('/login', async (req, res) => {
   const match = await user.comparePassword(password);
   if (!match) return res.status(401).json({ error: 'Invalid credentials' });
 
-  const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
-  res.json({ token, user: { id: user._id, role: user.role, username: user.username, employeeId: user.employee } });
+  const employeeId = user.employee || user.supervisor;
+  const token = jwt.sign(
+    { id: user._id, role: user.role, employeeId },
+    process.env.JWT_SECRET || 'secret',
+    { expiresIn: '1h' }
+  );
+  res.json({ token, user: { id: user._id, role: user.role, username: user.username, employeeId } });
 });
 
 router.post('/logout', async (req, res) => {

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -2,22 +2,23 @@ import request from 'supertest'
 import express from 'express'
 import { jest } from '@jest/globals'
 import jwt from 'jsonwebtoken'
-import { isTokenBlacklisted } from '../src/utils/tokenBlacklist.js'
 
 const compareMock = jest.fn();
 const fakeUser = { _id: 'u1', role: 'employee', username: 'john', employee: 'e1', comparePassword: compareMock };
 const mockUser = { findOne: jest.fn() };
 const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
 
-jest.mock('../src/models/User.js', () => ({ default: mockUser }), { virtual: true });
-jest.mock('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }), { virtual: true });
+jest.unstable_mockModule('../src/models/User.js', () => ({ default: mockUser }));
+jest.unstable_mockModule('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }));
 
 let app;
 let authRoutes;
+let isTokenBlacklisted;
 
 beforeAll(async () => {
   process.env.JWT_SECRET = 'secret';
   authRoutes = (await import('../src/routes/authRoutes.js')).default;
+  ({ isTokenBlacklisted } = await import('../src/utils/tokenBlacklist.js'));
   app = express();
   app.use(express.json());
   app.use('/api', authRoutes);

--- a/server/tests/supervisorSchedule.test.js
+++ b/server/tests/supervisorSchedule.test.js
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const mockShiftSchedule = { findOne: jest.fn(), create: jest.fn(), insertMany: jest.fn() };
+const mockLeaveRequest = { findOne: jest.fn() };
+const mockEmployee = { findById: jest.fn() };
+const mockUser = { findById: jest.fn() };
+
+jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
+jest.unstable_mockModule('../src/models/LeaveRequest.js', () => ({ default: mockLeaveRequest }));
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
+jest.unstable_mockModule('../src/models/User.js', () => ({ default: mockUser }));
+
+let app;
+let scheduleRoutes;
+
+beforeAll(async () => {
+  scheduleRoutes = (await import('../src/routes/scheduleRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.user = { id: 'u1', role: 'supervisor' };
+    next();
+  });
+  app.use('/api/schedules', scheduleRoutes);
+});
+
+beforeEach(() => {
+  mockShiftSchedule.findOne.mockReset();
+  mockShiftSchedule.create.mockReset();
+  mockShiftSchedule.insertMany.mockReset();
+  mockLeaveRequest.findOne.mockReset();
+  mockEmployee.findById.mockReset();
+  mockUser.findById.mockReset();
+});
+
+describe('Supervisor schedule permissions', () => {
+  it('allows supervisor to create schedule for own employee', async () => {
+    mockUser.findById.mockReturnValue({
+      populate: jest.fn().mockResolvedValue({ _id: 'u1', role: 'supervisor', employee: null, supervisor: 'sup1' })
+    });
+    mockEmployee.findById.mockResolvedValue({ _id: 'emp1', supervisor: 'sup1' });
+    mockShiftSchedule.findOne.mockResolvedValue(null);
+    mockLeaveRequest.findOne.mockResolvedValue(null);
+    mockShiftSchedule.create.mockResolvedValue({ _id: 'sch1' });
+
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ employee: 'emp1', date: '2023-01-01', shiftId: 'day' });
+
+    expect(res.status).toBe(201);
+    expect(mockShiftSchedule.create).toHaveBeenCalled();
+  });
+
+  it('rejects batch creation if any employee not under supervisor', async () => {
+    mockUser.findById.mockReturnValue({
+      populate: jest.fn().mockResolvedValue({ _id: 'u1', role: 'supervisor', employee: null, supervisor: 'sup1' })
+    });
+    mockEmployee.findById.mockImplementation((id) => {
+      if (id === 'emp1') return Promise.resolve({ _id: 'emp1', supervisor: 'sup1' });
+      if (id === 'emp2') return Promise.resolve({ _id: 'emp2', supervisor: 'other' });
+      return Promise.resolve(null);
+    });
+
+    const payload = {
+      schedules: [
+        { employee: 'emp1', date: '2023-01-01', shiftId: 'day' },
+        { employee: 'emp2', date: '2023-01-02', shiftId: 'day' }
+      ]
+    };
+
+    const res = await request(app).post('/api/schedules/batch').send(payload);
+
+    expect(res.status).toBe(403);
+    expect(mockShiftSchedule.insertMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- verify supervisor access using multiple user identifiers and validate all target employees
- include supervisor employeeId in login token and response
- add tests for supervisor schedule creation and authentication

## Testing
- `npm test tests/auth.test.js tests/supervisorSchedule.test.js`
- `npm test` *(fails: require is not defined in existing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a6af4ea16083299a1c1521499a2626