### PR TITLE
feat: 控制登入 API 自動重導

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -3,14 +3,14 @@ import { getToken, clearToken } from './utils/tokenService'
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
 
-export function apiFetch(path, options = {}) {
+export function apiFetch(path, options = {}, { autoRedirect = true } = {}) {
   const token = getToken()
   const headers = {
     ...(options.headers || {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {})
   }
   return fetch(`${API_BASE_URL}${path}`, { ...options, headers }).then(res => {
-    if (res.status === 401) {
+    if (res.status === 401 && autoRedirect) {
       clearToken()
       const path = window.location.pathname || ''
       window.location.href = path.startsWith('/manager')

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -154,11 +154,15 @@ const onLogin = async () => {
     isLoading.value = true
     
     const { username, password, role } = loginForm.value
-    const res = await apiFetch('/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password, role })
-    })
+    const res = await apiFetch(
+      '/api/login',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password, role })
+      },
+      { autoRedirect: false }
+    )
     
     if (res.ok) {
       const data = await res.json()

--- a/client/src/views/front/FrontLogin.vue
+++ b/client/src/views/front/FrontLogin.vue
@@ -161,15 +161,19 @@ async function onLogin() {
     
     isLoading.value = true
     
-    const res = await apiFetch('/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        username: loginForm.value.username,
-        password: loginForm.value.password,
-        role: loginForm.value.role
-      })
-    })
+    const res = await apiFetch(
+      '/api/login',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: loginForm.value.username,
+          password: loginForm.value.password,
+          role: loginForm.value.role
+        })
+      },
+      { autoRedirect: false }
+    )
     
     const data = await res.json()
     

--- a/client/tests/api.spec.js
+++ b/client/tests/api.spec.js
@@ -46,4 +46,12 @@ describe('apiFetch', () => {
     expect(res).toBe(response)
     expect(clearToken).not.toHaveBeenCalled()
   })
+
+  it('does not redirect when autoRedirect is false', async () => {
+    window.location.pathname = '/profile'
+    fetch.mockResolvedValueOnce({ status: 401 })
+    await apiFetch('/test', {}, { autoRedirect: false })
+    expect(clearToken).not.toHaveBeenCalled()
+    expect(window.location.href).toBe('')
+  })
 })

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -112,8 +112,14 @@ describe('Login.vue', () => {
   })
 
   it('shows error on role mismatch', async () => {
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '', pathname: '' }
+    })
     fetch.mockResolvedValueOnce({
       ok: false,
+      status: 401,
       json: async () => ({ message: '角色錯誤' })
     })
     const wrapper = mountLogin()
@@ -126,6 +132,8 @@ describe('Login.vue', () => {
     expect(ElMessage.error).toHaveBeenCalledWith('角色錯誤')
     expect(fetchMenuSpy).not.toHaveBeenCalled()
     expect(push).not.toHaveBeenCalled()
+    expect(window.location.href).toBe('')
+    window.location = originalLocation
   })
 
   it('navigates to employee login when link clicked', async () => {


### PR DESCRIPTION
## Summary
- 新增 `apiFetch` 的 `autoRedirect` 選項，讓呼叫端可決定是否於 401 自動導向登入頁
- 登入與前台登入頁在呼叫 API 時停用自動導向並由元件顯示錯誤
- 擴充相關單元測試覆蓋登入失敗情境

## Testing
- `npm test -- tests/login.spec.js tests/frontLogin.spec.js tests/api.spec.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68b426d895f88329830f016e9c158ba4