### PR TITLE
feat: 前台登入加入角色欄位並驗證

### DIFF
--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -164,9 +164,10 @@ async function onLogin() {
     const res = await apiFetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ 
-        username: loginForm.value.username, 
-        password: loginForm.value.password 
+      body: JSON.stringify({
+        username: loginForm.value.username,
+        password: loginForm.value.password,
+        role: loginForm.value.role
       })
     })
     

--- a/client/tests/frontLogin.spec.js
+++ b/client/tests/frontLogin.spec.js
@@ -62,6 +62,12 @@ describe('FrontLogin.vue', () => {
     await wrapper.find('input[placeholder="請輸入密碼"]').setValue('p1p1p1')
     await wrapper.find('.login-button').trigger('click')
     await flushPromises()
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/login',
+      expect.objectContaining({
+        body: expect.stringContaining('"role":"employee"')
+      })
+    )
     expect(localStorage.getItem('role')).toBe('employee')
     expect(localStorage.getItem('employeeId')).toBe('e1')
     expect(push).toHaveBeenCalledWith('/front/attendance')


### PR DESCRIPTION
## Summary
- login API 帶上使用者角色
- 測試確認登入時送出 role

## Testing
- `npm test` *(失敗：tests/approvalFlowSetting.spec.js 等)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e382fbdc8329a318d706e7d63e53