### PR TITLE
test: 使用記憶體資料庫驗證登入流程

### DIFF
--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,70 +1,63 @@
 import request from 'supertest'
 import express from 'express'
-import { jest } from '@jest/globals'
+import mongoose from 'mongoose'
 import jwt from 'jsonwebtoken'
+import { MongoMemoryServer } from 'mongodb-memory-server'
 
-const verifyMock = jest.fn();
-const selectMock = jest.fn();
-const fakeEmployee = { _id: 'e1', role: 'employee', username: 'john', verifyPassword: verifyMock };
-const mockEmployee = { findOne: jest.fn() };
-const mockBlacklistedToken = { create: jest.fn(), findOne: jest.fn() };
+import authRoutes from '../src/routes/authRoutes.js'
+import Employee from '../src/models/Employee.js'
+import { isTokenBlacklisted } from '../src/utils/tokenBlacklist.js'
 
-jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
-jest.unstable_mockModule('../src/models/BlacklistedToken.js', () => ({ default: mockBlacklistedToken }));
-
-let app;
-let authRoutes;
-let isTokenBlacklisted;
+let app
+let mongod
+let testEmployee
 
 beforeAll(async () => {
-  process.env.JWT_SECRET = 'secret';
-  authRoutes = (await import('../src/routes/authRoutes.js')).default;
-  ({ isTokenBlacklisted } = await import('../src/utils/tokenBlacklist.js'));
-  app = express();
-  app.use(express.json());
-  app.use('/api', authRoutes);
-});
+  process.env.JWT_SECRET = 'secret'
+  mongod = await MongoMemoryServer.create()
+  await mongoose.connect(mongod.getUri(), { dbName: 'test' })
 
-beforeEach(() => {
-  mockEmployee.findOne.mockReset();
-  selectMock.mockReset();
-  verifyMock.mockReset();
-  mockBlacklistedToken.create.mockReset();
-  mockBlacklistedToken.findOne.mockReset();
-});
+  app = express()
+  app.use(express.json())
+  app.use('/api', authRoutes)
+})
+
+beforeEach(async () => {
+  await mongoose.connection.db.dropDatabase()
+  testEmployee = await Employee.create({
+    name: 'John',
+    username: 'john',
+    password: 'pass',
+    role: 'employee'
+  })
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongod.stop()
+})
 
 describe('Auth API', () => {
-  it('logs in with valid credentials', async () => {
-    mockEmployee.findOne.mockReturnValue({ select: selectMock });
-    selectMock.mockResolvedValue(fakeEmployee);
-    verifyMock.mockReturnValue(true);
-    const signSpy = jest.spyOn(jwt, 'sign').mockReturnValue('tok');
-    const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' });
-    expect(res.status).toBe(200);
-    expect(res.body.token).toBe('tok');
-    expect(res.body.user).toEqual({ id: 'e1', role: 'employee', username: 'john' });
-    expect(signSpy).toHaveBeenCalledWith(
-      { id: 'e1', role: 'employee' },
-      'secret',
-      { expiresIn: '1h' }
-    );
-    signSpy.mockRestore();
-  });
+  it('使用正確帳密登入', async () => {
+    const signSpy = jest.spyOn(jwt, 'sign')
+    const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' })
+    expect(res.status).toBe(200)
+    expect(res.body.token).toBeDefined()
+    expect(res.body.user).toEqual({ id: testEmployee._id.toString(), role: 'employee', username: 'john' })
+    expect(signSpy).toHaveBeenCalledWith({ id: testEmployee._id, role: 'employee' }, 'secret', { expiresIn: '1h' })
+    signSpy.mockRestore()
+  })
 
-  it('fails with invalid credentials', async () => {
-    mockEmployee.findOne.mockReturnValue({ select: selectMock });
-    selectMock.mockResolvedValue(fakeEmployee);
-    verifyMock.mockReturnValue(false);
-    const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' });
-    expect(res.status).toBe(401);
-  });
+  it('使用錯誤密碼登入失敗', async () => {
+    const res = await request(app).post('/api/login').send({ username: 'john', password: 'wrong' })
+    expect(res.status).toBe(401)
+  })
 
-  it('invalidates token on logout', async () => {
-    mockBlacklistedToken.create.mockResolvedValue();
-    mockBlacklistedToken.findOne.mockResolvedValue({ token: 'tok', expiresAt: new Date(Date.now() + 1000) });
-    const res = await request(app).post('/api/logout').set('Authorization', 'Bearer tok')
+  it('登出後將 token 加入黑名單', async () => {
+    const token = jwt.sign({ id: testEmployee._id, role: 'employee' }, 'secret', { expiresIn: '1h' })
+    const res = await request(app).post('/api/logout').set('Authorization', `Bearer ${token}`)
     expect(res.status).toBe(204)
-    const result = await isTokenBlacklisted('tok')
+    const result = await isTokenBlacklisted(token)
     expect(result).toBe(true)
   })
-});
+})


### PR DESCRIPTION
## Summary
- 使用 MongoMemoryServer 建立記憶體 MongoDB，改為真實 Employee 模型
- 移除 mockEmployee 與 BlacklistedToken 模擬，直接操作資料庫驗證登入/登出
- 驗證登入需選取 `passwordHash`，以避免登入流程失敗

## Testing
- `npm test` *(失敗：缺少 mongodb-memory-server 套件)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ba68f0c8329b715e02f58119ffe