### PR TITLE
feat(schedule): allow department override

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -50,19 +50,47 @@
         <template #default="{ row }">
           <div :class="{ 'is-leave': scheduleMap[row._id]?.[d.date]?.leave }">
             <template v-if="scheduleMap[row._id]?.[d.date]">
-              <el-select
-                v-if="canEdit"
-                v-model="scheduleMap[row._id][d.date].shiftId"
-                placeholder=""
-                @change="val => onSelect(row._id, d.date, val)"
-              >
-                <el-option
-                  v-for="opt in shifts"
-                  :key="opt._id"
-                  :label="opt.code"
-                  :value="opt._id"
-                />
-              </el-select>
+              <template v-if="canEdit">
+                <el-select
+                  v-model="scheduleMap[row._id][d.date].shiftId"
+                  placeholder=""
+                  @change="val => onSelect(row._id, d.date, val)"
+                >
+                  <el-option
+                    v-for="opt in shifts"
+                    :key="opt._id"
+                    :label="opt.code"
+                    :value="opt._id"
+                  />
+                </el-select>
+                <el-select
+                  v-model="scheduleMap[row._id][d.date].department"
+                  placeholder="部門"
+                  size="small"
+                  style="margin-top:4px"
+                  @change="() => (scheduleMap[row._id][d.date].subDepartment = '')"
+                >
+                  <el-option
+                    v-for="dept in departments"
+                    :key="dept._id"
+                    :label="dept.name"
+                    :value="dept._id"
+                  />
+                </el-select>
+                <el-select
+                  v-model="scheduleMap[row._id][d.date].subDepartment"
+                  placeholder="單位"
+                  size="small"
+                  style="margin-top:4px"
+                >
+                  <el-option
+                    v-for="sub in subDepsFor(scheduleMap[row._id][d.date].department)"
+                    :key="sub._id"
+                    :label="sub.name"
+                    :value="sub._id"
+                  />
+                </el-select>
+              </template>
               <el-popover
                 v-else
                 v-if="shiftInfo(scheduleMap[row._id][d.date].shiftId)"
@@ -194,13 +222,23 @@ async function fetchSchedules() {
     employees.value.forEach(emp => {
       scheduleMap.value[emp._id] = {}
       ds.forEach(d => {
-        scheduleMap.value[emp._id][d.date] = { shiftId: '' }
+        scheduleMap.value[emp._id][d.date] = {
+          shiftId: '',
+          department: emp.departmentId,
+          subDepartment: emp.subDepartmentId
+        }
       })
     })
     data.forEach((s) => {
       const empId = s.employee?._id || s.employee
       const d = dayjs(s.date).date()
-      scheduleMap.value[empId][d] = { id: s._id, shiftId: s.shiftId }
+      const emp = employees.value.find(e => e._id === empId) || {}
+      scheduleMap.value[empId][d] = {
+        id: s._id,
+        shiftId: s.shiftId,
+        department: s.department || emp.departmentId,
+        subDepartment: s.subDepartment || emp.subDepartmentId
+      }
     })
 
     const res2 = await apiFetch(
@@ -233,13 +271,12 @@ async function saveAll() {
     Object.keys(scheduleMap.value[empId]).forEach(day => {
       const item = scheduleMap.value[empId][day]
       if (item.shiftId && !item.id) {
-        const emp = employees.value.find(e => e._id === empId)
         schedules.push({
           employee: empId,
           date: `${currentMonth.value}-${String(day).padStart(2, '0')}`,
           shiftId: item.shiftId,
-          department: emp?.departmentId,
-          subDepartment: emp?.subDepartmentId
+          department: item.department,
+          subDepartment: item.subDepartment
         })
       }
     })
@@ -302,7 +339,6 @@ async function onSelect(empId, day, value) {
   const dateStr = `${currentMonth.value}-${String(day).padStart(2, '0')}`
   const existing = scheduleMap.value[empId][day]
   const prev = existing.shiftId
-  const emp = employees.value.find(e => e._id === empId)
   if (existing && existing.id) {
     try {
       const res = await apiFetch(`/api/schedules/${existing.id}`, {
@@ -310,8 +346,8 @@ async function onSelect(empId, day, value) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           shiftId: value,
-          department: emp?.departmentId,
-          subDepartment: emp?.subDepartmentId
+          department: existing.department,
+          subDepartment: existing.subDepartment
         })
       })
       if (!res.ok) {
@@ -329,13 +365,18 @@ async function onSelect(empId, day, value) {
           employee: empId,
           date: dateStr,
           shiftId: value,
-          department: emp?.departmentId,
-          subDepartment: emp?.subDepartmentId
+          department: existing.department,
+          subDepartment: existing.subDepartment
         })
       })
       if (res.ok) {
         const saved = await res.json()
-        scheduleMap.value[empId][day] = { id: saved._id, shiftId: saved.shiftId }
+        scheduleMap.value[empId][day] = {
+          id: saved._id,
+          shiftId: saved.shiftId,
+          department: existing.department,
+          subDepartment: existing.subDepartment
+        }
       } else {
         await handleScheduleError(res, '新增排班失敗', empId, day, prev)
       }
@@ -378,6 +419,10 @@ async function handleScheduleError(res, defaultMsg, empId, day, prev) {
 
 function shiftInfo(id) {
   return shifts.value.find(s => s._id === id)
+}
+
+function subDepsFor(deptId) {
+  return subDepartments.value.filter(s => s.department === deptId)
 }
 
 async function fetchEmployees(department = '', subDepartment = '') {

--- a/server/tests/schedule.unit.test.js
+++ b/server/tests/schedule.unit.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 const mockShiftSchedule = {
   findOne: jest.fn(),
+  findById: jest.fn(),
   create: jest.fn(),
   insertMany: jest.fn(),
 };
@@ -14,7 +15,7 @@ jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: 
 jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: mockFormTemplate }));
 jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }));
 
