### PR TITLE
feat: 登出後清空選單並重置狀態

### DIFF
--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -75,12 +75,13 @@ function toggleCollapse() {
   isCollapse.value = !isCollapse.value
 }
 
-function logout() {
-  clearToken()
-  localStorage.removeItem('role')
-  localStorage.removeItem('employeeId')
-  router.push('/')
-}
+  function logout() {
+    clearToken()
+    menuStore.setMenu([])
+    localStorage.removeItem('role')
+    localStorage.removeItem('employeeId')
+    router.push('/')
+  }
 </script>
 
 <style scoped>

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -79,12 +79,13 @@ function gotoPage(pageName) {
   router.push(`/front/${pageName}`);
 }
 
-function onLogout() {
-  localStorage.removeItem("role");
-  localStorage.removeItem("username");
-  clearToken();
-  router.push(`/`);
-}
+  function onLogout() {
+    localStorage.removeItem("role");
+    localStorage.removeItem("username");
+    clearToken();
+    menuStore.setMenu([]);
+    router.push(`/`);
+  }
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- 登出時清除 menuStore 避免保留舊選單
- 前台與後台佈局在登出後同步重置選單

## Testing
- `npm test` *(失敗：approvalFlowSetting.spec.js 等 3 個測試檔)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e1424cd483298a0c384f46a3af5a