### PR TITLE
feat: centralize employee form validation

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -126,9 +126,10 @@
         title="員工資料管理" 
         width="1200px"
         class="employee-dialog"
-        :close-on-click-modal="false"
+      :close-on-click-modal="false"
       >
-        <el-tabs v-model="employeeDialogTab" type="border-card" class="employee-tabs">
+        <el-form ref="formRef" :model="employeeForm" :rules="rules" label-width="140px" class="employee-form">
+          <el-tabs v-model="employeeDialogTab" type="border-card" class="employee-tabs">
           <!-- 帳號/權限 -->
           <el-tab-pane name="account">
             <template #label>
@@ -139,20 +140,20 @@
             </template>
             
             <div class="tab-content">
-              <el-form :model="employeeForm" label-width="140px" class="form-section">
+              <div class="form-section">
                 <div class="form-group">
                   <h3 class="form-group-title">登入資訊</h3>
-                  <el-form-item label="登入帳號" required>
+                  <el-form-item label="登入帳號" required prop="username">
                     <el-input v-model="employeeForm.username" placeholder="請輸入登入帳號" />
                   </el-form-item>
-                  <el-form-item label="登入密碼" required>
+                  <el-form-item label="登入密碼" required prop="password">
                     <el-input v-model="employeeForm.password" type="password" placeholder="請輸入密碼" show-password />
                   </el-form-item>
                 </div>
-                
+
                 <div class="form-group">
                   <h3 class="form-group-title">權限設定</h3>
-                  <el-form-item label="系統權限" required>
+                  <el-form-item label="系統權限" required prop="role">
                     <el-radio-group v-model="employeeForm.role" class="role-radio-group">
                       <el-radio v-for="r in ROLE_OPTIONS" :key="r.value" :label="r.value" class="role-radio">
                         <div class="role-option">
@@ -162,14 +163,14 @@
                       </el-radio>
                     </el-radio-group>
                   </el-form-item>
-                  
+
                   <el-form-item label="權限職等">
                     <el-select v-model="employeeForm.permissionGrade" placeholder="選擇職等">
                       <el-option v-for="g in PERMISSION_GRADE_OPTIONS" :key="g" :label="g" :value="g" />
                     </el-select>
                   </el-form-item>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
 
@@ -183,7 +184,7 @@
             </template>
             
             <div class="tab-content">
-              <el-form :model="employeeForm" label-width="140px" class="form-section">
+              <div class="form-section">
                 <div class="form-group">
                   <h3 class="form-group-title">簽核權限</h3>
                   <el-form-item label="簽核角色">
@@ -212,7 +213,7 @@
                     </el-select>
                   </el-form-item>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
 
@@ -226,14 +227,14 @@
             </template>
 
             <div class="tab-content">
-              <el-form ref="formRef" :model="employeeForm" :rules="rules" label-width="140px" class="form-section">
+              <div class="form-section">
                 <div class="form-group">
                   <h3 class="form-group-title">基本資料</h3>
                   <div class="form-row">
                     <el-form-item label="員工編號">
                       <el-input v-model="employeeForm.employeeNo" placeholder="請輸入員工編號" />
                     </el-form-item>
-                    <el-form-item label="員工姓名" required>
+                    <el-form-item label="員工姓名" required prop="name">
                       <el-input v-model="employeeForm.name" placeholder="請輸入員工姓名" />
                     </el-form-item>
                   </div>
@@ -314,7 +315,7 @@
                     <el-input v-model="employeeForm.contactAddress" placeholder="請輸入聯絡地址" />
                   </el-form-item>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
 
@@ -328,16 +329,16 @@
             </template>
             
             <div class="tab-content">
-              <el-form :model="employeeForm" label-width="140px" class="form-section">
+              <div class="form-section">
                 <div class="form-group">
                   <h3 class="form-group-title">組織架構</h3>
                   <div class="form-row">
-                    <el-form-item label="所屬機構" required>
+                    <el-form-item label="所屬機構" required prop="organization">
                       <el-select v-model="employeeForm.organization" placeholder="選擇機構">
                         <el-option v-for="org in orgList" :key="org._id" :label="org.name" :value="org._id" />
                       </el-select>
                     </el-form-item>
-                    <el-form-item label="所屬部門" required>
+                    <el-form-item label="所屬部門" required prop="department">
                       <el-select v-model="employeeForm.department" placeholder="選擇部門">
                         <el-option
                           v-for="dept in filteredDepartments"
@@ -438,7 +439,7 @@
                     </el-form-item>
                   </div>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
 
@@ -452,7 +453,7 @@
             </template>
             
             <div class="tab-content">
-              <el-form :model="employeeForm" label-width="140px" class="form-section">
+              <div class="form-section">
                 <!-- 學歷資訊 -->
                 <div class="form-group">
                   <h3 class="form-group-title">學歷資訊</h3>
@@ -564,7 +565,7 @@
                     新增經歷
                   </el-button>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
 
@@ -578,7 +579,7 @@
             </template>
             
             <div class="tab-content">
-              <el-form :model="employeeForm" label-width="160px" class="form-section">
+              <div class="form-section">
                 <div class="form-group">
                   <h3 class="form-group-title">薪資資訊</h3>
                   <div class="form-row">
@@ -625,11 +626,11 @@
                     </div>
                   </div>
                 </div>
-              </el-form>
+              </div>
             </div>
           </el-tab-pane>
-        </el-tabs>
-
+          </el-tabs>
+        </el-form>
         <template #footer>
           <div class="dialog-footer">
             <el-button @click="employeeDialogVisible = false" class="cancel-btn">取消</el-button>
