### PR TITLE
feat: 加入 MySchedule 選單與測試調整

### DIFF
--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -49,6 +49,7 @@ describe('router', () => {
     const front = router.getRoutes().find(r => r.name === 'FrontLayout')
     const childRoles = front.children.map(r => ({ name: r.name, roles: r.meta && r.meta.roles }))
     expect(childRoles.find(c => c.name === 'Attendance').roles).toEqual(['employee', 'supervisor', 'admin'])
+    expect(childRoles.find(c => c.name === 'MySchedule').roles).toEqual(['employee', 'supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Schedule').roles).toEqual(['supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Approval').roles).toEqual(['employee', 'supervisor', 'admin'])
   })

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -3,6 +3,7 @@ export function getMenu(req, res) {
   const menus = {
     employee: [
       { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
+      { name: 'MySchedule', label: '我的排班', icon: 'el-icon-timer' },
       { name: 'Approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     supervisor: [

--- a/server/tests/menu.test.js
+++ b/server/tests/menu.test.js
@@ -24,6 +24,7 @@ describe('Menu API', () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.find(i => i.name === 'Attendance')).toBeDefined();
+    expect(res.body.find(i => i.name === 'MySchedule')).toBeDefined();
     expect(res.body.find(i => i.name === 'Approval')).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary
- add MySchedule menu item for employees
- verify MySchedule in backend menu test
- validate MySchedule route roles in frontend router test

## Testing
- `npm test` *(fails: multiple frontend tests report component resolution and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b43db54e0c832989f8b3885e86beb2