### PR TITLE
test(server): 新增 ensureAdminUser 預設帳號測試

### DIFF
--- a/server/tests/ensureAdminUser.test.js
+++ b/server/tests/ensureAdminUser.test.js
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+const mockEmployee = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+};
+
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
+
+let ensureAdminUser;
+let createdUser;
+
+beforeEach(async () => {
+  jest.resetModules();
+  process.env.NODE_ENV = 'test';
+  process.env.PORT = '3000';
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  process.env.JWT_SECRET = 'secret';
+  process.env.DEFAULT_ADMIN_USERNAME = 'boss';
+  process.env.DEFAULT_ADMIN_PASSWORD = 'secret';
+
+  createdUser = undefined;
+  mockEmployee.findOne.mockReset();
+  mockEmployee.create.mockReset();
+  mockEmployee.create.mockImplementation(async (data) => {
+    const salt = crypto.randomBytes(16).toString('hex');
+    const hash = crypto
+      .pbkdf2Sync(data.password, salt, 100000, 64, 'sha512')
+      .toString('hex');
+    createdUser = { ...data, passwordHash: `${salt}:${hash}` };
+    return createdUser;
+  });
+
+  ({ ensureAdminUser } = await import('../src/index.js'));
+});
+
+test('creates default admin user from env variables when none exists', async () => {
+  mockEmployee.findOne.mockResolvedValue(null);
+  await ensureAdminUser();
+  expect(createdUser).toMatchObject({
+    username: 'boss',
+    email: 'boss@example.com',
+    role: 'admin',
+  });
+  expect(createdUser.passwordHash).toBeDefined();
+  expect(createdUser.passwordHash).not.toBe('');
+});


### PR DESCRIPTION
## Summary
- add test verifying ensureAdminUser creates default admin from env variables when no admin exists

## Testing
- `npm test` *(server 測試全部通過；root 測試因前端套件問題失敗)*


------
https://chatgpt.com/codex/tasks/task_e_68b09ba872d48329803726e81695ec99