### PR TITLE
fix: expose inbox route before id

### DIFF
--- a/server/src/routes/approvalRoutes.js
+++ b/server/src/routes/approvalRoutes.js
@@ -32,9 +32,9 @@ router.put('/forms/:formId/workflow', authorizeRoles('admin'), setWorkflow)
 
 // Requests
 router.post('/', authorizeRoles('employee', 'supervisor', 'admin'), createApprovalRequest)
+router.get('/inbox', authorizeRoles('employee', 'supervisor', 'admin'), inboxApprovals)
 router.get('/:id', authorizeRoles('employee', 'supervisor', 'admin'), getApprovalRequest)
 router.get('/', authorizeRoles('employee', 'supervisor', 'admin'), myApprovalRequests)
-router.get('/inbox', authorizeRoles('employee', 'supervisor', 'admin'), inboxApprovals)
 router.post('/:id/act', authorizeRoles('employee', 'supervisor', 'admin'), actOnApproval)
 
 export default router


### PR DESCRIPTION
## Summary
- ensure /api/approvals/inbox is registered before the catch-all id route
- test supervisor inbox retrieval via router

## Testing
- `npm test tests/inboxApprovals.test.js`
- `npm test tests/user.test.js` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a7429f3d2c8329bf098a60847cd132