### PR TITLE
feat: 顯示班別名稱並格式化排班日期

### DIFF
--- a/client/src/views/front/MySchedule.vue
+++ b/client/src/views/front/MySchedule.vue
@@ -2,7 +2,7 @@
   <div class="my-schedule">
     <el-table v-if="schedules.length" :data="schedules" class="schedule-table">
       <el-table-column prop="date" label="日期" width="120" />
-      <el-table-column prop="shiftId" label="班別" />
+      <el-table-column prop="shiftName" label="班別" />
     </el-table>
     <p v-else>目前無排班資料</p>
   </div>
@@ -15,17 +15,37 @@ import { apiFetch } from '../../api'
 import { getToken } from '../../utils/tokenService'
 
 const schedules = ref([])
+const shiftMap = ref({})
+
+async function fetchShifts() {
+  try {
+    const res = await apiFetch('/api/attendance-settings')
+    if (res.ok) {
+      const data = await res.json()
+      const list = Array.isArray(data?.shifts) ? data.shifts : data
+      shiftMap.value = Object.fromEntries(list.map(s => [s._id, s.name]))
+    }
+  } catch (err) {
+    console.error(err)
+  }
+}
 
 onMounted(async () => {
   const token = getToken()
   if (!token) return
   try {
+    await fetchShifts()
     const payload = JSON.parse(atob(token.split('.')[1]))
     const userId = payload.id || payload._id || payload.sub
     const month = dayjs().format('YYYY-MM')
     const res = await apiFetch(`/api/schedules/monthly?month=${month}&employee=${userId}`)
     if (res.ok) {
-      schedules.value = await res.json()
+      const data = await res.json()
+      schedules.value = data.map(s => ({
+        ...s,
+        date: dayjs(s.date).format('YYYY/MM/DD'),
+        shiftName: shiftMap.value[s.shiftId] || ''
+      }))
     }
   } catch (err) {
     console.error(err)

--- a/client/tests/mySchedule.spec.js
+++ b/client/tests/mySchedule.spec.js
@@ -18,10 +18,12 @@ describe('MySchedule.vue', () => {
     return new Promise(resolve => setTimeout(resolve))
   }
 
-  it('fetches schedules for current user', async () => {
+  it('fetches schedules with shift names and formatted dates', async () => {
     const token = `h.${btoa(JSON.stringify({ id: 'emp1', role: 'employee' }))}.s`
     localStorage.setItem('token', token)
-    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => [{ date: '2023-01-01', shiftId: 'A' }] })
+    apiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: '1', name: '早班' }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ date: '2023-01-01', shiftId: '1' }] })
 
     const wrapper = shallowMount(MySchedule, {
       global: {
@@ -32,7 +34,9 @@ describe('MySchedule.vue', () => {
       }
     })
     await flush()
-    expect(apiFetch).toHaveBeenCalledWith(`/api/schedules/monthly?month=${dayjs().format('YYYY-MM')}&employee=emp1`)
-    expect(wrapper.vm.schedules).toHaveLength(1)
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/attendance-settings')
+    expect(apiFetch).toHaveBeenNthCalledWith(2, `/api/schedules/monthly?month=${dayjs().format('YYYY-MM')}&employee=emp1`)
+    expect(wrapper.vm.schedules[0].shiftName).toBe('早班')
+    expect(wrapper.vm.schedules[0].date).toBe('2023/01/01')
   })
 })


### PR DESCRIPTION
## Summary
- 前台顯示班別名稱並同步取得班別列表
- 排班日期統一格式化為 YYYY/MM/DD
- 新增測試驗證班別名稱與日期格式

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b443e32f1c83298655bfdc7390fd2c