### PR TITLE
feat(router): enforce backend roles

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -116,16 +116,23 @@ const router = createRouter({
 
 // ★ 路由守衛
 router.beforeEach((to, from, next) => {
-  // 簡易示範: 後台 requiresAuth
-  if (to.meta.requiresAuth) {
+  const requiresAuth = to.matched.some(r => r.meta.requiresAuth)
+  const frontRequiresAuth = to.matched.some(r => r.meta.frontRequiresAuth)
+
+  // 後台登入檢查
+  if (requiresAuth) {
     const token = getToken()
     if (!token) {
       return next({ name: 'ManagerLogin' })
     }
+    const userRole = localStorage.getItem('role') || 'employee'
+    if (!['supervisor', 'admin'].includes(userRole)) {
+      return next('/login')
+    }
   }
 
-  // 若要檢查前台也需登入
-  if (to.meta.frontRequiresAuth) {
+  // 前台登入檢查
+  if (frontRequiresAuth) {
     const token = getToken()
     if (!token) {
       return next({ name: 'FrontLogin' })

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -51,14 +51,31 @@ describe('router', () => {
   it('role guard blocks unauthorized user', () => {
     localStorage.setItem('role', 'employee')
     const next = vi.fn()
-    capturedGuard({ meta: { roles: ['supervisor'] } }, {}, next)
+    capturedGuard({ matched: [], meta: { roles: ['supervisor'] } }, {}, next)
     expect(next).toHaveBeenCalledWith({ name: 'Forbidden' })
   })
 
   it('role guard allows employee when permitted', () => {
     localStorage.setItem('role', 'employee')
     const next = vi.fn()
-    capturedGuard({ meta: { roles: ['employee', 'supervisor', 'admin'] } }, {}, next)
+    capturedGuard({ matched: [], meta: { roles: ['employee', 'supervisor', 'admin'] } }, {}, next)
+    expect(next).toHaveBeenCalled()
+    expect(next.mock.calls[0][0]).toBeUndefined()
+  })
+
+  it('backend guard redirects non-supervisor', () => {
+    localStorage.setItem('token', 't')
+    localStorage.setItem('role', 'employee')
+    const next = vi.fn()
+    capturedGuard({ matched: [{ meta: { requiresAuth: true } }], meta: {} }, {}, next)
+    expect(next).toHaveBeenCalledWith('/login')
+  })
+
+  it('backend guard allows supervisor', () => {
+    localStorage.setItem('token', 't')
+    localStorage.setItem('role', 'supervisor')
+    const next = vi.fn()
+    capturedGuard({ matched: [{ meta: { requiresAuth: true } }], meta: {} }, {}, next)
     expect(next).toHaveBeenCalled()
     expect(next.mock.calls[0][0]).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- 使用 `to.matched.some` 改寫路由守衛，新增後台角色檢查
- 補強路由單元測試，驗證不同角色之存取控制

## Testing
- `npm --prefix server test`
- `cd client && npx vitest run tests/router.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68af3c84d4e08329a9d61caebed09c51