### PR TITLE
fix: load env from server path in seed script

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -1,9 +1,15 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { connectDB } from '../src/config/db.js';
-import { seedSampleData, seedTestUsers, seedApprovalTemplates } from '../src/index.js';
 
-dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+const { seedSampleData, seedTestUsers, seedApprovalTemplates } = await import('../src/index.js');
 
 if (!process.env.MONGODB_URI) {
   console.error('MONGODB_URI is not defined in the environment');

--- a/server/tests/seedScript.test.js
+++ b/server/tests/seedScript.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+import path from 'path';
+
+test('seed script loads env from server/.env', async () => {
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  const configMock = jest.fn();
+
+  await jest.unstable_mockModule('dotenv', () => ({ default: { config: configMock } }));
+  await jest.unstable_mockModule('../src/config/db.js', () => ({ connectDB: jest.fn() }));
+  await jest.unstable_mockModule('../src/index.js', () => ({
+    seedSampleData: jest.fn(),
+    seedTestUsers: jest.fn(),
+    seedApprovalTemplates: jest.fn()
+  }));
+  await jest.unstable_mockModule('mongoose', () => ({ default: { disconnect: jest.fn() } }));
+
+  await import('../scripts/seed.js');
+
+  expect(configMock).toHaveBeenCalledWith({ path: path.resolve(process.cwd(), '.env') });
+});


### PR DESCRIPTION
## Summary
- resolve .env path in server/scripts/seed.js using fileURLToPath
- add unit test ensuring seeding script reads server/.env

## Testing
- `node server/scripts/seed.js` *(fails: Operation `organizations.findOne()` buffering timed out after 10000ms)*
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68b5dd20bd0083299fab31b64cc0e549