### PR TITLE
feat: allow employee role to view org data

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -244,7 +244,7 @@ app.use(
   authenticate,
   (req, res, next) => {
     if (req.method === 'GET') {
-      return authorizeRoles('admin', 'supervisor')(req, res, next);
+      return authorizeRoles('admin', 'supervisor', 'employee')(req, res, next);
     }
     return authorizeRoles('admin')(req, res, next);
   },
@@ -284,8 +284,28 @@ app.use('/api/insurance', authenticate, authorizeRoles('admin'), insuranceRoutes
 app.use('/api/approvals', authenticate, approvalRoutes);
 app.use('/api/menu', authenticate, menuRoutes);
 app.use('/api/users', authenticate, authorizeRoles('admin'), userRoutes);
-app.use('/api/departments', authenticate, authorizeRoles('admin'), departmentRoutes);
-app.use('/api/organizations', authenticate, authorizeRoles('admin'), organizationRoutes);
+app.use(
+  '/api/departments',
+  authenticate,
+  (req, res, next) => {
+    if (req.method === 'GET') {
+      return authorizeRoles('admin', 'supervisor', 'employee')(req, res, next);
+    }
+    return authorizeRoles('admin')(req, res, next);
+  },
+  departmentRoutes
+);
+app.use(
+  '/api/organizations',
+  authenticate,
+  (req, res, next) => {
+    if (req.method === 'GET') {
+      return authorizeRoles('admin', 'supervisor', 'employee')(req, res, next);
+    }
+    return authorizeRoles('admin')(req, res, next);
+  },
+  organizationRoutes
+);
 app.use('/api/sub-departments', authenticate, authorizeRoles('admin'), subDepartmentRoutes);
 app.use('/api/dept-schedules', authenticate, authorizeRoles('admin'), deptScheduleRoutes);
 


### PR DESCRIPTION
## Summary
- allow employee role to GET employees, departments and organizations
- cover employee access in tests

## Testing
- `npm --prefix server test tests/employee.test.js tests/department.test.js tests/organization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7161a4fa48329901cd7b2869998ae