### PR TITLE
改用 sessionStorage 保存角色資訊避免覆蓋

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -136,7 +136,7 @@ router.beforeEach((to, from, next) => {
     if (!token) {
       return next({ name: 'ManagerLogin' })
     }
-    const userRole = localStorage.getItem('role') || 'employee'
+    const userRole = sessionStorage.getItem('role') || 'employee'
     if (!['supervisor', 'admin'].includes(userRole)) {
       return next('/login')
     }
@@ -152,7 +152,7 @@ router.beforeEach((to, from, next) => {
 
   // 若有角色限制 meta.roles
   if (to.meta.roles) {
-    const userRole = localStorage.getItem('role') || 'employee'
+    const userRole = sessionStorage.getItem('role') || 'employee'
     if (!to.meta.roles.includes(userRole)) {
       return next({ name: 'Forbidden' })
     }

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -167,8 +167,8 @@ const onLogin = async () => {
     if (res.ok) {
       const data = await res.json()
       setToken(data.token)
-      localStorage.setItem('role', data.user.role)
-      localStorage.setItem('employeeId', data.user.employeeId || data.user.id)
+      sessionStorage.setItem('role', data.user.role)
+      sessionStorage.setItem('employeeId', data.user.employeeId || data.user.id)
 
       await menuStore.fetchMenu()
       ElMessage.success('登入成功！')

--- a/client/src/views/ModernLayout.vue
+++ b/client/src/views/ModernLayout.vue
@@ -78,8 +78,8 @@ function toggleCollapse() {
   function logout() {
     clearToken()
     menuStore.setMenu([])
-    localStorage.removeItem('role')
-    localStorage.removeItem('employeeId')
+    sessionStorage.removeItem('role')
+    sessionStorage.removeItem('employeeId')
     router.push('/')
   }
 </script>

--- a/client/src/views/Settings.vue
+++ b/client/src/views/Settings.vue
@@ -15,8 +15,8 @@ import { clearToken } from '../utils/tokenService'
   
 const logout = () => {
   clearToken()
-  localStorage.removeItem('role')
-  localStorage.removeItem('employeeId')
+  sessionStorage.removeItem('role')
+  sessionStorage.removeItem('employeeId')
   router.push('/')
 }
   </script>

--- a/client/tests/login.spec.js
+++ b/client/tests/login.spec.js
@@ -55,6 +55,7 @@ describe('Login.vue', () => {
     setActivePinia(createPinia())
     vi.stubGlobal('fetch', vi.fn())
     localStorage.clear()
+    sessionStorage.clear()
     push.mockReset()
     const module = await import('../src/views/Login.vue')
     Login = module.default
@@ -66,6 +67,7 @@ describe('Login.vue', () => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     localStorage.clear()
+    sessionStorage.clear()
   })
 
   afterAll(() => {
@@ -89,8 +91,8 @@ describe('Login.vue', () => {
         body: JSON.stringify({ username: 'u', password: 'p', role: 'supervisor' })
       })
     )
-    expect(localStorage.getItem('role')).toBe('supervisor')
-    expect(localStorage.getItem('employeeId')).toBe('e1')
+    expect(sessionStorage.getItem('role')).toBe('supervisor')
+    expect(sessionStorage.getItem('employeeId')).toBe('e1')
     expect(fetchMenuSpy).toHaveBeenCalled()
     expect(push).toHaveBeenCalledWith('/front/schedule')
   })
@@ -106,7 +108,7 @@ describe('Login.vue', () => {
     wrapper.vm.loginForm.password = 'p'
     wrapper.vm.loginForm.role = 'admin'
     await wrapper.vm.onLogin()
-    expect(localStorage.getItem('employeeId')).toBe('a1')
+    expect(sessionStorage.getItem('employeeId')).toBe('a1')
     expect(fetchMenuSpy).toHaveBeenCalled()
     expect(push).toHaveBeenCalledWith('/manager/settings')
   })

--- a/client/tests/logout.spec.js
+++ b/client/tests/logout.spec.js
@@ -10,21 +10,28 @@ vi.mock('vue-router', () => ({
 describe('Settings.vue logout', () => {
   beforeEach(() => {
     localStorage.setItem('token', 't')
-    localStorage.setItem('role', 'r')
-    localStorage.setItem('employeeId', 'e')
+    sessionStorage.setItem('role', 'r')
+    sessionStorage.setItem('employeeId', 'e')
     pushMock.mockClear()
   })
 
   afterEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
   })
 
   it('removes auth values and redirects', async () => {
-    const wrapper = mount(Settings)
+    const wrapper = mount(Settings, {
+      global: {
+        components: {
+          'el-button': { template: '<button><slot /></button>' }
+        }
+      }
+    })
     await wrapper.find('button').trigger('click')
     expect(localStorage.getItem('token')).toBeNull()
-    expect(localStorage.getItem('role')).toBeNull()
-    expect(localStorage.getItem('employeeId')).toBeNull()
+    expect(sessionStorage.getItem('role')).toBeNull()
+    expect(sessionStorage.getItem('employeeId')).toBeNull()
     expect(pushMock).toHaveBeenCalledWith('/')
   })
 })

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -13,10 +13,12 @@ import router from '../src/router/index.js'
 
 beforeEach(() => {
   localStorage.clear()
+  sessionStorage.clear()
 })
 
 afterEach(() => {
   localStorage.clear()
+  sessionStorage.clear()
 })
 
 describe('router', () => {
@@ -55,14 +57,14 @@ describe('router', () => {
   })
 
   it('role guard blocks unauthorized user', () => {
-    localStorage.setItem('role', 'employee')
+    sessionStorage.setItem('role', 'employee')
     const next = vi.fn()
     capturedGuard({ matched: [], meta: { roles: ['supervisor'] } }, {}, next)
     expect(next).toHaveBeenCalledWith({ name: 'Forbidden' })
   })
 
   it('role guard allows employee when permitted', () => {
-    localStorage.setItem('role', 'employee')
+    sessionStorage.setItem('role', 'employee')
     const next = vi.fn()
     capturedGuard({ matched: [], meta: { roles: ['employee', 'supervisor', 'admin'] } }, {}, next)
     expect(next).toHaveBeenCalled()
@@ -71,7 +73,7 @@ describe('router', () => {
 
   it('backend guard redirects non-supervisor', () => {
     localStorage.setItem('token', 't')
-    localStorage.setItem('role', 'employee')
+    sessionStorage.setItem('role', 'employee')
     const next = vi.fn()
     capturedGuard({ matched: [{ meta: { requiresAuth: true } }], meta: {} }, {}, next)
     expect(next).toHaveBeenCalledWith('/login')
@@ -79,7 +81,7 @@ describe('router', () => {
 
   it('backend guard allows supervisor', () => {
     localStorage.setItem('token', 't')
-    localStorage.setItem('role', 'supervisor')
+    sessionStorage.setItem('role', 'supervisor')
     const next = vi.fn()
     capturedGuard({ matched: [{ meta: { requiresAuth: true } }], meta: {} }, {}, next)
     expect(next).toHaveBeenCalled()

--- a/client/tests/sessionStorage.spec.js
+++ b/client/tests/sessionStorage.spec.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+
+describe('sessionStorage 多視窗隔離', () => {
+  it('不同視窗角色不互相覆蓋', () => {
+    const win1 = new JSDOM('', { url: 'http://localhost' }).window
+    const win2 = new JSDOM('', { url: 'http://localhost' }).window
+    win1.sessionStorage.setItem('role', 'admin')
+    win2.sessionStorage.setItem('role', 'employee')
+    expect(win1.sessionStorage.getItem('role')).toBe('admin')
+    expect(win2.sessionStorage.getItem('role')).toBe('employee')
+  })
+})


### PR DESCRIPTION
## Summary
- 登入時以 sessionStorage 儲存角色與員工編號
- 路由守衛改讀取 sessionStorage 角色
- 登出時同步清除 sessionStorage 並新增多視窗測試

## Testing
- `npm --prefix server test`
- `npm --prefix client test run tests/login.spec.js tests/logout.spec.js tests/router.spec.js tests/sessionStorage.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68c10ca693d48329b557abce8e4742ee