### PR TITLE
調整排班儀表板排版與新增響應測試

### DIFF
--- a/client/src/views/front/ScheduleDashboard.vue
+++ b/client/src/views/front/ScheduleDashboard.vue
@@ -28,15 +28,17 @@ const metrics = computed(() => [
 <style scoped>
 .dashboard {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   margin: 24px 0;
 }
 .metric-card {
-  flex: 1;
+  width: 200px;
+  padding: 12px;
   text-align: center;
 }
 .metric-icon {
-  font-size: 24px;
+  font-size: 16px;
   margin-bottom: 4px;
 }
 .metric-label {

--- a/client/tests/scheduleDashboardResponsive.spec.js
+++ b/client/tests/scheduleDashboardResponsive.spec.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('ScheduleDashboard responsive styles', () => {
+  it('defines wrapping and card sizing', () => {
+    const file = fs.readFileSync(path.resolve(__dirname, '../src/views/front/ScheduleDashboard.vue'), 'utf-8')
+    expect(file).toMatch(/\.dashboard\s*{[^}]*flex-wrap:\s*wrap/)
+    expect(file).toMatch(/\.metric-card\s*{[^}]*width:\s*200px/)
+    expect(file).toMatch(/\.metric-icon\s*{[^}]*font-size:\s*16px/)
+  })
+})


### PR DESCRIPTION
## 摘要
- 儀表板容器改為可換行佈局，卡片固定寬度並縮小圖示
- 新增測試確認排班儀表板樣式設定

## 測試
- `npm --prefix server test`
- `npx vitest run tests/scheduleDashboardResponsive.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee75624c832986f1bd8b7851ee2e