### PR TITLE
修正單位過濾的 ID 比對問題

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -117,7 +117,9 @@ const selectedDepartment = ref('')
 const selectedSubDepartment = ref('')
 
 const filteredSubDepartments = computed(() =>
-  subDepartments.value.filter(s => s.department === selectedDepartment.value)
+  subDepartments.value.filter(
+    s => String(s.department) === selectedDepartment.value
+  )
 )
 
 const router = useRouter()
@@ -170,7 +172,14 @@ async function fetchOptions() {
       apiFetch('/api/sub-departments')
     ])
     departments.value = deptRes.ok ? await deptRes.json() : []
-    subDepartments.value = subRes.ok ? await subRes.json() : []
+    const subData = subRes.ok ? await subRes.json() : []
+    subDepartments.value = Array.isArray(subData)
+      ? subData.map(s => ({
+          ...s,
+          _id: String(s._id),
+          department: String(s.department)
+        }))
+      : []
   } catch (err) {
     console.error(err)
   }

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -72,6 +72,30 @@ describe('Schedule.vue', () => {
     expect(wrapper.vm.shifts).toEqual([{ _id: 's1', code: 'S1', startTime: '08:00', endTime: '17:00', remark: 'R' }])
   })
 
+  it('filters subDepartments by stringified department id', async () => {
+    apiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: 'd1', name: 'Dept A' }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { _id: 'sd1', name: 'Sub A', department: { toString: () => 'd1' } }
+        ]
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ _id: 'e1', name: 'E1', department: 'd1', subDepartment: 'sd1' }]
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ approvals: [], leaves: [] }) })
+    const wrapper = mountSchedule()
+    await flush()
+    wrapper.vm.selectedDepartment = 'd1'
+    expect(wrapper.vm.filteredSubDepartments).toEqual([
+      { _id: 'sd1', name: 'Sub A', department: 'd1' }
+    ])
+  })
+
   it('reverts change when update fails', async () => {
     apiFetch
       .mockResolvedValueOnce({ ok: true, json: async () => [] })


### PR DESCRIPTION
## Summary
- 比對子單位時轉為字串避免 ObjectId 導致失敗
- 取得子單位資料時將 ID 字串化
- 新增測試覆蓋字串化部門 ID 的情境

## Testing
- `npm --prefix server test` (失敗，ReferenceError: require is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a88123991083299e6112f9736703f9