### PR TITLE
feat(front): add manager login link

### DIFF
--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -83,6 +83,14 @@
           </el-form-item>
         </el-form>
 
+        <el-button
+          type="text"
+          class="manager-login-link"
+          @click="router.push('/manager/login')"
+        >
+          主管／系統管理員登入
+        </el-button>
+
         <!-- Added role-based access information -->
         <div class="access-info">
           <div class="info-item">
@@ -340,6 +348,13 @@ async function onLogin() {
 .login-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+.manager-login-link {
+  display: block;
+  width: 100%;
+  text-align: right;
+  margin-top: 0.5rem;
 }
 
 .access-info {

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import FrontLogin from '../src/views/front/FrontLogin.vue'
+vi.mock('../src/stores/menu', () => ({ useMenuStore: () => ({ fetchMenu: vi.fn() }) }))
 
 function createToken(offset = 3600) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
@@ -12,6 +13,32 @@ const push = vi.fn()
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push })
 }))
+
+function mountLogin() {
+  return mount(FrontLogin, {
+    global: {
+      components: {
+        'el-input': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+        },
+        'el-button': {
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>'
+        }
+      },
+      stubs: {
+        'el-form': {
+          template: '<form><slot /></form>',
+          methods: { validate: () => Promise.resolve(true) }
+        },
+        'el-form-item': { template: '<div><slot /></div>' },
+        'el-card': { template: '<div><slot /></div>' }
+      }
+    }
+  })
+}
 
 describe('FrontLogin.vue', () => {
   beforeEach(() => {
@@ -30,16 +57,21 @@ describe('FrontLogin.vue', () => {
         ok: true,
         json: async () => ({ token: createToken(), user: { role: 'employee', employeeId: 'e1' } })
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ([])
-      })
-    const wrapper = mount(FrontLogin)
+    const wrapper = mountLogin()
     await wrapper.find('input[placeholder="請輸入員工帳號"]').setValue('u1')
     await wrapper.find('input[placeholder="請輸入密碼"]').setValue('p1p1p1')
-    await wrapper.find('button').trigger('click')
+    await wrapper.find('.login-button').trigger('click')
+    await flushPromises()
     expect(localStorage.getItem('role')).toBe('employee')
     expect(localStorage.getItem('employeeId')).toBe('e1')
     expect(push).toHaveBeenCalledWith('/front/attendance')
+  })
+
+  it('navigates to manager login when link clicked', async () => {
+    const wrapper = mountLogin()
+    const button = wrapper.find('.manager-login-link')
+    expect(button.exists()).toBe(true)
+    await button.trigger('click')
+    expect(push).toHaveBeenCalledWith('/manager/login')
   })
 })


### PR DESCRIPTION
## Summary
- add manager login link on employee login page
- cover manager login link in tests

## Testing
- `npm test` *(fails: approvalFlowSetting.spec.js, schedule.spec.js)*
- `npm --prefix client test tests/frontLogin.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68afc9b74900832997df8fe3ed7a9139