### PR TITLE
Allow employees to view attendance settings

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -268,7 +268,7 @@ app.use(
   authenticate,
   (req, res, next) => {
     if (req.method === 'GET') {
-      return authorizeRoles('supervisor', 'admin')(req, res, next);
+      return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
     }
     return authorizeRoles('admin')(req, res, next);
   },

--- a/server/tests/attendanceSettingsAccess.test.js
+++ b/server/tests/attendanceSettingsAccess.test.js
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const findOne = jest.fn().mockResolvedValue({ shifts: [{ name: '日班' }] });
+
+jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({
+  default: { findOne }
+}));
+
+let app;
+let authorizeRoles;
+let attendanceShiftRoutes;
+
+beforeAll(async () => {
+  ({ authorizeRoles } = await import('../src/middleware/auth.js'));
+  attendanceShiftRoutes = (await import('../src/routes/attendanceShiftRoutes.js')).default;
+
+  app = express();
+  app.use(express.json());
+  // 模擬已驗證的員工使用者
+  app.use((req, res, next) => {
+    req.user = { role: 'employee' };
+    next();
+  });
+  app.use(
+    '/api/attendance-settings',
+    (req, res, next) => {
+      if (req.method === 'GET') {
+        return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
+      }
+      return authorizeRoles('admin')(req, res, next);
+    },
+    attendanceShiftRoutes
+  );
+});
+
+afterEach(() => {
+  findOne.mockClear();
+});
+
+describe('Attendance settings access', () => {
+  it('允許員工取得班別資料', async () => {
+    const res = await request(app).get('/api/attendance-settings');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ name: '日班' }]);
+    expect(findOne).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Permit employee role to access attendance settings
- Add test verifying employee can fetch attendance settings

## Testing
- `npm test` *(server tests passed; client tests reported failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b44aec11c883299608e29f5a3e8e6b