### PR TITLE
feat: enhance schedule dashboard and table

### DIFF
--- a/client/src/views/front/ScheduleDashboard.vue
+++ b/client/src/views/front/ScheduleDashboard.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="dashboard">
     <el-card class="metric-card" v-for="item in metrics" :key="item.label">
+      <component :is="item.icon" class="metric-icon" :style="{ color: item.color }" />
       <div class="metric-label">{{ item.label }}</div>
       <div class="metric-value">{{ item.value }}</div>
     </el-card>
@@ -9,6 +10,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { UserFilled, CircleCloseFilled, WarningFilled } from '@element-plus/icons-vue'
 const props = defineProps({
   summary: {
     type: Object,
@@ -17,9 +19,9 @@ const props = defineProps({
 })
 
 const metrics = computed(() => [
-  { label: '直屬員工數', value: props.summary.direct },
-  { label: '未排班員工', value: props.summary.unscheduled },
-  { label: '請假中員工', value: props.summary.onLeave }
+  { label: '直屬員工數', value: props.summary.direct, icon: UserFilled, color: '#0f766e' },
+  { label: '未排班員工', value: props.summary.unscheduled, icon: CircleCloseFilled, color: '#dc2626' },
+  { label: '請假中員工', value: props.summary.onLeave, icon: WarningFilled, color: '#f59e0b' }
 ])
 </script>
 
@@ -32,6 +34,10 @@ const metrics = computed(() => [
 .metric-card {
   flex: 1;
   text-align: center;
+}
+.metric-icon {
+  font-size: 24px;
+  margin-bottom: 4px;
 }
 .metric-label {
   color: #475569;

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -210,6 +210,42 @@ describe('Schedule.vue', () => {
     expect(wrapper.vm.filteredEmployees[0].name).toBe('Alice')
   })
 
+  it('filters employees by status', async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+    wrapper.vm.employees = [
+      { _id: 'e1', name: 'A', department: '', subDepartment: '' },
+      { _id: 'e2', name: 'B', department: '', subDepartment: '' }
+    ]
+    wrapper.vm.scheduleMap = {
+      e1: { 1: { shiftId: '', department: '', subDepartment: '' } },
+      e2: { 1: { shiftId: 's1', department: '', subDepartment: '', leave: {} } }
+    }
+    wrapper.vm.statusFilter = 'unscheduled'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.filteredEmployees.map(e => e._id)).toEqual(['e1'])
+    wrapper.vm.statusFilter = 'onLeave'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.filteredEmployees.map(e => e._id)).toEqual(['e2'])
+  })
+
+  it('toggles row expansion in lazy mode', async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+    wrapper.vm.employees = Array.from({ length: 51 }, (_, i) => ({
+      _id: 'e' + i,
+      name: 'E' + i,
+      department: '',
+      subDepartment: ''
+    }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.lazyMode).toBe(true)
+    wrapper.vm.toggleRow('e1')
+    expect(wrapper.vm.expandedRows.has('e1')).toBe(true)
+  })
+
   it('reverts change when update fails', async () => {
     apiFetch
       .mockResolvedValueOnce({ ok: true, json: async () => [] })

--- a/client/tests/scheduleDashboard.spec.js
+++ b/client/tests/scheduleDashboard.spec.js
@@ -16,5 +16,6 @@ describe('ScheduleDashboard.vue', () => {
     expect(wrapper.text()).toContain('1')
     expect(wrapper.text()).toContain('請假中員工')
     expect(wrapper.text()).toContain('2')
+    expect(wrapper.findAll('.metric-icon').length).toBe(3)
   })
 })


### PR DESCRIPTION
## Summary
- show colored icons for schedule metrics
- add employee status filter, icons, and lazy row expansion
- cover dashboard and schedule behaviors in tests

## Testing
- `npm test` *(fails: multiple client tests due to unresolved components)*

------
https://chatgpt.com/codex/tasks/task_e_68b5afcf4c4c8329929e9b2beb2d343c