### PR TITLE
feat: 強制 Employee email 必填並補測試

### DIFF
--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -91,7 +91,7 @@ const employeeSchema = new Schema(
     dependents: { type: Number, default: 0 }, // 扣繳
 
     /* 聯絡方式 */
-    email: { type: String, unique: true, sparse: true, index: true },
+    email: { type: String, unique: true, sparse: true, index: true, required: true },
     mobile: { type: String, alias: 'phone' }, // 前端 phone = mobile
     landline: String,
     householdAddress: String, // 戶籍地

--- a/server/tests/employee.test.js
+++ b/server/tests/employee.test.js
@@ -138,6 +138,13 @@ describe('Employee API', () => {
     expect(res.status).toBe(400);
   });
 
+  it('fails when email is missing', async () => {
+    const payload = { name: 'A', username: 'a', password: 'p' };
+    const res = await request(app).post('/api/employees').send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Email is required' });
+  });
+
   it('gets employee', async () => {
     const fake = { _id: '1', name: 'John' };
     mockEmployee.findById.mockReturnValue({ populate: jest.fn().mockResolvedValue(fake) });

--- a/server/tests/employeeModel.test.js
+++ b/server/tests/employeeModel.test.js
@@ -1,0 +1,9 @@
+import Employee from '../src/models/Employee.js';
+
+describe('Employee model validation', () => {
+  it('should require email', () => {
+    const emp = new Employee({ name: 'NoEmail' });
+    const err = emp.validateSync();
+    expect(err.errors.email.kind).toBe('required');
+  });
+});


### PR DESCRIPTION
## Summary
- Employee 模型新增 email 必填
- 新增及擴充測試，驗證缺少 email 會回傳錯誤

## Testing
- `npm test` *(failed: command not found)*
- `apt-get update` *(failed: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9297d0c74832993671541251d23ae