### PR TITLE
feat: filter sub-departments in employee form

### DIFF
--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -40,4 +40,23 @@ describe('EmployeeManagement.vue', () => {
     expect(wrapper.vm.supervisorList.length).toBe(1)
     expect(wrapper.vm.supervisorList[0]._id).toBe('s1')
   })
+
+  it('filters subDepartments and renders select field', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
+    wrapper.vm.employeeForm.department = 'd1'
+    await wrapper.vm.$nextTick()
+    wrapper.vm.subDepartmentList = [
+      { _id: 'sd1', name: 'SD1', department: 'd1' },
+      { _id: 'sd2', name: 'SD2', department: 'd2' }
+    ]
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.filteredSubDepartments.length).toBe(1)
+    expect(wrapper.vm.filteredSubDepartments[0]._id).toBe('sd1')
+    wrapper.vm.openEmployeeDialog()
+    await wrapper.vm.$nextTick()
+    const subDeptItem = wrapper
+      .findAllComponents({ name: 'ElFormItem' })
+      .find(w => w.props('label') === '小單位/區域(C02-1)')
+    expect(subDeptItem.findComponent({ name: 'ElSelect' }).exists()).toBe(true)
+  })
 })

--- a/server/src/controllers/subDepartmentController.js
+++ b/server/src/controllers/subDepartmentController.js
@@ -2,7 +2,8 @@ import SubDepartment from '../models/SubDepartment.js';
 
 export async function listSubDepartments(req, res) {
   try {
-    const subDepts = await SubDepartment.find();
+    const filter = req.query.department ? { department: req.query.department } : {};
+    const subDepts = await SubDepartment.find(filter);
     res.json(subDepts);
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- allow querying sub-departments by department
- load and filter sub-departments on employee form
- test sub-department filtering

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading '_id'))*
- `npm --prefix client test` *(fails: expected '' to be '25%')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c49dc7e4832987ee6c00d85cacec