### PR TITLE
測試員工建立使用部門與子部門 ID

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -91,6 +91,10 @@ export async function seedTestUsers() {
     { username: 'salesManager', password: 'password', role: 'supervisor', signTags: ['業務負責人'] },
     { username: 'hr', password: 'password', role: 'admin', signTags: ['人資'] }
   ];
+  const org = await Organization.findOne({ name: '示範機構' });
+  const dept = await Department.findOne({ code: 'HR' });
+  const subDept = await SubDepartment.findOne({ code: 'HR1' });
+
   let supervisorId = null;
   for (const data of users) {
     const existing = await Employee.findOne({ username: data.username });
@@ -101,9 +105,9 @@ export async function seedTestUsers() {
         username: data.username,
         password: data.password,
         role: data.role,
-        organization: '示範機構',
-        department: '人力資源部',
-        subDepartment: '招聘組',
+        organization: org?._id,
+        department: dept?._id,
+        subDepartment: subDept?._id,
         title: 'Staff',
         status: '正職員工',
         signTags: data.signTags ?? []

--- a/server/tests/seedData.test.js
+++ b/server/tests/seedData.test.js
@@ -46,12 +46,24 @@ describe('seedSampleData', () => {
 
 describe('seedTestUsers', () => {
   it('creates test users and assigns supervisor', async () => {
+    mockOrg.findOne.mockResolvedValue({ _id: 'org1' });
+    mockDept.findOne.mockResolvedValue({ _id: 'dept1' });
+    mockSubDept.findOne.mockResolvedValue({ _id: 'sub1' });
     mockEmployee.findOne.mockResolvedValue(null);
     mockEmployee.create.mockImplementation(async (data) => ({ _id: data.username, ...data }));
     await seedTestUsers();
     expect(mockEmployee.create).toHaveBeenCalledTimes(8);
-    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'scheduler', signTags: ['排班負責人'] }));
-    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'hr', signTags: ['人資'] }));
+    mockEmployee.create.mock.calls.forEach(([data]) => {
+      expect(data).toEqual(
+        expect.objectContaining({ organization: 'org1', department: 'dept1', subDepartment: 'sub1' })
+      );
+    });
+    expect(mockEmployee.create).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'scheduler', signTags: ['排班負責人'] })
+    );
+    expect(mockEmployee.create).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'hr', signTags: ['人資'] })
+    );
     expect(mockEmployee.updateMany).toHaveBeenCalledWith({ role: 'employee' }, { supervisor: 'salesManager' });
   });
 });


### PR DESCRIPTION
## Summary
- 模擬 Organization、Department、SubDepartment 的查詢回傳固定 ID，並更新測試
- seedTestUsers 以查得的部門與子部門 ID 建立員工

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e0c439488329afeb544fdde9ef10