### PR TITLE
Translate workflow dialog headers to Chinese

### DIFF
--- a/client/src/components/backComponents/ApprovalFlowSetting.vue
+++ b/client/src/components/backComponents/ApprovalFlowSetting.vue
@@ -91,14 +91,14 @@
               <el-table-column label="#" width="60">
                 <template #default="{ $index }">{{ $index + 1 }}</template>
               </el-table-column>
-              <el-table-column label="Approver Type" width="150">
+              <el-table-column label="簽核類型" width="150">
                 <template #default="{ row }">
                   <el-select v-model="row.approver_type" placeholder="選擇類型" style="width:140px">
                     <el-option v-for="t in APPROVER_TYPES" :key="t" :label="t" :value="t" />
                   </el-select>
                 </template>
               </el-table-column>
-              <el-table-column label="Approver Value" width="200">
+              <el-table-column label="簽核對象" width="200">
                 <template #default="{ row }">
                   <el-select v-if="row.approver_type==='user'" v-model="row.approver_value" placeholder="選擇員工" multiple>
                     <el-option v-for="e in employeeOptions" :key="e.id" :label="e.name" :value="e.id" />
@@ -109,7 +109,7 @@
                   <el-input v-else v-model="row.approver_value" placeholder="userId/標籤/角色..." />
                 </template>
               </el-table-column>
-              <el-table-column label="Scope" width="120">
+              <el-table-column label="範圍" width="120">
                 <template #default="{ row }">
                   <el-select v-model="row.scope_type" style="width:110px">
                     <el-option label="none" value="none" />

--- a/client/tests/approvalFlowSetting.spec.js
+++ b/client/tests/approvalFlowSetting.spec.js
@@ -20,6 +20,21 @@ apiFetch.mockImplementation((url, opts) => {
 })
 
 describe('ApprovalFlowSetting approver select', () => {
+  it('renders Chinese headers in workflow dialog', async () => {
+    const wrapper = mount(ApprovalFlowSetting, {
+      global: { plugins: [ElementPlus], stubs: { teleport: true } }
+    })
+    await flushPromises()
+    await wrapper.vm.openWorkflowDialog({ _id: 'f1' })
+    await flushPromises()
+    const headers = wrapper
+      .findAll('.el-dialog .el-table th .cell')
+      .map(h => h.text())
+    expect(headers).toContain('簽核類型')
+    expect(headers).toContain('簽核對象')
+    expect(headers).toContain('範圍')
+  })
+
   it('loads options and saves selected id', async () => {
     const wrapper = mount(ApprovalFlowSetting, { global: { plugins: [ElementPlus] } })
     await flushPromises()


### PR DESCRIPTION
## Summary
- localize workflow dialog table headers
- verify headers via new unit test

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*
- `npm --prefix client test` *(fails: component resolution errors)*
- `npm run dev` *(fails: Missing required environment variables: PORT, MONGODB_URI, JWT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a75fdbd8808329b664361ba41cea13