### PR TITLE
修正登入選取密碼並新增整合測試

### DIFF
--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -7,7 +7,7 @@ const router = Router();
 
 router.post('/login', async (req, res) => {
   const { username, password } = req.body
-  const employee = await Employee.findOne({ username })
+  const employee = await Employee.findOne({ username }).select('+passwordHash')
   if (!employee) return res.status(401).json({ error: 'Invalid credentials' })
 
   const match = employee.verifyPassword(password)

--- a/server/tests/auth.integration.test.js
+++ b/server/tests/auth.integration.test.js
@@ -1,0 +1,48 @@
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+
+// 先取得真正的 Employee 模型供密碼驗證使用
+const { default: RealEmployee } = await import('../src/models/Employee.js')
+
+// 模擬資料庫查詢，login 路由中將會呼叫 findOne().select('+passwordHash')
+const selectMock = jest.fn()
+const mockEmployee = {
+  findOne: jest.fn(() => ({ select: selectMock }))
+}
+
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }))
+
+let app
+let authRoutes
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'secret'
+  authRoutes = (await import('../src/routes/authRoutes.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api', authRoutes)
+})
+
+beforeEach(() => {
+  selectMock.mockReset()
+  mockEmployee.findOne.mockReset()
+})
+
+describe('Auth Integration', () => {
+  it('建立員工並成功登入', async () => {
+    // 建立包含密碼的員工物件
+    const employee = new RealEmployee({ name: 'Tester', username: 'tester', password: 'pass123', role: 'employee' })
+    // 設定查詢回傳
+    selectMock.mockResolvedValue(employee)
+    mockEmployee.findOne.mockReturnValue({ select: selectMock })
+
+    const res = await request(app).post('/api/login').send({ username: 'tester', password: 'pass123' })
+
+    expect(mockEmployee.findOne).toHaveBeenCalledWith({ username: 'tester' })
+    expect(selectMock).toHaveBeenCalledWith('+passwordHash')
+    expect(res.status).toBe(200)
+    expect(res.body.user).toMatchObject({ username: 'tester' })
+    expect(res.body.token).toBeDefined()
+  })
+})

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -4,6 +4,7 @@ import { jest } from '@jest/globals'
 import jwt from 'jsonwebtoken'
 
 const verifyMock = jest.fn();
+const selectMock = jest.fn();
 const fakeEmployee = { _id: 'e1', role: 'employee', username: 'john', verifyPassword: verifyMock };
 const mockEmployee = { findOne: jest.fn() };
 const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
@@ -26,6 +27,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockEmployee.findOne.mockReset();
+  selectMock.mockReset();
   verifyMock.mockReset();
   mockBlacklistedToken.create.mockReset();
   mockBlacklistedToken.findOne.mockReset();
@@ -33,7 +35,8 @@ beforeEach(() => {
 
 describe('Auth API', () => {
   it('logs in with valid credentials', async () => {
-    mockEmployee.findOne.mockResolvedValue(fakeEmployee);
+    mockEmployee.findOne.mockReturnValue({ select: selectMock });
+    selectMock.mockResolvedValue(fakeEmployee);
     verifyMock.mockReturnValue(true);
     const signSpy = jest.spyOn(jwt, 'sign').mockReturnValue('tok');
     const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' });
@@ -49,7 +52,8 @@ describe('Auth API', () => {
   });
 
   it('fails with invalid credentials', async () => {
-    mockEmployee.findOne.mockResolvedValue(fakeEmployee);
+    mockEmployee.findOne.mockReturnValue({ select: selectMock });
+    selectMock.mockResolvedValue(fakeEmployee);
     verifyMock.mockReturnValue(false);
     const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' });
     expect(res.status).toBe(401);


### PR DESCRIPTION
## 摘要
- 登入查詢時顯式選取 `passwordHash`，確保可進行密碼驗證
- 新增登入整合測試，建立含密碼的員工並驗證登入成功

## 測試
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09983375883298788334d45b2d37c