### PR TITLE
調整待簽清單查詢邏輯並新增測試

### DIFF
--- a/server/src/controllers/approvalRequestController.js
+++ b/server/src/controllers/approvalRequestController.js
@@ -158,10 +158,10 @@ export async function inboxApprovals(req, res) {
     // 找出目前關卡包含我，且我的 decision 是 pending 的
     const list = await ApprovalRequest.find({
       status: 'pending',
-      $expr: { $eq: ['$current_step_index', { $indexOfArray: ['$steps.step_order', { $add: [ '$current_step_index', 1 ] }] }] } // 只是保險；也可不寫
-    })
-      .populate('form', 'name category')
-    // 因為上面 $expr 寫起來繁瑣，這裡用程式過濾較直觀：
+      'steps.approvers.approver': empId,
+      'steps.approvers.decision': 'pending',
+    }).populate('form', 'name category')
+    // 仍以程式邏輯判斷是否為當前關卡：
     const mine = list.filter(doc => {
       const step = doc.steps?.[doc.current_step_index]
       if (!step) return false

--- a/server/tests/inboxApprovals.test.js
+++ b/server/tests/inboxApprovals.test.js
@@ -1,0 +1,44 @@
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+
+const mockApprovalRequest = { find: jest.fn() }
+const mockUser = { findById: jest.fn() }
+
+let app
+let inboxApprovals
+
+beforeAll(async () => {
+  await jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }))
+  await jest.unstable_mockModule('../src/models/User.js', () => ({ default: mockUser }))
+  ;({ inboxApprovals } = await import('../src/controllers/approvalRequestController.js'))
+  app = express()
+  app.use(express.json())
+  app.get('/api/approvals/inbox', inboxApprovals)
+})
+
+beforeEach(() => {
+  mockApprovalRequest.find.mockReset()
+  mockUser.findById.mockReset()
+})
+
+describe('inboxApprovals', () => {
+  it('returns pending approvals for employee', async () => {
+    const docs = [{
+      steps: [{ approvers: [{ approver: 'emp1', decision: 'pending' }] }],
+      current_step_index: 0,
+      form: { name: 'F', category: 'C' }
+    }]
+    mockApprovalRequest.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(docs) })
+
+    const res = await request(app).get('/api/approvals/inbox?employee_id=emp1')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(docs)
+    expect(mockApprovalRequest.find).toHaveBeenCalledWith({
+      status: 'pending',
+      'steps.approvers.approver': 'emp1',
+      'steps.approvers.decision': 'pending'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 移除 `$expr` 與 `$indexOfArray`，改以欄位條件與程式邏輯判斷當前關卡
- 新增 `/api/approvals/inbox` 測試，確認員工可取得待簽清單

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in existing suites)*
- `npm --prefix server test tests/inboxApprovals.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7161dc4908329a11e292eb5f22846