### PR TITLE
處理逾時 token 自動導向登入頁

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,4 +1,4 @@
-import { getToken } from './utils/tokenService'
+import { getToken, clearToken } from './utils/tokenService'
 
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
@@ -9,5 +9,11 @@ export function apiFetch(path, options = {}) {
     ...(options.headers || {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {})
   }
-  return fetch(`${API_BASE_URL}${path}`, { ...options, headers })
+  return fetch(`${API_BASE_URL}${path}`, { ...options, headers }).then(res => {
+    if (res.status === 401) {
+      clearToken()
+      window.location.href = '/login'
+    }
+    return res
+  })
 }

--- a/client/tests/api.spec.js
+++ b/client/tests/api.spec.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { apiFetch } from '../src/api'
+import { clearToken } from '../src/utils/tokenService'
+
+vi.mock('../src/utils/tokenService', () => ({
+  getToken: vi.fn(() => 't'),
+  clearToken: vi.fn()
+}))
+
+describe('apiFetch', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '' }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.location = originalLocation
+  })
+
+  it('redirects to login on 401', async () => {
+    fetch.mockResolvedValueOnce({ status: 401 })
+    await apiFetch('/test')
+    expect(clearToken).toHaveBeenCalled()
+    expect(window.location.href).toBe('/login')
+  })
+
+  it('returns response on success', async () => {
+    const response = { status: 200 }
+    fetch.mockResolvedValueOnce(response)
+    const res = await apiFetch('/ok')
+    expect(res).toBe(response)
+    expect(clearToken).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- 401 回應時清除 token 並轉址登入頁
- 新增 apiFetch 401 行為測試

## Testing
- `npm test` *(fails: SalarySetting API creates setting, Report API creates report)*
- `npm --prefix client test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68ac267d94f4832997203f5bedd3e81e