### PR TITLE
feat: 取得送審單時附帶表單欄位

### DIFF
--- a/server/src/controllers/approvalRequestController.js
+++ b/server/src/controllers/approvalRequestController.js
@@ -1,6 +1,7 @@
 import ApprovalWorkflow from '../models/approval_workflow.js'
 import ApprovalRequest from '../models/approval_request.js'
 import FormTemplate from '../models/form_template.js'
+import FormField from '../models/form_field.js'
 import Employee from '../models/Employee.js'
 
 /* 依流程步驟解析「此關簽核人」 */
@@ -129,7 +130,10 @@ export async function getApprovalRequest(req, res) {
       .populate('applicant_employee', 'name employeeId department organization')
       .populate('steps.approvers.approver', 'name employeeId')
     if (!doc) return res.status(404).json({ error: 'not found' })
-    res.json(doc)
+    const fields = await FormField.find({ form: doc.form._id }).sort({ order: 1 })
+    const result = doc.toObject()
+    result.form.fields = fields
+    res.json(result)
   } catch (e) {
     res.status(400).json({ error: e.message })
   }

--- a/server/tests/getApprovalRequest.test.js
+++ b/server/tests/getApprovalRequest.test.js
@@ -1,0 +1,54 @@
+import request from 'supertest'
+import express from 'express'
+import { jest } from '@jest/globals'
+
+const mockApprovalRequest = { findById: jest.fn() }
+const mockFormField = { find: jest.fn() }
+
+let app
+let approvalRoutes
+
+beforeAll(async () => {
+  await jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }))
+  await jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }))
+  await jest.unstable_mockModule('../src/middleware/auth.js', () => ({
+    authenticate: (req, res, next) => { req.user = { role: 'employee' }; next() },
+    authorizeRoles: () => (req, res, next) => next()
+  }))
+  approvalRoutes = (await import('../src/routes/approvalRoutes.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/approvals', approvalRoutes)
+})
+
+beforeEach(() => {
+  mockApprovalRequest.findById.mockReset()
+  mockFormField.find.mockReset()
+})
+
+describe('GET /api/approvals/:id', () => {
+  it('returns approval request with form fields', async () => {
+    const doc = {
+      _id: 'req1',
+      form: { _id: 'form1', name: 'F', category: 'C' },
+      form_data: { field1: 'v1' },
+      toObject() { return this }
+    }
+    const fields = [{ _id: 'field1', label: 'Field 1', order: 1 }]
+    const populate3 = jest.fn().mockResolvedValue(doc)
+    const populate2 = jest.fn().mockReturnValue({ populate: populate3 })
+    const populate1 = jest.fn().mockReturnValue({ populate: populate2 })
+    mockApprovalRequest.findById.mockReturnValue({ populate: populate1 })
+
+    const sort = jest.fn().mockResolvedValue(fields)
+    mockFormField.find.mockReturnValue({ sort })
+
+    const res = await request(app).get('/api/approvals/req1')
+
+    expect(res.status).toBe(200)
+    expect(res.body.form.fields).toEqual(fields)
+    expect(Object.keys(res.body.form_data)).toEqual(fields.map(f => f._id))
+    expect(mockFormField.find).toHaveBeenCalledWith({ form: 'form1' })
+    expect(sort).toHaveBeenCalledWith({ order: 1 })
+  })
+})


### PR DESCRIPTION
## Summary
- 查詢送審單時連同表單欄位依 order 排序回傳
- 新增測試驗證 form.fields 與 form_data 對應

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42e6d812c83298706ad13ab3625ef