### PR TITLE
修正管理員登入導向設定頁並調整路由重導

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -46,6 +46,7 @@ const routes = [
     name: 'ManagerLayout',
     component: ManagerLayout,
     meta: { requiresAuth: true },
+    redirect: '/manager/settings',
     children: [
       { path: 'settings', name: 'Settings', component: Settings },
       { path: 'attendance-setting', name: 'AttendanceSetting', component: AttendanceSetting },

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -169,7 +169,7 @@ const onLogin = async () => {
       if (data.user.role === 'supervisor') {
         router.push('/front/schedule')
       } else if (data.user.role === 'admin') {
-        router.push('/manager')
+        router.push('/manager/settings')
       }
     } else {
       const errorData = await res.json()

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -99,7 +99,7 @@ describe('Login.vue', () => {
     wrapper.vm.loginForm.role = 'admin'
     await wrapper.vm.onLogin()
     expect(localStorage.getItem('employeeId')).toBe('a1')
-    expect(push).toHaveBeenCalledWith('/manager')
+    expect(push).toHaveBeenCalledWith('/manager/settings')
   })
 
   it('shows error on role mismatch', async () => {

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -40,6 +40,11 @@ describe('router', () => {
     expect(paths).toContain('/manager/login')
   })
 
+  it('redirects /manager to settings', () => {
+    const manager = router.getRoutes().find(r => r.path === '/manager')
+    expect(manager.redirect).toBe('/manager/settings')
+  })
+
   it('front child routes define role meta', () => {
     const front = router.getRoutes().find(r => r.name === 'FrontLayout')
     const childRoles = front.children.map(r => ({ name: r.name, roles: r.meta && r.meta.roles }))


### PR DESCRIPTION
## Summary
- 管理員登入後直接導向至 /manager/settings
- 後台 /manager 路由新增 redirect 確保載入設定頁
- 更新相關測試以反映新導向

## Testing
- `npm test` (client) *(failed: ApprovalFlowSetting, FieldSetting, Schedule, Logout 等多項測試)*
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68b3dc6485a0832997e7929409276459