### PR TITLE
統一日期格式為 YYYY/MM/DD 並補測試

### DIFF
--- a/client/src/components/backComponents/ShiftScheduleSetting.vue
+++ b/client/src/components/backComponents/ShiftScheduleSetting.vue
@@ -435,7 +435,7 @@ import { apiFetch } from '../../api'
 import { getToken } from '../../utils/tokenService'
 
 const activeTab = ref('calendar')
-const dateFormat = 'YYYY-MM-DD'
+const dateFormat = 'YYYY/MM/DD'
 const timeFormat = 'HH:mm'
 
 // =========== 1) 年度行事曆/休假日設定 ===========

--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -133,7 +133,7 @@ async function fetchRecords() {
     const data = await res.json()
     records.value = data.map(r => ({
       action: reverseActionMap[r.action] || r.action,
-      time: dayjs(r.timestamp).format('YYYY-MM-DD HH:mm:ss'),
+      time: dayjs(r.timestamp).format('YYYY/MM/DD HH:mm:ss'),
       remark: r.remark || ''
     }))
   }
@@ -202,7 +202,7 @@ async function addRecord(action, remark = '') {
     const saved = await res.json()
     records.value.push({
       action: reverseActionMap[saved.action] || saved.action,
-      time: dayjs(saved.timestamp).format('YYYY-MM-DD HH:mm:ss'),
+      time: dayjs(saved.timestamp).format('YYYY/MM/DD HH:mm:ss'),
       remark: saved.remark || ''
     })
   }
@@ -211,7 +211,7 @@ async function addRecord(action, remark = '') {
 function updateTime() {
   const now = dayjs()
   currentTime.value = now.format('HH:mm:ss')
-  currentDate.value = now.format('YYYY年MM月DD日 dddd')
+  currentDate.value = now.format('YYYY/MM/DD dddd')
 }
 
 function getActionTagType(action) {

--- a/client/tests/attendanceDateFormat.spec.js
+++ b/client/tests/attendanceDateFormat.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import dayjs from 'dayjs'
+
+import Attendance from '../src/views/front/Attendance.vue'
+import { apiFetch } from '../src/api'
+import { getToken } from '../src/utils/tokenService'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('../src/utils/tokenService', () => ({ getToken: vi.fn() }))
+
+const stubs = {
+  'el-table': { template: '<div><slot></slot></div>' },
+  'el-table-column': true,
+  'el-tag': { template: '<div><slot></slot></div>' },
+  'el-dialog': { template: '<div><slot></slot></div>' },
+  'el-input': true,
+  'el-button': true
+}
+
+describe('Attendance.vue 日期格式', () => {
+  beforeEach(() => {
+    apiFetch.mockReset()
+    getToken.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function flush() {
+    return new Promise(resolve => setTimeout(resolve))
+  }
+
+  it('以 YYYY/MM/DD HH:mm:ss 儲存打卡時間，並顯示 YYYY/MM/DD 日期', async () => {
+    const ts = '2024-05-01T08:00:00'
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [{ action: 'clockIn', timestamp: ts, remark: '' }] })
+
+    const wrapper = shallowMount(Attendance, { global: { stubs, mocks: { ElMessage: { warning: vi.fn() } } } })
+    await flush()
+    expect(wrapper.vm.records[0].time).toBe(dayjs(ts).format('YYYY/MM/DD HH:mm:ss'))
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(ts))
+    wrapper.vm.updateTime()
+    expect(wrapper.vm.currentDate).toBe(dayjs(ts).format('YYYY/MM/DD dddd'))
+  })
+})

--- a/client/tests/shiftScheduleSettingDateFormat.spec.js
+++ b/client/tests/shiftScheduleSettingDateFormat.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+
+import ShiftScheduleSetting from '../src/components/backComponents/ShiftScheduleSetting.vue'
+import { apiFetch } from '../src/api'
+import { getToken } from '../src/utils/tokenService'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('../src/utils/tokenService', () => ({ getToken: vi.fn() }))
+
+const stubs = {
+  'el-form': true,
+  'el-form-item': true,
+  'el-input': true,
+  'el-select': true,
+  'el-option': true,
+  'el-date-picker': true,
+  'el-button': true,
+  'el-dialog': true,
+  'el-table': true,
+  'el-table-column': true,
+  'el-tabs': true,
+  'el-tab-pane': true,
+  'el-checkbox': true,
+  'el-switch': true,
+  'el-tag': true,
+  'el-time-picker': true,
+  'el-input-number': true
+}
+
+describe('ShiftScheduleSetting.vue 日期格式', () => {
+  beforeEach(() => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
+  })
+
+  it('使用 YYYY/MM/DD 作為日期格式', async () => {
+    const wrapper = shallowMount(ShiftScheduleSetting, { global: { stubs } })
+    await Promise.resolve()
+    expect(wrapper.vm.dateFormat).toBe('YYYY/MM/DD')
+  })
+})


### PR DESCRIPTION
## Summary
- 將排班設定與出勤頁面日期格式統一為 `YYYY/MM/DD`
- 新增前端測試，驗證 ShiftScheduleSetting 與 Attendance 使用新日期格式

## Testing
- `npm --prefix server test`
- `npm --prefix client test tests/attendanceDateFormat.spec.js tests/shiftScheduleSettingDateFormat.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b444f715808329b3c98ff65f07c0b6