### PR TITLE
feat: filter employees by subDepartment

### DIFF
--- a/server/src/controllers/employeeController.js
+++ b/server/src/controllers/employeeController.js
@@ -360,12 +360,13 @@ function buildEmployeePatch(body = {}, existing = null) {
 /** GET /api/employees?q=...&supervisor=...&organization=...&department=...&status=...&role=... */
 export async function listEmployees(req, res) {
   try {
-    const { q, supervisor, organization, department, status, role } = req.query
+    const { q, supervisor, organization, department, subDepartment, status, role } = req.query
     const filter = {}
 
     if (supervisor) filter.supervisor = supervisor
     if (organization) filter.organization = organization
     if (department) filter.department = department
+    if (subDepartment) filter.subDepartment = subDepartment
     if (status) filter.status = status
     if (role) filter.role = role
     if (q) {

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -56,6 +56,16 @@ describe('Employee API', () => {
     expect(res.body).toEqual(fakeEmployees);
   });
 
+  it('lists employees filtered by subDepartment', async () => {
+    const fakeEmployees = [{ name: 'Alice' }];
+    const populate = jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue(fakeEmployees) });
+    mockEmployee.find.mockReturnValue({ populate });
+    const res = await request(app).get('/api/employees?subDepartment=sd1');
+    expect(res.status).toBe(200);
+    expect(mockEmployee.find).toHaveBeenCalledWith({ subDepartment: 'sd1' });
+    expect(res.body).toEqual(fakeEmployees);
+  });
+
   it('lists employee options', async () => {
     const opts = [{ _id: '1', name: 'A' }];
     mockEmployee.find.mockResolvedValue(opts);


### PR DESCRIPTION
## Summary
- parse `subDepartment` from query in `listEmployees`
- add tests to verify filtering by subDepartment

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*
- `npm --prefix server test server/tests/employee.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7fec8ff2083298e04e3bfe0403360