@@ -842,6 +843,12 @@ const emptyEmployee = {
 const employeeForm = ref({ ...emptyEmployee })
 const formRef = ref()
 const rules = {
+  username: [{ required: true, message: '請輸入登入帳號', trigger: 'blur' }],
+  password: [{ required: true, message: '請輸入登入密碼', trigger: 'blur' }],
+  role: [{ required: true, message: '請選擇系統權限', trigger: 'change' }],
+  organization: [{ required: true, message: '請選擇所屬機構', trigger: 'change' }],
+  department: [{ required: true, message: '請選擇所屬部門', trigger: 'change' }],
+  name: [{ required: true, message: '請輸入員工姓名', trigger: 'blur' }],
   email: [
     {
       required: true,
@@ -918,33 +925,9 @@ async function openEmployeeDialog(index = null) {
 }
 
 async function saveEmployee() {
-  const valid = await formRef.value?.validate?.().catch(() => false)
-  if (valid === false) return
+  const valid = await formRef.value?.validate().catch(() => false)
+  if (!valid) return
   const form = employeeForm.value
-  if (!form.name) {
-    alert('請填寫姓名')
-    return
-  }
-  if (!form.username) {
-    alert('請填寫登入帳號')
-    return
-  }
-  if (!form.password) {
-    alert('請填寫登入密碼')
-    return
-  }
-  if (!form.role) {
-    alert('請填寫系統權限')
-    return
-  }
-  if (!form.organization) {
-    alert('請填寫所屬機構')
-    return
-  }
-  if (!form.department) {
-    alert('請填寫所屬部門')
-    return
-  }
   const payload = { ...form }
   if (payload.supervisor === '' || payload.supervisor === null) delete payload.supervisor
 
@@ -965,6 +948,9 @@ async function saveEmployee() {
   if (res && res.ok) {
     await fetchEmployees()
     employeeDialogVisible.value = false
+    ElMessage.success('儲存成功')
+  } else {
+    ElMessage.error('儲存失敗')
   }
 }
 

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
 vi.mock('../src/api', () => ({
   apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }))
 }))
@@ -8,6 +7,9 @@ import { apiFetch } from '../src/api'
 import EmployeeManagement from '../src/components/backComponents/EmployeeManagement.vue'
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() })
+}))
+vi.mock('element-plus', () => ({
+  ElMessage: { success: vi.fn(), error: vi.fn() }
 }))
 
 const elStubs = ['el-table','el-table-column','el-button','el-tabs','el-tab-pane','el-form','el-form-item','el-input','el-select','el-option','el-dialog','el-avatar','el-tag','el-radio','el-radio-group','el-date-picker','el-input-number','el-switch']
@@ -26,19 +28,25 @@ describe('EmployeeManagement.vue', () => {
     expect(calls).toContain('/api/sub-departments')
   })
 
-  it('has email validation rule', () => {
+  it('has validation rules for required fields', () => {
     const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
-    expect(wrapper.vm.rules.email[0].required).toBe(true)
+    const required = ['name','username','password','role','organization','department','email']
+    required.forEach(r => {
+      expect(wrapper.vm.rules[r][0].required).toBe(true)
+    })
     expect(wrapper.vm.rules.email[0].type).toBe('email')
   })
 
   it('sends login info when saving employee', async () => {
     const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
+    const validate = vi.fn(() => Promise.resolve(true))
+    wrapper.vm.formRef = { validate }
     apiFetch.mockClear()
     apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
     wrapper.vm.employeeForm = { ...wrapper.vm.employeeForm, name: 'n', username: 'u', password: 'p', role: 'admin', organization: 'o', department: 'd' }
     wrapper.vm.editEmployeeIndex = null
     await wrapper.vm.saveEmployee()
+    expect(validate).toHaveBeenCalled()
     const body = JSON.parse(apiFetch.mock.calls[0][1].body)
     expect(body.username).toBe('u')
     expect(body.password).toBe('p')
@@ -46,33 +54,13 @@ describe('EmployeeManagement.vue', () => {
     expect(apiFetch).toHaveBeenCalledWith('/api/employees', expect.objectContaining({ method: 'POST' }))
   })
 
-  it.each([
-    ['name', '姓名'],
-    ['username', '登入帳號'],
-    ['password', '登入密碼'],
-    ['role', '系統權限'],
-    ['organization', '所屬機構'],
-    ['department', '所屬部門']
-  ])('alerts when %s missing', async (field, label) => {
+  it('stops saving when validation fails', async () => {
     const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const validate = vi.fn(() => Promise.resolve(false))
+    wrapper.vm.formRef = { validate }
     apiFetch.mockClear()
-    wrapper.vm.fetchSubDepartments = vi.fn()
-    wrapper.vm.employeeForm = {
-      ...wrapper.vm.employeeForm,
-      name: 'n',
-      username: 'u',
-      password: 'p',
-      role: 'admin',
-      organization: 'o',
-      department: 'd'
-    }
-    await nextTick()
-    apiFetch.mockClear()
-    delete wrapper.vm.employeeForm[field]
     await wrapper.vm.saveEmployee()
-    expect(alertSpy).toHaveBeenCalledWith('請填寫' + label)
+    expect(validate).toHaveBeenCalled()
     expect(apiFetch).not.toHaveBeenCalled()
-    alertSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- consolidate employee form validation using Element Plus rules
- replace manual field checks with formRef.validate and message prompts
- update unit tests for new validation flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92a73daac8329a548afd255de4260