### PR TITLE
feat(subdept): support department name query

### DIFF
--- a/server/src/controllers/subDepartmentController.js
+++ b/server/src/controllers/subDepartmentController.js
@@ -1,8 +1,24 @@
+import mongoose from 'mongoose';
 import SubDepartment from '../models/SubDepartment.js';
+import Department from '../models/Department.js';
 
 export async function listSubDepartments(req, res) {
   try {
-    const filter = req.query.department ? { department: req.query.department } : {};
+    const filter = {};
+    const { department } = req.query;
+
+    if (department) {
+      if (mongoose.Types.ObjectId.isValid(department)) {
+        filter.department = department;
+      } else {
+        const dept = await Department.findOne({ name: department });
+        if (!dept) {
+          return res.status(400).json({ error: 'Department not found' });
+        }
+        filter.department = dept._id;
+      }
+    }
+
     const subDepts = await SubDepartment.find(filter);
     res.json(subDepts);
   } catch (err) {

--- a/server/tests/subDepartment.test.js
+++ b/server/tests/subDepartment.test.js
@@ -7,8 +7,10 @@ const mockSubDepartment = jest.fn().mockImplementation(() => ({ save: saveMock }
 mockSubDepartment.find = jest.fn();
 mockSubDepartment.findByIdAndUpdate = jest.fn();
 mockSubDepartment.findByIdAndDelete = jest.fn();
+const mockDepartment = { findOne: jest.fn() };
 
 jest.unstable_mockModule('../src/models/SubDepartment.js', () => ({ default: mockSubDepartment }));
+jest.unstable_mockModule('../src/models/Department.js', () => ({ default: mockDepartment }));
 jest.unstable_mockModule('../src/middleware/auth.js', () => ({ authorizeRoles: () => (req, res, next) => next() }));
 
 let app;
@@ -26,6 +28,7 @@ beforeEach(() => {
   mockSubDepartment.find.mockReset();
   mockSubDepartment.findByIdAndUpdate.mockReset();
   mockSubDepartment.findByIdAndDelete.mockReset();
+  mockDepartment.findOne.mockReset();
 });
 
 describe('SubDepartment API', () => {
@@ -33,6 +36,30 @@ describe('SubDepartment API', () => {
     mockSubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
     const res = await request(app).get('/api/sub-departments');
     expect(res.status).toBe(200);
+  });
+
+  it('lists sub-departments by department id', async () => {
+    const id = '507f1f77bcf86cd799439011';
+    mockSubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
+    const res = await request(app).get(`/api/sub-departments?department=${id}`);
+    expect(res.status).toBe(200);
+    expect(mockSubDepartment.find).toHaveBeenCalledWith({ department: id });
+    expect(mockDepartment.findOne).not.toHaveBeenCalled();
+  });
+
+  it('lists sub-departments by department name', async () => {
+    mockDepartment.findOne.mockResolvedValue({ _id: '507f1f77bcf86cd799439012' });
+    mockSubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
+    const res = await request(app).get('/api/sub-departments?department=HR');
+    expect(res.status).toBe(200);
+    expect(mockDepartment.findOne).toHaveBeenCalledWith({ name: 'HR' });
+    expect(mockSubDepartment.find).toHaveBeenCalledWith({ department: '507f1f77bcf86cd799439012' });
+  });
+
+  it('returns 400 when department not found', async () => {
+    mockDepartment.findOne.mockResolvedValue(null);
+    const res = await request(app).get('/api/sub-departments?department=Unknown');
+    expect(res.status).toBe(400);
   });
 
   it('creates sub-department', async () => {


### PR DESCRIPTION
## Summary
- allow sub-department listing by department id or name
- handle invalid department query with 400 response
- test coverage for id, name, and not-found cases

## Testing
- `npm test` *(fails: salarySetting.test.js, report.test.js)*
- `npm --prefix server test tests/subDepartment.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b82f13483299597cce49a2874c1