### PR TITLE
feat: route by role after login

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -147,13 +147,17 @@ const onLogin = async () => {
       localStorage.setItem('employeeId', data.user.employeeId)
       
       ElMessage.success('登入成功！')
-      
-      await menuStore.fetchMenu()
-      const first = menuStore.items[0]
-      if (first) {
-        router.push({ name: first.name })
-      } else {
-        router.push({ name: 'ManagerLogin' })
+
+      if (data.user.role === 'supervisor') {
+        router.push('/front/schedule')
+      } else if (data.user.role === 'admin') {
+        await menuStore.fetchMenu()
+        const first = menuStore.items[0]
+        if (first) {
+          router.push({ name: first.name })
+        } else {
+          router.push('/manager')
+        }
       }
     } else {
       const errorData = await res.json()

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import Login from '../src/views/Login.vue'
+
+function createToken(offset = 3600) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + offset })).toString('base64')
+  return `${header}.${payload}.sig`
+}
+
+const push = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push })
+}))
+vi.mock('element-plus', () => ({ ElMessage: { success: vi.fn(), error: vi.fn() } }))
+
+describe('Login.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('fetch', vi.fn())
+    localStorage.clear()
+    push.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('redirects supervisor to schedule', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: createToken(), user: { role: 'supervisor', employeeId: 'e1' } })
+    })
+    const wrapper = mount(Login)
+    wrapper.vm.loginFormRef = { validate: async () => true }
+    wrapper.vm.loginForm.username = 'u'
+    wrapper.vm.loginForm.password = 'p'
+    await wrapper.vm.onLogin()
+    expect(localStorage.getItem('role')).toBe('supervisor')
+    expect(push).toHaveBeenCalledWith('/front/schedule')
+  })
+
+  it('redirects admin to first menu item', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: createToken(), user: { role: 'admin', employeeId: 'a1' } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{ name: 'Settings' }])
+      })
+    const wrapper = mount(Login)
+    wrapper.vm.loginFormRef = { validate: async () => true }
+    wrapper.vm.loginForm.username = 'u'
+    wrapper.vm.loginForm.password = 'p'
+    await wrapper.vm.onLogin()
+    expect(push).toHaveBeenCalledWith({ name: 'Settings' })
+  })
+
+  it('redirects admin to /manager when menu empty', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: createToken(), user: { role: 'admin', employeeId: 'a1' } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([]) 
+      })
+    const wrapper = mount(Login)
+    wrapper.vm.loginFormRef = { validate: async () => true }
+    wrapper.vm.loginForm.username = 'u'
+    wrapper.vm.loginForm.password = 'p'
+    await wrapper.vm.onLogin()
+    expect(push).toHaveBeenCalledWith('/manager')
+  })
+})


### PR DESCRIPTION
## Summary
- 根據登入者角色導向不同頁面
- menu 空時改導向 `/manager`
- 新增登入導向測試

## Testing
- `npm test` *(failed: ApprovalFlowSetting approver select renders Chinese headers; Schedule.vue floor label; Schedule.vue creates schedule after selecting department and unit)*

------
https://chatgpt.com/codex/tasks/task_e_68af41df53ac8329ac01c9b496ec0d02