### PR TITLE
前台顯示後台入口按鈕與測試

### DIFF
--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -31,6 +31,18 @@
           <span class="menu-label">{{ item.label }}</span>
         </el-menu-item>
       </el-menu>
+      <!-- 進入後台按鈕 -->
+      <div v-if="showManagerBtn" class="manager-section">
+        <el-button
+          type="primary"
+          @click="gotoManager"
+          class="manager-btn"
+          block
+          data-test="manager-btn"
+        >
+          進入後台
+        </el-button>
+      </div>
 
       <!-- 登出按鈕 -->
       <div class="logout-section">
@@ -64,6 +76,7 @@ const { items: menuItems } = storeToRefs(menuStore);
 
 const username = ref("");
 const activeMenu = computed(() => route.name?.toLowerCase() || "");
+const showManagerBtn = ref(false);
 
 onMounted(() => {
   const savedRole = localStorage.getItem("role");
@@ -71,7 +84,11 @@ onMounted(() => {
   if (savedUsername) {
     username.value = savedUsername;
   }
-  
+
+  if (savedRole === "supervisor" || savedRole === "admin") {
+    showManagerBtn.value = true;
+  }
+
   if (menuItems.value.length === 0) {
     menuStore.fetchMenu();
   }
@@ -79,6 +96,10 @@ onMounted(() => {
 
 function gotoPage(pageName) {
   router.push(`/front/${pageName}`);
+}
+
+function gotoManager() {
+  router.push(`/manager`);
 }
 
 function onLogout() {
@@ -175,6 +196,27 @@ function onLogout() {
   font-size: 14px;
 }
 
+.manager-section {
+  padding: 20px;
+  border-top: 1px solid rgba(203, 213, 225, 0.1);
+}
+
+.manager-btn {
+  background: #3b82f6 !important;
+  border: none !important;
+  color: #ffffff !important;
+  font-weight: 500;
+  height: 44px;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.manager-btn:hover {
+  background: #2563eb !important;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
 .logout-section {
   padding: 20px;
   border-top: 1px solid rgba(203, 213, 225, 0.1);
@@ -261,8 +303,12 @@ function onLogout() {
   .menu-label {
     display: none;
   }
-  
+
   .logout-section {
+    padding: 8px;
+  }
+
+  .manager-section {
     padding: 8px;
   }
 }

--- a/client/tests/frontLayout.spec.js
+++ b/client/tests/frontLayout.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FrontLayout from '../src/views/front/FrontLayout.vue'
+import { ref } from 'vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ name: 'attendance' })
+}))
+
+vi.mock('../src/stores/menu', () => ({
+  useMenuStore: () => ({ items: ref([]), fetchMenu: vi.fn() })
+}))
+
+describe('FrontLayout manager button', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    push.mockClear()
+  })
+
+  afterAll(() => {
+    vi.resetModules()
+  })
+
+  function mountLayout() {
+    return mount(FrontLayout, {
+      global: { stubs: ['el-menu', 'el-menu-item', 'el-button', 'el-avatar', 'el-icon', 'router-view'] }
+    })
+  }
+
+  it.each(['supervisor', 'admin'])('顯示按鈕並導向 %s', async role => {
+    localStorage.setItem('role', role)
+    const wrapper = mountLayout()
+    await wrapper.vm.$nextTick()
+    const btn = wrapper.get('[data-test="manager-btn"]')
+    await btn.trigger('click')
+    expect(push).toHaveBeenCalledWith('/manager')
+  })
+
+  it('無權限不顯示按鈕', () => {
+    localStorage.setItem('role', 'employee')
+    const wrapper = mountLayout()
+    // onMounted will run, but no button expected
+    expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- 前台佈局於登入後依角色顯示「進入後台」按鈕
- supervisor/admin 角色可導向 /manager
- 新增前台佈局按鈕測試

## Testing
- `npm --prefix client test frontLayout.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68afc2a50eac8329af8bb047301d81b8