### PR TITLE
改進前端 API 基底網址以自動指向部署網域

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ npm run dev
    \`\`\`bash
    npm install
    \`\`\`
-2. (選擇性) 在 `client/.env` 設定 `VITE_API_BASE_URL` 以指定後端 API 位址，預設可使用 `http://localhost:3000`
+2. (選擇性) 在 `client/.env` 設定 `VITE_API_BASE_URL` 以指定後端 API 位址；未設定時，前端將自動使用目前網域（開發伺服器仍預設代理至 `http://localhost:3000`）
 3. 啟動 Vite 開發伺服器：
    \`\`\`bash
    npm run dev

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,7 +1,7 @@
 import { getToken, clearToken } from './utils/tokenService'
 
 export const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000'
+  import.meta.env.VITE_API_BASE_URL ?? window.location.origin
 
 export function apiFetch(path, options = {}, { autoRedirect = true } = {}) {
   const token = getToken()

--- a/client/tests/apiBaseUrl.spec.js
+++ b/client/tests/apiBaseUrl.spec.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+describe('API_BASE_URL', () => {
+  const originalEnv = { ...import.meta.env }
+  const originalLocation = window.location
+
+  afterEach(() => {
+    import.meta.env.VITE_API_BASE_URL = originalEnv.VITE_API_BASE_URL
+    window.location = originalLocation
+    vi.resetModules()
+  })
+
+  it('uses env variable when provided', async () => {
+    vi.resetModules()
+    import.meta.env.VITE_API_BASE_URL = 'https://api.example.com'
+    const { API_BASE_URL } = await import('../src/api')
+    expect(API_BASE_URL).toBe('https://api.example.com')
+  })
+
+  it('falls back to window.location.origin', async () => {
+    vi.resetModules()
+    delete import.meta.env.VITE_API_BASE_URL
+    Object.defineProperty(window, 'location', { value: { origin: 'https://app.example.com' }, writable: true })
+    const { API_BASE_URL } = await import('../src/api')
+    expect(API_BASE_URL).toBe('https://app.example.com')
+  })
+})

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,7 +7,8 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  const API_BASE_URL = env.VITE_API_BASE_URL ?? 'http://localhost:3000'
+  // 使用於開發伺服器代理，未設定時預設指向本機後端
+  const API_BASE_URL = env.VITE_API_BASE_URL || 'http://localhost:3000'
   return {
     plugins: [
       vue(),


### PR DESCRIPTION
## Summary
- 前端預設 API_BASE_URL 改以 `window.location.origin`，未設定環境變數時自動指向部署網域
- 開發環境 Vite 代理改為以 `||` 設定 `API_BASE_URL`，並新增相關說明
- 新增 `API_BASE_URL` 預設行為測試

## Testing
- `npm run build`
- `rg 'http://localhost:3000' -n dist`
- `npm test` *(failed: multiple component resolution errors)*
- `npm test tests/apiBaseUrl.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b46606c2148329af1454767b9570ff