### PR TITLE
refactor(menu): use global auth for menu routes

### DIFF
--- a/server/src/routes/menuRoutes.js
+++ b/server/src/routes/menuRoutes.js
@@ -1,9 +1,8 @@
 import { Router } from 'express';
 import { getMenu } from '../controllers/menuController.js';
-import { authenticate } from '../middleware/auth.js';
 
 const router = Router();
 
-router.get('/', authenticate, getMenu);
+router.get('/', getMenu);
 
 export default router;

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -9,11 +9,13 @@ jest.unstable_mockModule('../src/middleware/auth.js', () => ({
 
 let app;
 let menuRoutes;
+let authenticate;
 
 beforeAll(async () => {
+  ({ authenticate } = await import('../src/middleware/auth.js'));
   menuRoutes = (await import('../src/routes/menuRoutes.js')).default;
   app = express();
-  app.use('/api/menu', menuRoutes);
+  app.use('/api/menu', authenticate, menuRoutes);
 });
 
 describe('Menu API', () => {


### PR DESCRIPTION
## Summary
- remove route-level authenticate middleware from menu routes
- adjust menu API tests to apply authenticate globally

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42920cc548329866e311bd5c8a6cd