### PR TITLE
使用 $elemMatch 修正待辦簽核查詢並補測試

### DIFF
--- a/server/src/controllers/approvalRequestController.js
+++ b/server/src/controllers/approvalRequestController.js
@@ -151,10 +151,14 @@ export async function inboxApprovals(req, res) {
   try {
     const empId = req.query.employee_id || req.user?.id
     // 找出目前關卡包含我，且我的 decision 是 pending 的
+    // 使用 $elemMatch 確保 approver 與 decision 位於同一子文件
     const list = await ApprovalRequest.find({
       status: 'pending',
-      'steps.approvers.approver': empId,
-      'steps.approvers.decision': 'pending',
+      steps: {
+        $elemMatch: {
+          approvers: { $elemMatch: { approver: empId, decision: 'pending' } },
+        },
+      },
     }).populate('form', 'name category')
     // 仍以程式邏輯判斷是否為當前關卡：
     const mine = list.filter(doc => {


### PR DESCRIPTION
## Summary
- 使用 `$elemMatch` 篩選 `steps.approvers`，避免錯誤匹配不同子文件
- 擴充 `inboxApprovals` 測試，涵蓋不符合待簽條件之案例

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68b42f6251f883299879f1bd9c1dab1b