### PR TITLE
feat: 加強員工管理必填驗證與測試

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -240,7 +240,7 @@
                   </div>
                   
                   <div class="form-row">
-                    <el-form-item label="性別">
+                    <el-form-item label="性別" required prop="gender">
                       <el-select v-model="employeeForm.gender" placeholder="選擇性別">
                         <el-option label="男" value="M" />
                         <el-option label="女" value="F" />
@@ -650,6 +650,7 @@ import { ref, onMounted, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { apiFetch } from '../../api'
+import { REQUIRED_FIELDS } from './requiredFields'
 
 const router = useRouter()
 
@@ -848,6 +849,7 @@ const rules = {
   role: [{ required: true, message: '請選擇系統權限', trigger: 'change' }],
   organization: [{ required: true, message: '請選擇所屬機構', trigger: 'change' }],
   department: [{ required: true, message: '請選擇所屬部門', trigger: 'change' }],
+  gender: [{ required: true, message: '請選擇性別', trigger: 'change' }],
   name: [{ required: true, message: '請輸入員工姓名', trigger: 'blur' }],
   email: [
     {

--- a/client/src/components/backComponents/requiredFields.js
+++ b/client/src/components/backComponents/requiredFields.js
@@ -1,0 +1,10 @@
+export const REQUIRED_FIELDS = [
+  'username',
+  'password',
+  'role',
+  'name',
+  'email',
+  'organization',
+  'department',
+  'gender'
+]

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -5,6 +5,8 @@ vi.mock('../src/api', () => ({
 }))
 import { apiFetch } from '../src/api'
 import EmployeeManagement from '../src/components/backComponents/EmployeeManagement.vue'
+import { REQUIRED_FIELDS } from '../src/components/backComponents/requiredFields'
+import Schema from 'async-validator'
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() })
 }))
@@ -30,11 +32,21 @@ describe('EmployeeManagement.vue', () => {
 
   it('has validation rules for required fields', () => {
     const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
-    const required = ['name','username','password','role','organization','department','email']
-    required.forEach(r => {
+    REQUIRED_FIELDS.forEach(r => {
       expect(wrapper.vm.rules[r][0].required).toBe(true)
     })
     expect(wrapper.vm.rules.email[0].type).toBe('email')
+  })
+
+  it('rejects when required fields are empty', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
+    for (const field of REQUIRED_FIELDS) {
+      const validator = new Schema({ [field]: wrapper.vm.rules[field] })
+      const msg = wrapper.vm.rules[field][0].message
+      await expect(validator.validate({ [field]: '' })).rejects.toMatchObject({
+        errors: [{ message: msg }]
+      })
+    }
   })
 
   it('sends login info when saving employee', async () => {
@@ -42,12 +54,16 @@ describe('EmployeeManagement.vue', () => {
     const validate = vi.fn(() => Promise.resolve(true))
     wrapper.vm.formRef = { validate }
     apiFetch.mockClear()
-    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-    wrapper.vm.employeeForm = { ...wrapper.vm.employeeForm, name: 'n', username: 'u', password: 'p', role: 'admin', organization: 'o', department: 'd' }
+    apiFetch.mockImplementation((url, opts) =>
+      Promise.resolve({ ok: true, json: async () => (opts?.method === 'POST' ? {} : []) })
+    )
+    wrapper.vm.employeeForm = { ...wrapper.vm.employeeForm, name: 'n', username: 'u', password: 'p', role: 'admin', organization: 'o', department: 'd', gender: 'M', email: 'a@a.com' }
     wrapper.vm.editEmployeeIndex = null
     await wrapper.vm.saveEmployee()
     expect(validate).toHaveBeenCalled()
-    const body = JSON.parse(apiFetch.mock.calls[0][1].body)
+    const postCall = apiFetch.mock.calls.find(c => c[1]?.method === 'POST')
+    expect(postCall).toBeTruthy()
+    const body = JSON.parse(postCall[1].body)
     expect(body.username).toBe('u')
     expect(body.password).toBe('p')
     expect(body.role).toBe('admin')
@@ -61,6 +77,7 @@ describe('EmployeeManagement.vue', () => {
     apiFetch.mockClear()
     await wrapper.vm.saveEmployee()
     expect(validate).toHaveBeenCalled()
-    expect(apiFetch).not.toHaveBeenCalled()
+    const postCall = apiFetch.mock.calls.find(c => c[1]?.method === 'POST')
+    expect(postCall).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- 新增 `REQUIRED_FIELDS` 常數集中管理必填欄位
- `EmployeeManagement` 加入性別欄位必填與完整驗證規則
- 為所有必填欄位撰寫單元測試並驗證空值錯誤

## Testing
- `npx vitest run tests/employeeManagement.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68b92ef371d88329a4367a78d679873c