### PR TITLE
新增登入 employeeId 回傳並調整排班主管參數

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -152,7 +152,7 @@ const onLogin = async () => {
       const data = await res.json()
       setToken(data.token)
       localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.employeeId)
+      localStorage.setItem('employeeId', data.user.employeeId || data.user.id)
       
       ElMessage.success('登入成功！')
 

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -175,7 +175,7 @@ async function onLogin() {
     if (res.ok) {
       setToken(data.token)
       localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.employeeId)
+      localStorage.setItem('employeeId', data.user.employeeId || data.user.id)
       ElMessage.success(`歡迎回來，${roles[0].label}！`)
 
       await menuStore.fetchMenu()

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -359,10 +359,11 @@ async function fetchOptions() {
 }
 
 async function fetchSchedules() {
-  const supervisorId = localStorage.getItem('employeeId') || ''
+  const supervisorId = localStorage.getItem('employeeId')
+  const supParam = supervisorId && supervisorId !== 'undefined' ? `&supervisor=${supervisorId}` : ''
   try {
     const res = await apiFetch(
-      `/api/schedules/monthly?month=${currentMonth.value}&supervisor=${supervisorId}`
+      `/api/schedules/monthly?month=${currentMonth.value}${supParam}`
     )
     if (!res.ok) throw new Error('Failed to fetch schedules')
     const data = await res.json()
@@ -396,7 +397,7 @@ async function fetchSchedules() {
     })
 
     const res2 = await apiFetch(
-      `/api/schedules/leave-approvals?month=${currentMonth.value}&supervisor=${supervisorId}`
+      `/api/schedules/leave-approvals?month=${currentMonth.value}${supParam}`
     )
     if (res2.ok) {
       const extra = await res2.json()
@@ -589,10 +590,12 @@ function subDepsFor(deptId) {
 }
 
 async function fetchEmployees(department = '', subDepartment = '') {
-  const supervisorId = localStorage.getItem('employeeId') || ''
-  let url = `/api/employees?supervisor=${supervisorId}`
-  if (department) url += `&department=${department}`
-  if (subDepartment) url += `&subDepartment=${subDepartment}`
+  const supervisorId = localStorage.getItem('employeeId')
+  const params = []
+  if (supervisorId && supervisorId !== 'undefined') params.push(`supervisor=${supervisorId}`)
+  if (department) params.push(`department=${department}`)
+  if (subDepartment) params.push(`subDepartment=${subDepartment}`)
+  const url = `/api/employees${params.length ? `?${params.join('&')}` : ''}`
   try {
     const empRes = await apiFetch(url)
     if (!empRes.ok) throw new Error('Failed to fetch employees')

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -73,6 +73,7 @@ describe('Login.vue', () => {
     wrapper.vm.loginForm.password = 'p'
     await wrapper.vm.onLogin()
     expect(localStorage.getItem('role')).toBe('supervisor')
+    expect(localStorage.getItem('employeeId')).toBe('e1')
     expect(push).toHaveBeenCalledWith('/front/schedule')
   })
 
@@ -91,6 +92,7 @@ describe('Login.vue', () => {
     wrapper.vm.loginForm.username = 'u'
     wrapper.vm.loginForm.password = 'p'
     await wrapper.vm.onLogin()
+    expect(localStorage.getItem('employeeId')).toBe('a1')
     expect(push).toHaveBeenCalledWith({ name: 'Settings' })
   })
 
@@ -109,6 +111,7 @@ describe('Login.vue', () => {
     wrapper.vm.loginForm.username = 'u'
     wrapper.vm.loginForm.password = 'p'
     await wrapper.vm.onLogin()
+    expect(localStorage.getItem('employeeId')).toBe('a1')
     expect(push).toHaveBeenCalledWith('/manager')
   })
 

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -18,7 +18,15 @@ router.post('/login', async (req, res) => {
     process.env.JWT_SECRET || 'secret',
     { expiresIn: '1h' }
   )
-  res.json({ token, user: { id: employee._id, role: employee.role, username: employee.username } })
+  res.json({
+    token,
+    user: {
+      id: employee._id,
+      employeeId: employee._id,
+      role: employee.role,
+      username: employee.username
+    }
+  })
 })
 
 router.post('/logout', async (req, res) => {

--- a/server/tests/auth.integration.test.js
+++ b/server/tests/auth.integration.test.js
@@ -43,6 +43,7 @@ describe('Auth Integration', () => {
     expect(selectMock).toHaveBeenCalledWith('+passwordHash')
     expect(res.status).toBe(200)
     expect(res.body.user).toMatchObject({ username: 'tester' })
+    expect(res.body.user.employeeId).toBe(String(employee._id))
     expect(res.body.token).toBeDefined()
   })
 })

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -52,7 +52,7 @@ describe('Auth API', () => {
     const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass' });
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    expect(res.body.user).toEqual({ id: '1', role: 'employee', username: 'john' });
+    expect(res.body.user).toEqual({ id: '1', employeeId: '1', role: 'employee', username: 'john' });
     expect(signSpy).toHaveBeenCalledWith({ id: '1', role: 'employee' }, 'secret', { expiresIn: '1h' });
     signSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- 後端登入 API 回傳 employeeId
- 前後台登入頁儲存主管 ID 並於排班頁判斷有效性
- 補強相關測試驗證 ID 使用

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27a634adc832993c4a4ad53f4ff9c