### PR TITLE
feat(server): auto-create default admin on startup

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -214,6 +214,18 @@ export async function seedApprovalTemplates() {
   }
 }
 
+export async function ensureAdminUser() {
+  const existing = await User.findOne({ role: 'admin' });
+  if (existing) {
+    console.log('Admin user already exists');
+    return;
+  }
+  const username = process.env.DEFAULT_ADMIN_USERNAME || 'admin';
+  const password = process.env.DEFAULT_ADMIN_PASSWORD || 'password';
+  await User.create({ username, password, role: 'admin' });
+  console.log(`Created default admin user ${username}`);
+}
+
 dotenv.config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -334,6 +346,7 @@ app.get('*', (req, res, next) => {
 async function start() {
   try {
     await connectDB(process.env.MONGODB_URI);
+    await ensureAdminUser();
     app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/server/tests/ensureAdminUser.test.js
+++ b/server/tests/ensureAdminUser.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+const mockFindOne = jest.fn();
+const mockCreate = jest.fn();
+
+jest.unstable_mockModule('../src/models/User.js', () => ({
+  default: { findOne: mockFindOne, create: mockCreate },
+}));
+
+beforeAll(() => {
+  process.env.PORT = '3000';
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  process.env.JWT_SECRET = 'secret';
+  process.env.NODE_ENV = 'test';
+});
+
+describe('ensureAdminUser', () => {
+  beforeEach(() => {
+    mockFindOne.mockReset();
+    mockCreate.mockReset();
+    delete process.env.DEFAULT_ADMIN_USERNAME;
+    delete process.env.DEFAULT_ADMIN_PASSWORD;
+  });
+
+  it('skips creation when admin exists', async () => {
+    mockFindOne.mockResolvedValue({ username: 'admin' });
+    const { ensureAdminUser } = await import('../src/index.js');
+    await ensureAdminUser();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates default admin using env variables', async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockCreate.mockResolvedValue({});
+    process.env.DEFAULT_ADMIN_USERNAME = 'root';
+    process.env.DEFAULT_ADMIN_PASSWORD = 'secret';
+    const { ensureAdminUser } = await import('../src/index.js');
+    await ensureAdminUser();
+    expect(mockCreate).toHaveBeenCalledWith({ username: 'root', password: 'secret', role: 'admin' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add ensureAdminUser to create default admin when missing
- invoke ensureAdminUser after DB connection during startup
- test ensureAdminUser behavior for existing and missing admin users

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afdb52fb948329a73caacd6993ca8c