### PR TITLE
新增排班儀表板與員工搜尋功能

### DIFF
--- a/client/src/views/front/ScheduleDashboard.vue
+++ b/client/src/views/front/ScheduleDashboard.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="dashboard">
+    <el-card class="metric-card" v-for="item in metrics" :key="item.label">
+      <div class="metric-label">{{ item.label }}</div>
+      <div class="metric-value">{{ item.value }}</div>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+const props = defineProps({
+  summary: {
+    type: Object,
+    default: () => ({ direct: 0, unscheduled: 0, onLeave: 0 })
+  }
+})
+
+const metrics = computed(() => [
+  { label: '直屬員工數', value: props.summary.direct },
+  { label: '未排班員工', value: props.summary.unscheduled },
+  { label: '請假中員工', value: props.summary.onLeave }
+])
+</script>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  gap: 16px;
+  margin: 24px 0;
+}
+.metric-card {
+  flex: 1;
+  text-align: center;
+}
+.metric-label {
+  color: #475569;
+  margin-bottom: 8px;
+}
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f766e;
+}
+</style>

--- a/client/tests/scheduleDashboard.spec.js
+++ b/client/tests/scheduleDashboard.spec.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ScheduleDashboard from '../src/views/front/ScheduleDashboard.vue'
+
+describe('ScheduleDashboard.vue', () => {
+  it('renders metrics', () => {
+    const wrapper = mount(ScheduleDashboard, {
+      props: { summary: { direct: 3, unscheduled: 1, onLeave: 2 } },
+      global: {
+        stubs: { 'el-card': { template: '<div><slot></slot></div>' } }
+      }
+    })
+    expect(wrapper.text()).toContain('直屬員工數')
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('未排班員工')
+    expect(wrapper.text()).toContain('1')
+    expect(wrapper.text()).toContain('請假中員工')
+    expect(wrapper.text()).toContain('2')
+  })
+})


### PR DESCRIPTION
## Summary
- 新增 `ScheduleDashboard` 元件，以卡片呈現直屬員工數、未排班及請假人數
- `Schedule.vue` 匯入儀表板並於月分變更與載入時呼叫 `/api/schedules/summary`
- 加入員工搜尋欄位，支援大量員工時快速篩選

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ae05b54083299ef8d923f6c41d29