### PR TITLE
fix file buffer handling

### DIFF
--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -309,7 +309,7 @@ function selectLeave() {
 }
 const fieldList = ref([])
 const workflowSteps = ref([])
-const fileBuffers = reactive({}) // { fieldId: [FileItem...] }
+const fileBuffers = ref({}) // { fieldId: [FileItem...] }
 const submitting = ref(false)
 const applyError = ref('')
 
@@ -415,9 +415,9 @@ async function submitApply() {
   try {
     // 先把 fileBuffers 轉成檔名陣列（或在這裡改為實際上傳並回寫檔案 URL）
     const payloadData = { ...applyState.formData }
-    Object.keys(fileBuffers).forEach(fid => {
-      const files = fileBuffers[fid] || []
-      payloadData[fid] = files.map(f => f.name)
+    Object.keys(fileBuffers.value).forEach(fid => {
+      const files = fileBuffers.value[fid] || []
+      payloadData[fid] = Array.isArray(files) ? files.map(f => f.name) : []
     })
 
     applyError.value = ''

--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -51,4 +51,25 @@ describe('Approval.vue', () => {
     expect(wrapper.vm.workflowSteps[0].approvers).toBe('Alice')
     window.fetch.mockRestore()
   })
+
+  it('submits form with file upload without error', async () => {
+    vi.spyOn(window, 'fetch').mockImplementation(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const wrapper = shallowMount(Approval, { global: { stubs } })
+    await flushPromises()
+
+    wrapper.vm.applyState.formId = 'f1'
+    wrapper.vm.applyState.formData = { f2: 'text' }
+    wrapper.vm.fileBuffers = { f3: [{ name: 'a.txt' }] }
+
+    await wrapper.vm.submitApply()
+    await flushPromises()
+
+    const postCall = window.fetch.mock.calls.find(([url, opt]) => url.includes('/api/approvals') && opt?.method === 'POST')
+    expect(postCall).toBeTruthy()
+    expect(postCall[1].body).toContain('"f3":["a.txt"]')
+    expect(wrapper.vm.applyError).toBe('')
+    window.fetch.mockRestore()
+    alertSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- fix Approval form file buffer handling
- add regression test for file upload submission

## Testing
- `npm test` (fails: ReferenceError: require is not defined)
- `npm --prefix client test -- tests/approval.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68a703eb1ff4832996bd73fcb347643d