-const { createSchedule, createSchedulesBatch } = await import('../src/controllers/scheduleController.js');
+const { createSchedule, createSchedulesBatch, updateSchedule } = await import('../src/controllers/scheduleController.js');
 
 describe('createSchedule validations', () => {
   beforeEach(() => {
@@ -62,6 +63,77 @@ describe('createSchedulesBatch validations', () => {
     await createSchedulesBatch(req, res);
     expect(status).toHaveBeenCalledWith(400);
     expect(json).toHaveBeenCalledWith({ error: 'leave conflict' });
+  });
+});
+
+describe('updateSchedule validations', () => {
+  beforeEach(() => {
+    mockShiftSchedule.findOne.mockReset();
+    mockShiftSchedule.findById.mockReset();
+    mockApprovalRequest.findOne.mockReset();
+    mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
+    mockFormField.find.mockResolvedValue([
+      { _id: 's', label: '開始日期' },
+      { _id: 'e', label: '結束日期' },
+    ]);
+  });
+
+  it('returns department overlap when updating to other dept with existing schedule', async () => {
+    mockShiftSchedule.findById.mockResolvedValue({
+      _id: '1',
+      employee: 'e1',
+      date: new Date('2023-01-01'),
+      department: 'd1',
+      subDepartment: 'sd1',
+    });
+    mockShiftSchedule.findOne.mockResolvedValue({
+      _id: '2',
+      department: 'd3',
+      subDepartment: 'sd3',
+    });
+    const req = {
+      params: { id: '1' },
+      body: { department: 'd2', subDepartment: 'sd2' },
+    };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+    await updateSchedule(req, res);
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'department overlap' });
+  });
+
+  it('updates schedule with new department when no conflict', async () => {
+    const saved = {
+      _id: '1',
+      employee: 'e1',
+      date: new Date('2023-01-01'),
+      shiftId: 's1',
+      department: 'd2',
+      subDepartment: 'sd2',
+    };
+    mockShiftSchedule.findById.mockResolvedValue({
+      _id: '1',
+      employee: 'e1',
+      date: new Date('2023-01-01'),
+      shiftId: 's1',
+      department: 'd1',
+      subDepartment: 'sd1',
+      save: jest.fn().mockResolvedValue(saved),
+    });
+    mockShiftSchedule.findOne.mockResolvedValue(null);
+    mockApprovalRequest.findOne.mockResolvedValue(null);
+
+    const req = {
+      params: { id: '1' },
+      body: { department: 'd2', subDepartment: 'sd2' },
+    };
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = { status, json };
+    await updateSchedule(req, res);
+    expect(status).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(saved);
   });
 });
 


### PR DESCRIPTION
## Summary
- allow choosing department/unit per schedule cell and save selected values
- enforce department override checks when updating schedules
- test schedule updates and client save flow

## Testing
- `npm test` (failed: ReferenceError require is not defined)
- `npm --prefix client test` (failed: component resolution errors)

------
https://chatgpt.com/codex/tasks/task_e_68a89bfd7b088329b95ac05f7a261e94