### PR TITLE
feat(schedule): allow employees to view own shifts

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -29,6 +29,7 @@ const Attendance = () => import('@/views/front/Attendance.vue')
 const Approval = () => import('@/views/front/Approval.vue')
 const PreviewWeek = () => import('@/views/front/PreviewWeek.vue')
 const PreviewMonth = () => import('@/views/front/PreviewMonth.vue')
+const MySchedule = () => import('@/views/front/MySchedule.vue')
 
 const routes = [
   // 首頁重導至前台登入
@@ -76,6 +77,12 @@ const routes = [
         path: 'attendance',
         name: 'Attendance',
         component: Attendance,
+        meta: { roles: ['employee', 'supervisor', 'admin'] },
+      },
+      {
+        path: 'my-schedule',
+        name: 'MySchedule',
+        component: MySchedule,
         meta: { roles: ['employee', 'supervisor', 'admin'] },
       },
       {

--- a/client/src/views/front/MySchedule.vue
+++ b/client/src/views/front/MySchedule.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="my-schedule">
+    <el-table v-if="schedules.length" :data="schedules" class="schedule-table">
+      <el-table-column prop="date" label="日期" width="120" />
+      <el-table-column prop="shiftId" label="班別" />
+    </el-table>
+    <p v-else>目前無排班資料</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import dayjs from 'dayjs'
+import { apiFetch } from '../../api'
+import { getToken } from '../../utils/tokenService'
+
+const schedules = ref([])
+
+onMounted(async () => {
+  const token = getToken()
+  if (!token) return
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    const userId = payload.id || payload._id || payload.sub
+    const month = dayjs().format('YYYY-MM')
+    const res = await apiFetch(`/api/schedules/monthly?month=${month}&employee=${userId}`)
+    if (res.ok) {
+      schedules.value = await res.json()
+    }
+  } catch (err) {
+    console.error(err)
+  }
+})
+</script>
+
+<style scoped>
+.my-schedule {
+  padding: 20px;
+}
+.schedule-table {
+  width: 100%;
+}
+</style>

--- a/client/tests/mySchedule.spec.js
+++ b/client/tests/mySchedule.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import dayjs from 'dayjs'
+import { apiFetch } from '../src/api'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('../src/utils/tokenService', () => ({ getToken: () => localStorage.getItem('token') }))
+
+import MySchedule from '../src/views/front/MySchedule.vue'
+
+describe('MySchedule.vue', () => {
+  beforeEach(() => {
+    apiFetch.mockReset()
+    localStorage.clear()
+  })
+
+  function flush() {
+    return new Promise(resolve => setTimeout(resolve))
+  }
+
+  it('fetches schedules for current user', async () => {
+    const token = `h.${btoa(JSON.stringify({ id: 'emp1', role: 'employee' }))}.s`
+    localStorage.setItem('token', token)
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => [{ date: '2023-01-01', shiftId: 'A' }] })
+
+    const wrapper = shallowMount(MySchedule, {
+      global: {
+        stubs: {
+          'el-table': { template: '<div><slot></slot></div>' },
+          'el-table-column': true
+        }
+      }
+    })
+    await flush()
+    expect(apiFetch).toHaveBeenCalledWith(`/api/schedules/monthly?month=${dayjs().format('YYYY-MM')}&employee=emp1`)
+    expect(wrapper.vm.schedules).toHaveLength(1)
+  })
+})

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -49,8 +49,9 @@ export async function listMonthlySchedules(req, res) {
       const emps = await Employee.find({ supervisor }).select('_id');
       const ids = emps.map((e) => e._id.toString());
       query.employee = { $in: ids };
-    } else if (employee) {
-      query.employee = employee;
+    } else {
+      const empId = employee || (req.user?.role === 'employee' ? req.user.id : undefined);
+      if (empId) query.employee = empId;
     }
 
     const schedules = await ShiftSchedule.find(query).populate('employee');

--- a/server/tests/employeeMonthlySchedule.test.js
+++ b/server/tests/employeeMonthlySchedule.test.js
@@ -1,0 +1,37 @@
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+
+const mockShiftSchedule = { find: jest.fn() }
+const mockEmployee = { find: jest.fn() }
+
+jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }))
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }))
+
+let app
+let scheduleRoutes
+
+beforeAll(async () => {
+  scheduleRoutes = (await import('../src/routes/scheduleRoutes.js')).default
+  app = express()
+  app.use(express.json())
+  app.use((req, res, next) => {
+    req.user = { id: 'emp1', role: 'employee' }
+    next()
+  })
+  app.use('/api/schedules', scheduleRoutes)
+})
+
+beforeEach(() => {
+  mockShiftSchedule.find.mockReset()
+})
+
+describe('Employee monthly schedules', () => {
+  it('defaults employee param to req.user.id when missing', async () => {
+    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) })
+    const res = await request(app).get('/api/schedules/monthly?month=2023-01')
+    expect(res.status).toBe(200)
+    expect(mockShiftSchedule.find).toHaveBeenCalled()
+    expect(mockShiftSchedule.find.mock.calls[0][0].employee).toBe('emp1')
+  })
+})


### PR DESCRIPTION
## Summary
- add MySchedule view for employees to check their monthly shifts
- restrict monthly schedule listing to current employee when missing param
- cover employee schedule access with unit tests

## Testing
- `npm --prefix server test`
- `npm --prefix client test` *(fails: fieldSetting.spec.js, frontLayout.spec.js, orgDepartmentSetting.spec.js, schedule.spec.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b42a22d6e88329bf2d966840119bc2