### PR TITLE
feat: redirect 401 to appropriate login

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -12,7 +12,10 @@ export function apiFetch(path, options = {}) {
   return fetch(`${API_BASE_URL}${path}`, { ...options, headers }).then(res => {
     if (res.status === 401) {
       clearToken()
-      window.location.href = '/login'
+      const path = window.location.pathname || ''
+      window.location.href = path.startsWith('/manager')
+        ? '/manager/login'
+        : '/login'
     }
     return res
   })

--- a/client/tests/api.spec.js
+++ b/client/tests/api.spec.js
@@ -14,7 +14,7 @@ describe('apiFetch', () => {
     vi.stubGlobal('fetch', vi.fn())
     Object.defineProperty(window, 'location', {
       writable: true,
-      value: { href: '' }
+      value: { href: '', pathname: '' }
     })
   })
 
@@ -23,11 +23,20 @@ describe('apiFetch', () => {
     window.location = originalLocation
   })
 
-  it('redirects to login on 401', async () => {
+  it('redirects to login on 401 for frontend path', async () => {
+    window.location.pathname = '/profile'
     fetch.mockResolvedValueOnce({ status: 401 })
     await apiFetch('/test')
     expect(clearToken).toHaveBeenCalled()
     expect(window.location.href).toBe('/login')
+  })
+
+  it('redirects to manager login on 401 for backend path', async () => {
+    window.location.pathname = '/manager/dashboard'
+    fetch.mockResolvedValueOnce({ status: 401 })
+    await apiFetch('/test')
+    expect(clearToken).toHaveBeenCalled()
+    expect(window.location.href).toBe('/manager/login')
   })
 
   it('returns response on success', async () => {


### PR DESCRIPTION
## Summary
- redirect 401 responses to manager or user login based on current path
- add tests for manager and frontend 401 redirects

## Testing
- `npm test` *(fails: approvalFlowSetting.spec.js, schedule.spec.js)*
- `npm --prefix client test tests/api.spec.js -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af2de307ec8329b4567110f95fb379