### PR TITLE
feat: 班表顯示班別名稱並格式化日期

### DIFF
--- a/server/tests/employeeMonthlySchedule.test.js
+++ b/server/tests/employeeMonthlySchedule.test.js
@@ -4,9 +4,11 @@ import { jest } from '@jest/globals'
 
 const mockShiftSchedule = { find: jest.fn() }
 const mockEmployee = { find: jest.fn() }
+const mockAttendanceSetting = { findOne: jest.fn() }
 
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }))
 jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }))
+jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }))
 
 let app
 let scheduleRoutes
@@ -24,11 +26,18 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockShiftSchedule.find.mockReset()
+  mockAttendanceSetting.findOne.mockReset()
+  mockAttendanceSetting.findOne.mockReturnValue({
+    lean: jest.fn().mockResolvedValue({ shifts: [] })
+  })
 })
 
 describe('Employee monthly schedules', () => {
   it('defaults employee param to req.user.id when missing', async () => {
-    mockShiftSchedule.find.mockReturnValue({ populate: jest.fn().mockResolvedValue([]) })
+    mockShiftSchedule.find.mockReturnValue({
+      populate: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([])
+    })
     const res = await request(app).get('/api/schedules/monthly?month=2023-01')
     expect(res.status).toBe(200)
     expect(mockShiftSchedule.find).toHaveBeenCalled()

--- a/server/tests/schedule.unit.test.js
+++ b/server/tests/schedule.unit.test.js
@@ -9,11 +9,13 @@ const mockShiftSchedule = {
 const mockApprovalRequest = { findOne: jest.fn() };
 const mockFormTemplate = { findOne: jest.fn() };
 const mockFormField = { find: jest.fn() };
+const mockAttendanceSetting = { findOne: jest.fn() };
 
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
 jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }));
 jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: mockFormTemplate }));
 jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }));
+jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }));
 
 const { createSchedule, createSchedulesBatch, updateSchedule } = await import('../src/controllers/scheduleController.js');
 


### PR DESCRIPTION
## Summary
- 以 AttendanceSetting 對照 shiftId 將班別名稱附加到排班資料，日期格式統一為 YYYY/MM/DD
- 匯出 Excel/PDF 時加入 shiftName 欄位並套用同樣日期格式
- 更新相關排班 API 測試以符合新格式

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b444f637188329aaff975ba2d97062