### PR TITLE
允許主管查詢小單位並更新排班頁面

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -204,7 +204,8 @@ async function fetchSubDepartments(dept = '') {
   try {
     const url = dept ? `/api/sub-departments?department=${dept}` : '/api/sub-departments'
     const res = await apiFetch(url)
-    const subData = res.ok ? await res.json() : []
+    if (!res.ok) throw new Error('Failed to fetch sub departments')
+    const subData = await res.json()
     const deptMap = departments.value.reduce((acc, d) => {
       acc[d._id] = d._id
       acc[d.name] = d._id
@@ -221,9 +222,13 @@ async function fetchSubDepartments(dept = '') {
           return { ...s, _id: String(s._id), department: String(deptId) }
         })
       : []
+    if (subDepartments.value.length && !selectedSubDepartment.value) {
+      selectedSubDepartment.value = subDepartments.value[0]._id
+    }
   } catch (err) {
     console.error(err)
     subDepartments.value = []
+    selectedSubDepartment.value = ''
   }
 }
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -306,7 +306,12 @@ app.use(
   },
   organizationRoutes
 );
-app.use('/api/sub-departments', authenticate, authorizeRoles('admin'), subDepartmentRoutes);
+app.use(
+  '/api/sub-departments',
+  authenticate,
+  authorizeRoles('admin', 'supervisor'),
+  subDepartmentRoutes
+);
 app.use('/api/dept-schedules', authenticate, authorizeRoles('admin'), deptScheduleRoutes);
 
 app.use('/api/dept-managers', authenticate, authorizeRoles('admin'), deptManagerRoutes);

--- a/server/src/routes/subDepartmentRoutes.js
+++ b/server/src/routes/subDepartmentRoutes.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { authorizeRoles } from '../middleware/auth.js';
 import {
   listSubDepartments,
   createSubDepartment,
@@ -8,9 +9,9 @@ import {
 
 const router = Router();
 
-router.get('/', listSubDepartments);
-router.post('/', createSubDepartment);
-router.put('/:id', updateSubDepartment);
-router.delete('/:id', deleteSubDepartment);
+router.get('/', authorizeRoles('admin', 'supervisor'), listSubDepartments);
+router.post('/', authorizeRoles('admin'), createSubDepartment);
+router.put('/:id', authorizeRoles('admin'), updateSubDepartment);
+router.delete('/:id', authorizeRoles('admin'), deleteSubDepartment);
 
 export default router;


### PR DESCRIPTION
## Summary
- 開放主管存取小單位 API，仍限制新增與變更須由管理員操作
- 排班頁面成功取得小單位資料後自動填入選單

## Testing
- `npm test` *(失敗：ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9330728088329952eae4b5419f295