### PR TITLE
fix: ensure sub-department loading on employee edit

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -868,7 +868,7 @@ watch(
 )
 
 /* 事件 --------------------------------------------------------------------- */
-function openEmployeeDialog(index = null) {
+async function openEmployeeDialog(index = null) {
   if (index !== null) {
     editEmployeeIndex = index
     const emp = employeeList.value[index]
@@ -881,8 +881,18 @@ function openEmployeeDialog(index = null) {
     employeeDialogTab.value = 'account'
     employeeForm.value = { ...structuredClone(emptyEmployee) }
   }
-  fetchDepartments()
-  fetchSubDepartments(employeeForm.value.department)
+
+  await fetchDepartments()
+  if (
+    employeeForm.value.department &&
+    !/^[0-9a-fA-F]{24}$/.test(employeeForm.value.department)
+  ) {
+    const dept = departmentList.value.find(
+      d => d.name === employeeForm.value.department
+    )
+    if (dept) employeeForm.value.department = dept._id
+  }
+  await fetchSubDepartments(employeeForm.value.department)
   employeeDialogVisible.value = true
 }
 

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -67,6 +67,30 @@ describe('EmployeeManagement.vue', () => {
     expect(subDeptItem.findComponent({ name: 'ElSelect' }).exists()).toBe(true)
   })
 
+  it('loads subDepartments when editing employee with department name', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { plugins: [ElementPlus] } })
+    const deptSpy = vi
+      .spyOn(wrapper.vm, 'fetchDepartments')
+      .mockImplementation(async () => {
+        wrapper.vm.departmentList = [{ _id: 'd1', name: 'D1' }]
+      })
+    const subSpy = vi
+      .spyOn(wrapper.vm, 'fetchSubDepartments')
+      .mockImplementation(async dept => {
+        wrapper.vm.subDepartmentList = [
+          { _id: 'sd1', name: 'SD1', department: dept }
+        ]
+      })
+    wrapper.vm.employeeList = [
+      { _id: 'e1', name: 'E1', department: 'D1', subDepartment: 'sd1' }
+    ]
+    await wrapper.vm.openEmployeeDialog(0)
+    expect(deptSpy).toHaveBeenCalled()
+    expect(subSpy).toHaveBeenCalledWith('d1')
+    expect(wrapper.vm.employeeForm.department).toBe('d1')
+    expect(wrapper.vm.subDepartmentList[0].department).toBe('d1')
+  })
+
   describe('401 handling', () => {
     const fns = ['fetchDepartments', 'fetchSubDepartments', 'fetchOrganizations', 'fetchEmployees']
 


### PR DESCRIPTION
## Summary
- await department fetch before opening employee dialog
- convert department names to ids and reload sub-departments
- test editing existing employee loads correct sub-department

## Testing
- `npm test` *(fails: SalarySetting API creates setting, Report API creates report)*
- `npm --prefix client test` *(fails: multiple client-side tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5b889088832993d1a5799cf1624d