### PR TITLE
feat: 加入打卡備註與驗證

### DIFF
--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -55,8 +55,8 @@
     <div class="records-section">
       <h2 class="section-title">今日打卡記錄</h2>
       <div class="table-container">
-        <el-table 
-          :data="records" 
+        <el-table
+          :data="records"
           class="records-table"
           :header-cell-style="{ background: '#f8fafc', color: '#475569', fontWeight: '600' }"
           :row-style="{ height: '56px' }"
@@ -87,13 +87,25 @@
         </el-table>
       </div>
     </div>
+
+    <el-dialog v-model="remarkDialogVisible" title="新增備註" width="400px">
+      <el-input v-model="remarkText" placeholder="請輸入備註（可留空）" />
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="remarkDialogVisible = false">取消</el-button>
+          <el-button type="primary" @click="confirmRemark">確認</el-button>
+        </span>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import dayjs from 'dayjs'
+import { ElMessage } from 'element-plus'
 import { apiFetch } from '../../api'
+import { getToken } from '../../utils/tokenService'
 
 // 將中文動作與後端定義的值互轉
 const actionMap = {
@@ -111,6 +123,10 @@ const currentTime = ref('')
 const currentDate = ref('')
 let timeInterval = null
 
+const remarkDialogVisible = ref(false)
+const remarkText = ref('')
+const pendingAction = ref('')
+
 async function fetchRecords() {
   const res = await apiFetch('/api/attendance')
   if (res.ok) {
@@ -124,24 +140,56 @@ async function fetchRecords() {
 }
 
 function onClockIn() {
-  addRecord('上班簽到')
+  openRemarkDialog('上班簽到')
 }
 function onClockOut() {
-  addRecord('下班簽退')
+  openRemarkDialog('下班簽退')
 }
 function onOuting() {
-  addRecord('外出登記')
+  openRemarkDialog('外出登記')
 }
 function onBreakIn() {
-  addRecord('中午休息')
+  openRemarkDialog('中午休息')
 }
 
-async function addRecord(action) {
+function openRemarkDialog(action) {
+  pendingAction.value = action
+  remarkText.value = ''
+  remarkDialogVisible.value = true
+}
+
+async function confirmRemark() {
+  remarkDialogVisible.value = false
+  await addRecord(pendingAction.value, remarkText.value)
+}
+
+function getEmployeeId() {
+  let id = localStorage.getItem('employeeId')
+  if (!id) {
+    const token = getToken()
+    if (token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]))
+        id = payload.employeeId || payload.id
+      } catch (e) {
+        id = null
+      }
+    }
+  }
+  return id
+}
+
+async function addRecord(action, remark = '') {
+  const employeeId = getEmployeeId()
+  if (!employeeId) {
+    ElMessage.warning('請重新登入')
+    return
+  }
   const payload = {
     action: actionMap[action] || action,
     timestamp: new Date(),
-    remark: '',
-    employee: localStorage.getItem('employeeId') || ''
+    remark,
+    employee: employeeId
   }
   const res = await apiFetch('/api/attendance', {
     method: 'POST',

--- a/server/src/controllers/attendanceController.js
+++ b/server/src/controllers/attendanceController.js
@@ -11,7 +11,11 @@ export async function listRecords(req, res) {
 
 export async function createRecord(req, res) {
   try {
-    const record = new AttendanceRecord(req.body);
+    const { employee, action, timestamp, remark } = req.body;
+    if (!employee || !action) {
+      return res.status(400).json({ error: 'employee and action are required' });
+    }
+    const record = new AttendanceRecord({ employee, action, timestamp, remark });
     await record.save();
     res.status(201).json(record);
   } catch (err) {

--- a/server/tests/attendance.test.js
+++ b/server/tests/attendance.test.js
@@ -42,12 +42,19 @@ describe('Attendance API', () => {
     expect(res.body).toEqual({ error: 'fail' });
   });
 
-  it('creates record', async () => {
-    const payload = { action: 'clockIn' };
-    saveMock.mockResolvedValue();
-    const res = await request(app).post('/api/attendance').send(payload);
-    expect(res.status).toBe(201);
-    expect(saveMock).toHaveBeenCalled();
-    expect(res.body).toMatchObject(payload);
+    it('creates record with remark', async () => {
+      const payload = { action: 'clockIn', employee: 'emp1', remark: 'test' };
+      saveMock.mockResolvedValue();
+      const res = await request(app).post('/api/attendance').send(payload);
+      expect(res.status).toBe(201);
+      expect(saveMock).toHaveBeenCalled();
+      expect(res.body).toMatchObject(payload);
+    });
+
+    it('returns 400 when employee is missing', async () => {
+      const payload = { action: 'clockIn' };
+      const res = await request(app).post('/api/attendance').send(payload);
+      expect(res.status).toBe(400);
+      expect(saveMock).not.toHaveBeenCalled();
+    });
   });
-});


### PR DESCRIPTION
## Summary
- 於員工出勤頁加入備註對話框，提交時驗證員工身分
- 新增伺服器端 employee/action 檢查並回傳 remark
- 擴充考勤控制器測試涵蓋備註與缺少員工情境

## Testing
- `npm test` *(失敗：client 測試多項錯誤，如 ReferenceError: afterAll is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b28004d5908329a31a83733158517c