### PR TITLE
修正前台路由大小寫解析與選單導向

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -76,12 +76,14 @@ const routes = [
       {
         path: 'attendance',
         name: 'Attendance',
+        alias: 'Attendance',
         component: Attendance,
         meta: { roles: ['employee', 'supervisor', 'admin'] },
       },
       {
         path: 'my-schedule',
         name: 'MySchedule',
+        alias: 'MySchedule',
         component: MySchedule,
         meta: { roles: ['employee', 'supervisor', 'admin'] },
       },
@@ -106,6 +108,7 @@ const routes = [
       {
         path: 'approval',
         name: 'Approval',
+        alias: 'Approval',
         component: Approval,
         meta: { roles: ['employee', 'supervisor', 'admin'] },
       },

--- a/client/src/views/front/FrontLayout.vue
+++ b/client/src/views/front/FrontLayout.vue
@@ -62,7 +62,7 @@ const menuStore = useMenuStore();
 const { items: menuItems } = storeToRefs(menuStore);
 
 const username = ref("");
-const activeMenu = computed(() => route.name?.toLowerCase() || "");
+const activeMenu = computed(() => route.name || "");
 
 onMounted(() => {
   const savedUsername = localStorage.getItem("username");
@@ -76,7 +76,7 @@ onMounted(() => {
 });
 
 function gotoPage(pageName) {
-  router.push(`/front/${pageName}`);
+  router.push({ name: pageName });
 }
 
   function onLogout() {

--- a/client/tests/frontLayout.spec.js
+++ b/client/tests/frontLayout.spec.js
@@ -11,7 +11,11 @@ vi.mock('vue-router', () => ({
 }))
 
 vi.mock('../src/stores/menu', () => ({
-  useMenuStore: () => ({ items: ref([]), fetchMenu: vi.fn() })
+  useMenuStore: () => ({
+    items: ref([{ name: 'MySchedule', label: '我的排班' }]),
+    fetchMenu: vi.fn(),
+    setMenu: vi.fn(),
+  })
 }))
 
 describe('FrontLayout manager button', () => {
@@ -22,6 +26,8 @@ describe('FrontLayout manager button', () => {
 
   afterAll(() => {
     vi.resetModules()
+    vi.unmock('vue-router')
+    vi.unmock('../src/stores/menu')
   })
 
   function mountLayout() {
@@ -53,5 +59,12 @@ describe('FrontLayout manager button', () => {
     localStorage.setItem('role', 'employee')
     const wrapper = mountLayout()
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
+  })
+
+  it('點選我的排班導向 MySchedule', async () => {
+    const wrapper = mountLayout()
+    await wrapper.vm.$nextTick()
+    await wrapper.find('el-menu-item-stub[index="MySchedule"]').trigger('click')
+    expect(push).toHaveBeenCalledWith({ name: 'MySchedule' })
   })
 })


### PR DESCRIPTION
## Summary
- 為前台 Attendance、MySchedule、Approval 子路由加入 alias 以支援大小寫路徑
- FrontLayout 改以路由名稱計算 activeMenu 並以名稱跳轉
- 新增 FrontLayout 測試，確保點選「我的排班」會以名稱導向

## Testing
- `CI=1 npm test` *(失敗：部分測試檔案未通過)*

------
https://chatgpt.com/codex/tasks/task_e_68b440aad090832986a6b42059245c06