### PR TITLE
調整管理員登入導向與前台角色顯示

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -105,14 +105,11 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { useMenuStore } from '../stores/menu'
-import { storeToRefs } from 'pinia'
 import { apiFetch } from '../api'
 import { setToken } from '../utils/tokenService'
 import { ElMessage } from 'element-plus'
 
 const router = useRouter()
-const menuStore = useMenuStore()
 
 const loginForm = ref({
   username: '',
@@ -159,13 +156,7 @@ const onLogin = async () => {
       if (data.user.role === 'supervisor') {
         router.push('/front/schedule')
       } else if (data.user.role === 'admin') {
-        await menuStore.fetchMenu()
-        const first = menuStore.items[0]
-        if (first) {
-          router.push({ name: first.name })
-        } else {
-          router.push('/manager')
-        }
+        router.push('/front/attendance')
       }
     } else {
       const errorData = await res.json()

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -85,7 +85,7 @@ onMounted(() => {
     username.value = savedUsername;
   }
 
-  if (savedRole === "supervisor" || savedRole === "admin") {
+  if (savedRole === "supervisor") {
     showManagerBtn.value = true;
   }
 

--- a/client/tests/frontLayout.spec.js
+++ b/client/tests/frontLayout.spec.js
@@ -30,8 +30,8 @@ describe('FrontLayout manager button', () => {
     })
   }
 
-  it.each(['supervisor', 'admin'])('顯示按鈕並導向 %s', async role => {
-    localStorage.setItem('role', role)
+  it('supervisor 顯示按鈕並導向', async () => {
+    localStorage.setItem('role', 'supervisor')
     const wrapper = mountLayout()
     await wrapper.vm.$nextTick()
     const btn = wrapper.get('[data-test="manager-btn"]')
@@ -39,10 +39,21 @@ describe('FrontLayout manager button', () => {
     expect(push).toHaveBeenCalledWith('/manager')
   })
 
+  it('管理員不顯示按鈕並可登出', async () => {
+    localStorage.setItem('role', 'admin')
+    localStorage.setItem('username', 'boss')
+    const wrapper = mountLayout()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
+    await wrapper.find('.logout-btn').trigger('click')
+    expect(push).toHaveBeenCalledWith('/')
+    expect(localStorage.getItem('role')).toBeNull()
+    expect(localStorage.getItem('username')).toBeNull()
+  })
+
   it('無權限不顯示按鈕', () => {
     localStorage.setItem('role', 'employee')
     const wrapper = mountLayout()
-    // onMounted will run, but no button expected
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
   })
 })

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import Login from '../src/views/Login.vue'
@@ -77,42 +77,18 @@ describe('Login.vue', () => {
     expect(push).toHaveBeenCalledWith('/front/schedule')
   })
 
-  it('redirects admin to first menu item', async () => {
-    fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: createToken(), user: { role: 'admin', employeeId: 'a1' } })
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ([{ name: 'Settings' }])
-      })
+  it('redirects admin to front attendance', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: createToken(), user: { role: 'admin', employeeId: 'a1' } })
+    })
     const wrapper = mountLogin()
     wrapper.vm.loginFormRef = { validate: async () => true }
     wrapper.vm.loginForm.username = 'u'
     wrapper.vm.loginForm.password = 'p'
     await wrapper.vm.onLogin()
     expect(localStorage.getItem('employeeId')).toBe('a1')
-    expect(push).toHaveBeenCalledWith({ name: 'Settings' })
-  })
-
-  it('redirects admin to /manager when menu empty', async () => {
-    fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: createToken(), user: { role: 'admin', employeeId: 'a1' } })
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ([])
-      })
-    const wrapper = mountLogin()
-    wrapper.vm.loginFormRef = { validate: async () => true }
-    wrapper.vm.loginForm.username = 'u'
-    wrapper.vm.loginForm.password = 'p'
-    await wrapper.vm.onLogin()
-    expect(localStorage.getItem('employeeId')).toBe('a1')
-    expect(push).toHaveBeenCalledWith('/manager')
+    expect(push).toHaveBeenCalledWith('/front/attendance')
   })
 
   it('navigates to employee login when link clicked', async () => {


### PR DESCRIPTION
## Summary
- 僅主管顯示進入後台按鈕，管理員不再顯示
- 管理員登入後改導向前台出勤頁
- 新增與更新前端測試，驗證管理員無後台按鈕仍可登出

## Testing
- `CI=true npm test`
- `CI=true npm --prefix client test -- run tests/login.spec.js tests/frontLayout.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28000794c832984112bc3c6943eb4