### PR TITLE
修正 seedTestUsers 使用部門 ID 建立員工

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -91,6 +91,10 @@ export async function seedTestUsers() {
     { username: 'salesManager', password: 'password', role: 'supervisor', signTags: ['業務負責人'] },
     { username: 'hr', password: 'password', role: 'admin', signTags: ['人資'] }
   ];
+  const org = await Organization.findOne({ name: '示範機構' });
+  const dept = await Department.findOne({ name: '人力資源部' });
+  const subDept = await SubDepartment.findOne({ name: '招聘組' });
+
   let supervisorId = null;
   for (const data of users) {
     const existing = await Employee.findOne({ username: data.username });
@@ -101,9 +105,9 @@ export async function seedTestUsers() {
         username: data.username,
         password: data.password,
         role: data.role,
-        organization: '示範機構',
-        department: '人力資源部',
-        subDepartment: '招聘組',
+        organization: org?._id.toString(),
+        department: dept?._id,
+        subDepartment: subDept?._id,
         title: 'Staff',
         status: '正職員工',
         signTags: data.signTags ?? []

--- a/server/tests/seedData.test.js
+++ b/server/tests/seedData.test.js
@@ -46,11 +46,20 @@ describe('seedSampleData', () => {
 
 describe('seedTestUsers', () => {
   it('creates test users and assigns supervisor', async () => {
+    mockOrg.findOne.mockResolvedValue({ _id: 'org1' });
+    mockDept.findOne.mockResolvedValue({ _id: 'dept1' });
+    mockSubDept.findOne.mockResolvedValue({ _id: 'sub1' });
     mockEmployee.findOne.mockResolvedValue(null);
     mockEmployee.create.mockImplementation(async (data) => ({ _id: data.username, ...data }));
     await seedTestUsers();
     expect(mockEmployee.create).toHaveBeenCalledTimes(8);
-    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'scheduler', signTags: ['排班負責人'] }));
+    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({
+      username: 'scheduler',
+      signTags: ['排班負責人'],
+      organization: 'org1',
+      department: 'dept1',
+      subDepartment: 'sub1'
+    }));
     expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'hr', signTags: ['人資'] }));
     expect(mockEmployee.updateMany).toHaveBeenCalledWith({ role: 'employee' }, { supervisor: 'salesManager' });
   });


### PR DESCRIPTION
## Summary
- 建立測試使用者時，改以查詢後的組織與部門 `_id`
- 更新種子資料測試以驗證 `_id` 使用

## Testing
- `npm --prefix server test`
- `npm test` *(fails: Client tests require UI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e0bc8aa8832985a936a451249001