### PR TITLE
test: 補強員工登入與帳號權限測試

### DIFF
--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -2,58 +2,62 @@ import request from 'supertest'
 import express from 'express'
 import { jest } from '@jest/globals'
 import jwt from 'jsonwebtoken'
+import Employee from '../src/models/Employee.js'
 
-const verifyMock = jest.fn();
-const fakeEmployee = { _id: 'e1', role: 'employee', username: 'john', verifyPassword: verifyMock };
-const mockEmployee = { findOne: jest.fn() };
-const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
+const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() }
 
-jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
-jest.unstable_mockModule('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }));
+jest.unstable_mockModule('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }))
 
-let app;
-let authRoutes;
-let isTokenBlacklisted;
+let app
+let authRoutes
+let isTokenBlacklisted
+let findOneSpy
+let fakeEmployee
+let empId
 
 beforeAll(async () => {
-  process.env.JWT_SECRET = 'secret';
-  authRoutes = (await import('../src/routes/authRoutes.js')).default;
-  ({ isTokenBlacklisted } = await import('../src/utils/tokenBlacklist.js'));
-  app = express();
-  app.use(express.json());
-  app.use('/api', authRoutes);
-});
+  process.env.JWT_SECRET = 'secret'
+  authRoutes = (await import('../src/routes/authRoutes.js')).default
+  ;({ isTokenBlacklisted } = await import('../src/utils/tokenBlacklist.js'))
+  app = express()
+  app.use(express.json())
+  app.use('/api', authRoutes)
+})
 
 beforeEach(() => {
-  mockEmployee.findOne.mockReset();
-  verifyMock.mockReset();
-  mockBlacklistedToken.create.mockReset();
-  mockBlacklistedToken.findOne.mockReset();
-});
+  fakeEmployee = new Employee({ role: 'employee', username: 'john' })
+  fakeEmployee.password = 'pass'
+  empId = fakeEmployee._id.toString()
+  findOneSpy = jest.spyOn(Employee, 'findOne')
+  mockBlacklistedToken.create.mockReset()
+  mockBlacklistedToken.findOne.mockReset()
+})
+
+afterEach(() => {
+  findOneSpy.mockRestore()
+})
 
 describe('Auth API', () => {
   it('logs in with valid credentials', async () => {
-    mockEmployee.findOne.mockResolvedValue(fakeEmployee);
-    verifyMock.mockReturnValue(true);
-    const signSpy = jest.spyOn(jwt, 'sign').mockReturnValue('tok');
-    const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' });
-    expect(res.status).toBe(200);
-    expect(res.body.token).toBe('tok');
-    expect(res.body.user).toEqual({ id: 'e1', role: 'employee', username: 'john' });
+    findOneSpy.mockResolvedValue(fakeEmployee)
+    const signSpy = jest.spyOn(jwt, 'sign').mockReturnValue('tok')
+    const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' })
+    expect(res.status).toBe(200)
+    expect(res.body.token).toBe('tok')
+    expect(res.body.user).toEqual({ id: empId, role: 'employee', username: 'john' })
     expect(signSpy).toHaveBeenCalledWith(
-      { id: 'e1', role: 'employee' },
+      { id: fakeEmployee._id, role: 'employee' },
       'secret',
       { expiresIn: '1h' }
-    );
+    )
     signSpy.mockRestore();
   });
 
   it('fails with invalid credentials', async () => {
-    mockEmployee.findOne.mockResolvedValue(fakeEmployee);
-    verifyMock.mockReturnValue(false);
-    const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' });
-    expect(res.status).toBe(401);
-  });
+    findOneSpy.mockResolvedValue(fakeEmployee)
+    const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' })
+    expect(res.status).toBe(401)
+  })
 
   it('invalidates token on logout', async () => {
     mockBlacklistedToken.create.mockResolvedValue();


### PR DESCRIPTION
## Summary
- 使用 Employee 模型建立測試資料，驗證員工帳號登入可取得 JWT
- 新增員工建立與更新時對帳號、角色與密碼的測試案例

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b08fb618e08329a1808fbd7abc5f6a