### PR TITLE
feat(front): 隱藏主管登入後的進入後台按鈕

### DIFF
--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -31,19 +31,6 @@
           <span class="menu-label">{{ item.label }}</span>
         </el-menu-item>
       </el-menu>
-      <!-- 進入後台按鈕 -->
-      <div v-if="showManagerBtn" class="manager-section">
-        <el-button
-          type="primary"
-          @click="gotoManager"
-          class="manager-btn"
-          block
-          data-test="manager-btn"
-        >
-          進入後台
-        </el-button>
-      </div>
-
       <!-- 登出按鈕 -->
       <div class="logout-section">
         <el-button type="danger" @click="onLogout" class="logout-btn" block>
@@ -76,17 +63,11 @@ const { items: menuItems } = storeToRefs(menuStore);
 
 const username = ref("");
 const activeMenu = computed(() => route.name?.toLowerCase() || "");
-const showManagerBtn = ref(false);
 
 onMounted(() => {
-  const savedRole = localStorage.getItem("role");
   const savedUsername = localStorage.getItem("username");
   if (savedUsername) {
     username.value = savedUsername;
-  }
-
-  if (savedRole === "supervisor") {
-    showManagerBtn.value = true;
   }
 
   if (menuItems.value.length === 0) {
@@ -96,10 +77,6 @@ onMounted(() => {
 
 function gotoPage(pageName) {
   router.push(`/front/${pageName}`);
-}
-
-function gotoManager() {
-  router.push(`/manager`);
 }
 
 function onLogout() {
@@ -196,27 +173,6 @@ function onLogout() {
   font-size: 14px;
 }
 
-.manager-section {
-  padding: 20px;
-  border-top: 1px solid rgba(203, 213, 225, 0.1);
-}
-
-.manager-btn {
-  background: #3b82f6 !important;
-  border: none !important;
-  color: #ffffff !important;
-  font-weight: 500;
-  height: 44px;
-  border-radius: 8px;
-  transition: all 0.3s ease;
-}
-
-.manager-btn:hover {
-  background: #2563eb !important;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-}
-
 .logout-section {
   padding: 20px;
   border-top: 1px solid rgba(203, 213, 225, 0.1);
@@ -305,10 +261,6 @@ function onLogout() {
   }
 
   .logout-section {
-    padding: 8px;
-  }
-
-  .manager-section {
     padding: 8px;
   }
 }

--- a/client/tests/frontLayout.spec.js
+++ b/client/tests/frontLayout.spec.js
@@ -30,15 +30,6 @@ describe('FrontLayout manager button', () => {
     })
   }
 
-  it('supervisor 顯示按鈕並導向', async () => {
-    localStorage.setItem('role', 'supervisor')
-    const wrapper = mountLayout()
-    await wrapper.vm.$nextTick()
-    const btn = wrapper.get('[data-test="manager-btn"]')
-    await btn.trigger('click')
-    expect(push).toHaveBeenCalledWith('/manager')
-  })
-
   it('管理員不顯示按鈕並可登出', async () => {
     localStorage.setItem('role', 'admin')
     localStorage.setItem('username', 'boss')
@@ -51,7 +42,14 @@ describe('FrontLayout manager button', () => {
     expect(localStorage.getItem('username')).toBeNull()
   })
 
-  it('無權限不顯示按鈕', () => {
+  it('主管不顯示按鈕', async () => {
+    localStorage.setItem('role', 'supervisor')
+    const wrapper = mountLayout()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
+  })
+
+  it('員工不顯示按鈕', () => {
     localStorage.setItem('role', 'employee')
     const wrapper = mountLayout()
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)


### PR DESCRIPTION
## Summary
- 移除前台進入後台按鈕及相關顯示邏輯
- 調整 FrontLayout 測試，確認各角色皆不顯示按鈕

## Testing
- `npm test` *(失敗：approvalFlowSetting.spec.js)*
- `npm --prefix client test run frontLayout.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3d1fe3a588329a8b19ad648eace6f