### PR TITLE
feat: add refresh token support

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,13 +1,36 @@
-import { getToken } from './utils/tokenService'
+import { getToken, getRefreshToken, setToken, clearToken, clearRefreshToken } from './utils/tokenService'
 
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
 
-export function apiFetch(path, options = {}) {
+export async function apiFetch(path, options = {}) {
   const token = getToken()
   const headers = {
     ...(options.headers || {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {})
   }
-  return fetch(`${API_BASE_URL}${path}`, { ...options, headers })
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers })
+  if (res.status === 401 && path !== '/api/refresh') {
+    const refresh = getRefreshToken()
+    if (refresh) {
+      const refreshRes = await fetch(`${API_BASE_URL}/api/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken: refresh })
+      })
+      if (refreshRes.ok) {
+        const data = await refreshRes.json()
+        setToken(data.token)
+        const retryHeaders = {
+          ...(options.headers || {}),
+          Authorization: `Bearer ${data.token}`
+        }
+        return fetch(`${API_BASE_URL}${path}`, { ...options, headers: retryHeaders })
+      } else {
+        clearToken()
+        clearRefreshToken()
+      }
+    }
+  }
+  return res
 }

--- a/client/src/utils/tokenService.js
+++ b/client/src/utils/tokenService.js
@@ -50,3 +50,15 @@ export function clearToken() {
   localStorage.removeItem('token');
   localStorage.removeItem('token_expires');
 }
+
+export function setRefreshToken(token) {
+  localStorage.setItem('refresh_token', token);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem('refresh_token');
+}
+
+export function clearRefreshToken() {
+  localStorage.removeItem('refresh_token');
+}

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -100,7 +100,7 @@ import { useRouter } from 'vue-router'
 import { useMenuStore } from '../stores/menu'
 import { storeToRefs } from 'pinia'
 import { apiFetch } from '../api'
-import { setToken } from '../utils/tokenService'
+import { setToken, setRefreshToken } from '../utils/tokenService'
 import { ElMessage } from 'element-plus'
 
 const router = useRouter()
@@ -143,6 +143,7 @@ const onLogin = async () => {
     if (res.ok) {
       const data = await res.json()
       setToken(data.token)
+      setRefreshToken(data.refreshToken)
       localStorage.setItem('role', data.user.role)
       localStorage.setItem('employeeId', data.user.employeeId)
       

--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -51,7 +51,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMenuStore } from '../stores/menu'
-import { clearToken } from '../utils/tokenService'
+import { clearToken, clearRefreshToken } from '../utils/tokenService'
 import { storeToRefs } from 'pinia'
 
 const router = useRouter()
@@ -77,6 +77,7 @@ function toggleCollapse() {
 
 function logout() {
   clearToken()
+  clearRefreshToken()
   localStorage.removeItem('role')
   localStorage.removeItem('employeeId')
   router.push('/')

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -9,12 +9,13 @@
   
   <script setup>
 import { useRouter } from 'vue-router'
-import { clearToken } from '../utils/tokenService'
+import { clearToken, clearRefreshToken } from '../utils/tokenService'
   
   const router = useRouter()
   
 const logout = () => {
   clearToken()
+  clearRefreshToken()
   localStorage.removeItem('role')
   localStorage.removeItem('employeeId')
   router.push('/')

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -54,7 +54,7 @@
 import { ref, onMounted, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { useMenuStore } from "../../stores/menu";
-import { clearToken } from "../../utils/tokenService";
+import { clearToken, clearRefreshToken } from "../../utils/tokenService";
 import { storeToRefs } from "pinia";
 
 const router = useRouter();
@@ -85,6 +85,7 @@ function onLogout() {
   localStorage.removeItem("role");
   localStorage.removeItem("username");
   clearToken();
+  clearRefreshToken();
   router.push(`/`);
 }
 </script>

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -134,7 +134,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMenuStore } from '../../stores/menu'
 import { apiFetch } from '../../api'
-import { setToken } from '../../utils/tokenService'
+import { setToken, setRefreshToken } from '../../utils/tokenService'
 import { ElMessage } from 'element-plus'
 
 const router = useRouter()
@@ -206,6 +206,7 @@ async function onLogin() {
     
     if (res.ok) {
       setToken(data.token)
+      setRefreshToken(data.refreshToken)
       localStorage.setItem('role', data.user.role)
       localStorage.setItem('employeeId', data.user.employeeId)
       

--- a/client/tests/api.spec.js
+++ b/client/tests/api.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../src/utils/tokenService', () => ({
+  getToken: vi.fn(() => 'old'),
+  getRefreshToken: vi.fn(() => 'ref'),
+  setToken: vi.fn(),
+  clearToken: vi.fn(),
+  clearRefreshToken: vi.fn()
+}))
+
+import { getToken, getRefreshToken, setToken } from '../src/utils/tokenService'
+import { apiFetch } from '../src/api'
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  it('refreshes token on 401 and retries request', async () => {
+    global.fetch
+      .mockResolvedValueOnce({ status: 401 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'new' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    const res = await apiFetch('/api/protected')
+
+    expect(global.fetch).toHaveBeenNthCalledWith(1, expect.stringContaining('/api/protected'), expect.anything())
+    expect(global.fetch).toHaveBeenNthCalledWith(2, expect.stringContaining('/api/refresh'), expect.anything())
+    expect(global.fetch).toHaveBeenNthCalledWith(3, expect.stringContaining('/api/protected'), expect.anything())
+    expect(setToken).toHaveBeenCalledWith('new')
+    expect(res.ok).toBe(true)
+  })
+})

--- a/client/tests/tokenService.spec.js
+++ b/client/tests/tokenService.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { setToken, getToken, clearToken, _expiryTimeout } from '../src/utils/tokenService'
+import { setToken, getToken, clearToken, setRefreshToken, getRefreshToken, clearRefreshToken, _expiryTimeout } from '../src/utils/tokenService'
 
 function createToken(offset = 3600) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
@@ -31,5 +31,12 @@ describe('tokenService', () => {
     vi.runOnlyPendingTimers()
     expect(getToken()).toBeNull()
     expect(localStorage.getItem('token')).toBeNull()
+  })
+
+  it('stores and clears refresh token', () => {
+    setRefreshToken('ref')
+    expect(getRefreshToken()).toBe('ref')
+    clearRefreshToken()
+    expect(getRefreshToken()).toBeNull()
   })
 })

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -19,7 +19,28 @@ router.post('/login', async (req, res) => {
     process.env.JWT_SECRET || 'secret',
     { expiresIn: '1h' }
   );
-  res.json({ token, user: { id: user._id, role: user.role, username: user.username, employeeId } });
+  const refreshToken = jwt.sign(
+    { id: user._id, role: user.role, employeeId },
+    process.env.JWT_SECRET || 'secret',
+    { expiresIn: '7d' }
+  );
+  res.json({ token, refreshToken, user: { id: user._id, role: user.role, username: user.username, employeeId } });
+});
+
+router.post('/refresh', async (req, res) => {
+  const { refreshToken } = req.body;
+  if (!refreshToken) return res.status(401).json({ error: 'Invalid token' });
+  try {
+    const payload = jwt.verify(refreshToken, process.env.JWT_SECRET || 'secret');
+    const token = jwt.sign(
+      { id: payload.id, role: payload.role, employeeId: payload.employeeId },
+      process.env.JWT_SECRET || 'secret',
+      { expiresIn: '1h' }
+    );
+    res.json({ token });
+  } catch (e) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
 });
 
 router.post('/logout', async (req, res) => {


### PR DESCRIPTION
## Summary
- issue refresh token during login and expose `/api/refresh` for renewing access tokens
- manage refresh tokens on the client and auto-refresh expired access tokens
- cover refresh logic with new tests

## Testing
- `npm test` (server) *(fails: SalarySetting API, Report API)*
- `npm test tests/auth.test.js` (server)
- `npm test` (client) *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2680f2b4832995ee739762cb4ddf