### PR TITLE
fix: use correct API base URL in production

### DIFF
--- a/client/tests/viteConfig.spec.js
+++ b/client/tests/viteConfig.spec.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vite', () => ({
+  defineConfig: fn => fn,
+  loadEnv: () => ({})
+}))
+
+import configFactory from '../vite.config'
+
+describe('vite.config', () => {
+  it('defaults to localhost proxy in development', () => {
+    const config = configFactory({ mode: 'development' })
+    expect(config.server.proxy['/api'].target).toBe('http://localhost:3000')
+  })
+
+  it('omits server proxy in production without env', () => {
+    const config = configFactory({ mode: 'production' })
+    expect(config.server).toBeUndefined()
+  })
+})

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,9 +7,9 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  // 使用於開發伺服器代理，未設定時預設指向本機後端
-  const API_BASE_URL = env.VITE_API_BASE_URL || 'http://localhost:3000'
-  return {
+  const API_BASE_URL = env.VITE_API_BASE_URL || (mode === 'development' ? 'http://localhost:3000' : '')
+
+  const config = {
     plugins: [
       vue(),
       vueDevTools(),
@@ -19,16 +19,21 @@ export default defineConfig(({ mode }) => {
         '@': fileURLToPath(new URL('./src', import.meta.url))
       },
     },
-    server: {
+    test: {
+      environment: 'jsdom'
+    }
+  }
+
+  if (mode === 'development') {
+    config.server = {
       proxy: {
         '/api': {
           target: API_BASE_URL,
           changeOrigin: true
         }
       }
-    },
-    test: {
-      environment: 'jsdom'
     }
   }
+
+  return config
 })


### PR DESCRIPTION
## Summary
- avoid using localhost API proxy in production by only enabling dev server proxy when in development mode
- add tests covering vite config behavior

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68b477191a208329a9335829dff81e70