### PR TITLE
修正簽核詳情 approver 型態錯誤並新增測試

### DIFF
--- a/client/src/views/front/Approval.vue
+++ b/client/src/views/front/Approval.vue
@@ -694,9 +694,13 @@ async function openDetail(id) {
     detail.doc = data
     detail.visible = true
     // 補快取人名
-    (detail.doc.steps || []).forEach(s => s.approvers.forEach(a => {
-      if (a.approver?._id && a.approver?.name) employeeNameCache[a.approver._id] = a.approver.name
-    }))
+    const steps = Array.isArray(detail.doc.steps) ? detail.doc.steps : []
+    steps.forEach(s => {
+      const approvers = Array.isArray(s.approvers) ? s.approvers : []
+      approvers.forEach(a => {
+        if (a.approver?._id && a.approver?.name) employeeNameCache[a.approver._id] = a.approver.name
+      })
+    })
   }
 }
 

--- a/client/tests/approval.spec.js
+++ b/client/tests/approval.spec.js
@@ -97,4 +97,26 @@ describe('Approval.vue', () => {
     expect(wrapper.html()).toContain('測試')
     window.fetch.mockRestore()
   })
+
+  it('handles non-array approvers in detail steps', async () => {
+    const doc = {
+      _id: 'a1',
+      form: { name: '請假單', category: '請假', fields: [] },
+      applicant_employee: { name: 'Bob' },
+      status: 'pending',
+      form_data: {},
+      steps: [{ approvers: true }]
+    }
+    vi.spyOn(window, 'fetch').mockImplementation((url) => {
+      if (url.includes('/api/approvals/a1')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(doc) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+    const wrapper = shallowMount(Approval, { global: { stubs } })
+    await flushPromises()
+    await expect(wrapper.vm.openDetail('a1')).resolves.toBeUndefined()
+    expect(wrapper.vm.detail.visible).toBe(true)
+    window.fetch.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- 修正簽核詳情中 approvers 資料不是陣列時的錯誤處理
- 為 Approval.vue 新增測試涵蓋非陣列 approver

## Testing
- `npm test` *(部分測試失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68b42c0a09ac8329bc6dcf797111268f