### PR TITLE
feat: 主管排班摘要 API

### DIFF
--- a/server/src/routes/scheduleRoutes.js
+++ b/server/src/routes/scheduleRoutes.js
@@ -9,15 +9,18 @@ import {
   listMonthlySchedules,
   createSchedulesBatch,
   deleteOldSchedules,
-  listLeaveApprovals
+  listLeaveApprovals,
+  listSupervisorSummary
 } from '../controllers/scheduleController.js';
 import { verifySupervisor } from '../middleware/supervisor.js';
+import { authenticate, authorizeRoles } from '../middleware/auth.js';
 
 const router = Router();
 
 router.get('/', listSchedules);
 router.get('/monthly', listMonthlySchedules);
 router.get('/leave-approvals', listLeaveApprovals);
+router.get('/summary', authenticate, authorizeRoles('supervisor'), listSupervisorSummary);
 router.get('/export', exportSchedules);
 router.post('/batch', verifySupervisor, createSchedulesBatch);
 router.post('/', verifySupervisor, createSchedule);

--- a/server/tests/employeeSchedulePermissions.test.js
+++ b/server/tests/employeeSchedulePermissions.test.js
@@ -28,7 +28,8 @@ jest.unstable_mockModule('../src/controllers/scheduleController.js', () => ({
   listMonthlySchedules: jest.fn(),
   createSchedulesBatch: jest.fn(),
   deleteOldSchedules: jest.fn(),
-  listLeaveApprovals: jest.fn()
+  listLeaveApprovals: jest.fn(),
+  listSupervisorSummary: jest.fn()
 }));
 
 let app;

--- a/server/tests/scheduleSummary.test.js
+++ b/server/tests/scheduleSummary.test.js
@@ -1,0 +1,69 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const mockShiftSchedule = { find: jest.fn() };
+const mockEmployee = { find: jest.fn() };
+const mockAttendanceSetting = { findOne: jest.fn() };
+
+jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
+jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }));
+
+jest.unstable_mockModule('../src/middleware/auth.js', () => ({
+  authenticate: (req, res, next) => {
+    req.user = { id: 'sup1', role: 'supervisor' };
+    next();
+  },
+  authorizeRoles: () => (req, res, next) => next(),
+}));
+
+let app;
+let scheduleRoutes;
+
+beforeAll(async () => {
+  scheduleRoutes = (await import('../src/routes/scheduleRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/schedules', scheduleRoutes);
+});
+
+beforeEach(() => {
+  mockShiftSchedule.find.mockReset();
+  mockEmployee.find.mockReset();
+  mockAttendanceSetting.findOne.mockReset();
+});
+
+describe('Supervisor schedule summary', () => {
+  it('主管只能取得自己員工的摘要', async () => {
+    mockEmployee.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        { _id: 'emp1', name: 'Emp1' },
+        { _id: 'emp2', name: 'Emp2' },
+      ]),
+    });
+
+    mockAttendanceSetting.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        shifts: [{ _id: 'shift1', name: '早班' }],
+      }),
+    });
+
+    mockShiftSchedule.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { employee: 'emp1', shiftId: 'shift1', date: new Date('2023-05-01') },
+        { employee: 'emp3', shiftId: 'shift1', date: new Date('2023-05-02') },
+      ]),
+    });
+
+    const res = await request(app).get('/api/schedules/summary?month=2023-05');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { employee: 'emp1', name: 'Emp1', shiftCount: 1, leaveCount: 0, absenceCount: 0 },
+      { employee: 'emp2', name: 'Emp2', shiftCount: 0, leaveCount: 0, absenceCount: 0 },
+    ]);
+    expect(res.body.find(e => e.employee === 'emp3')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 listSupervisorSummary 以主管與月份聚合員工排班、請假及缺班
- 新增 /api/schedules/summary 路由並限制主管存取
- 撰寫整合測試驗證主管僅能取得自己員工的摘要

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5acaf9f508329a34f1be4da3302c6