### PR TITLE
調整部門排班與休息設定

### DIFF
--- a/client/src/components/backComponents/OrgDepartmentSetting.vue
+++ b/client/src/components/backComponents/OrgDepartmentSetting.vue
@@ -124,8 +124,8 @@
           </div>
           
           <div class="table-container">
-            <el-table 
-              :data="filteredDeptList" 
+            <el-table
+              :data="filteredDeptList"
               class="data-table"
               :header-cell-style="{ background: '#f8fafc', color: '#475569', fontWeight: '600' }"
               :row-style="{ height: '56px' }"
@@ -165,6 +165,89 @@
                 </template>
               </el-table-column>
             </el-table>
+          </div>
+
+          <!-- 部門排班規則與中場休息設定 -->
+          <div class="settings-block">
+            <div class="settings-card">
+              <h3 class="section-title">部門排班規則</h3>
+              <el-form :model="deptScheduleForm" label-width="200px" class="settings-form">
+                <el-form-item label="預設週休二日">
+                  <el-switch
+                    v-model="deptScheduleForm.defaultTwoDayOff"
+                    active-text="啟用"
+                    inactive-text="停用"
+                    active-color="#10b981"
+                  />
+                </el-form-item>
+                <el-form-item label="可否臨時調班">
+                  <el-switch
+                    v-model="deptScheduleForm.tempChangeAllowed"
+                    active-text="允許"
+                    inactive-text="禁止"
+                    active-color="#10b981"
+                  />
+                </el-form-item>
+                <el-form-item label="部門排班管理者">
+                  <el-select
+                    v-model="deptScheduleForm.deptManager"
+                    placeholder="選擇管理者"
+                    style="width: 300px"
+                  >
+                    <el-option
+                      v-for="mgr in managerList"
+                      :key="mgr.value"
+                      :label="mgr.label"
+                      :value="mgr.value"
+                    />
+                  </el-select>
+                </el-form-item>
+                <el-form-item>
+                  <el-button type="primary" @click="saveDeptSchedule" class="save-settings-btn">
+                    <i class="el-icon-check"></i>
+                    儲存部門排班規則
+                  </el-button>
+                </el-form-item>
+              </el-form>
+            </div>
+
+            <div class="settings-card">
+              <h3 class="section-title">中場休息設定</h3>
+              <el-form :model="breakSettingForm" label-width="220px" class="settings-form">
+                <el-form-item label="是否啟用全局中場休息設定">
+                  <el-switch
+                    v-model="breakSettingForm.enableGlobalBreak"
+                    active-text="啟用"
+                    inactive-text="停用"
+                    active-color="#10b981"
+                  />
+                </el-form-item>
+                <el-form-item label="全局休息時間 (分鐘)">
+                  <el-input-number
+                    v-model="breakSettingForm.breakMinutes"
+                    :min="0"
+                    :max="240"
+                    :disabled="!breakSettingForm.enableGlobalBreak"
+                    style="width: 200px"
+                  />
+                </el-form-item>
+                <el-form-item label="是否允許多段休息">
+                  <el-switch
+                    v-model="breakSettingForm.allowMultiBreak"
+                    :disabled="!breakSettingForm.enableGlobalBreak"
+                    active-text="允許"
+                    inactive-text="不允許"
+                    active-color="#10b981"
+                  />
+                </el-form-item>
+                <el-form-item>
+                  <el-button type="primary" @click="saveBreakSetting" class="save-settings-btn">
+                    <i class="el-icon-check"></i>
+                    儲存休息設定
+                  </el-button>
+                </el-form-item>
+              </el-form>
+            </div>
           </div>
         </div>
       </el-tab-pane>
@@ -406,6 +489,19 @@ const form = ref(defaultForm('org'))
 const currentType = ref('org')
 const editIndex = ref(null)
 
+// 部門排班規則與中場休息設定
+const deptScheduleForm = ref({
+  defaultTwoDayOff: true,
+  tempChangeAllowed: false,
+  deptManager: ''
+})
+const breakSettingForm = ref({
+  enableGlobalBreak: false,
+  breakMinutes: 60,
+  allowMultiBreak: false
+})
+const managerList = ref([])
+
 const filteredDeptList = computed(() =>
   selectedOrg.value
     ? deptList.value.filter(d => d.organization === selectedOrg.value)
@@ -559,7 +655,41 @@ function deleteItem(type, index) {
   })
 }
 
-onMounted(fetchAll)
+async function fetchManagers() {
+  const res = await apiFetch('/api/dept-managers')
+  if (res.ok) {
+    managerList.value = await res.json()
+  }
+}
+
+async function saveDeptSchedule() {
+  const method = deptScheduleForm.value._id ? 'PUT' : 'POST'
+  let url = '/api/dept-schedules'
+  if (method === 'PUT') url += `/${deptScheduleForm.value._id}`
+  const res = await apiFetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(deptScheduleForm.value)
+  })
+  if (res.ok) alert('已儲存「部門排班規則」設定')
+}
+
+async function saveBreakSetting() {
+  const method = breakSettingForm.value._id ? 'PUT' : 'POST'
+  let url = '/api/break-settings'
+  if (method === 'PUT') url += `/${breakSettingForm.value._id}`
+  const res = await apiFetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(breakSettingForm.value)
+  })
+  if (res.ok) alert('已儲存「中場休息」設定')
+}
+
+onMounted(() => {
+  fetchAll()
+  fetchManagers()
+})
 
 watch(selectedOrg, val => {
   fetchList('dept', val)

--- a/client/src/components/backComponents/ShiftScheduleSetting.vue
+++ b/client/src/components/backComponents/ShiftScheduleSetting.vue
@@ -5,7 +5,7 @@
     <div class="page-header">
       <div class="header-content">
         <h1 class="page-title">排班與班別管理設定</h1>
-        <p class="page-description">管理班別時間、假日設定、排班規則和休息時間配置</p>
+        <p class="page-description">管理班別時間、假日設定與國定假日挪移配置</p>
       </div>
       <div class="header-stats">
         <div class="stat-item">
@@ -253,122 +253,7 @@
         </div>
       </el-tab-pane>
 
-      <!-- 3) 部門排班規則 -->
-      <el-tab-pane name="deptSchedule">
-        <template #label>
-          <div class="tab-label">
-            <i class="el-icon-s-operation"></i>
-            <span>部門排班規則</span>
-          </div>
-        </template>
-        
-        <div class="tab-content">
-          <div class="settings-card">
-            <h2 class="section-title">排班規則設定</h2>
-            <el-form :model="deptScheduleForm" label-width="200px" class="settings-form">
-              <div class="form-group">
-                <el-form-item label="預設週休二日">
-                  <el-switch 
-                    v-model="deptScheduleForm.defaultTwoDayOff" 
-                    active-text="啟用" 
-                    inactive-text="停用"
-                    active-color="#10b981"
-                  />
-                  <div class="form-help">啟用後新員工預設採用週休二日制度</div>
-                </el-form-item>
-                
-                <el-form-item label="可否臨時調班">
-                  <el-switch 
-                    v-model="deptScheduleForm.tempChangeAllowed"
-                    active-text="允許" 
-                    inactive-text="禁止"
-                    active-color="#10b981"
-                  />
-                  <div class="form-help">允許員工在系統中申請臨時調班</div>
-                </el-form-item>
-                
-                <el-form-item label="部門排班管理者">
-                  <el-select 
-                    v-model="deptScheduleForm.deptManager" 
-                    placeholder="選擇管理者"
-                    style="width: 300px"
-                  >
-                    <el-option v-for="mgr in managerList" :key="mgr.value" :label="mgr.label" :value="mgr.value" />
-                  </el-select>
-                  <div class="form-help">指定負責部門排班管理的人員</div>
-                </el-form-item>
-              </div>
-              
-              <el-form-item>
-                <el-button type="primary" @click="saveDeptSchedule" class="save-settings-btn">
-                  <i class="el-icon-check"></i>
-                  儲存部門排班規則
-                </el-button>
-              </el-form-item>
-            </el-form>
-          </div>
-        </div>
-      </el-tab-pane>
-
-      <!-- 4) 中場休息時間全局設定 -->
-      <el-tab-pane name="breakSetting">
-        <template #label>
-          <div class="tab-label">
-            <i class="el-icon-coffee-cup"></i>
-            <span>中場休息設定</span>
-          </div>
-        </template>
-        
-        <div class="tab-content">
-          <div class="settings-card">
-            <h2 class="section-title">休息時間設定</h2>
-            <el-form :model="breakSettingForm" label-width="220px" class="settings-form">
-              <div class="form-group">
-                <el-form-item label="是否啟用全局中場休息設定">
-                  <el-switch 
-                    v-model="breakSettingForm.enableGlobalBreak"
-                    active-text="啟用" 
-                    inactive-text="停用"
-                    active-color="#10b981"
-                  />
-                  <div class="form-help">啟用後所有員工都會套用統一的休息時間設定</div>
-                </el-form-item>
-                
-                <el-form-item label="全局休息時間 (分鐘)">
-                  <el-input-number 
-                    v-model="breakSettingForm.breakMinutes" 
-                    :min="0" 
-                    :max="240"
-                    :disabled="!breakSettingForm.enableGlobalBreak"
-                    style="width: 200px"
-                  />
-                  <div class="form-help">設定每日的休息時間長度</div>
-                </el-form-item>
-                
-                <el-form-item label="是否允許多段休息">
-                  <el-switch 
-                    v-model="breakSettingForm.allowMultiBreak" 
-                    :disabled="!breakSettingForm.enableGlobalBreak"
-                    active-text="允許" 
-                    inactive-text="不允許"
-                    active-color="#10b981"
-                  />
-                  <div class="form-help">允許員工將休息時間分成多個時段</div>
-                </el-form-item>
-              </div>
-              
-              <el-form-item>
-                <el-button type="primary" @click="saveBreakSetting" class="save-settings-btn">
-                  <i class="el-icon-check"></i>
-                  儲存休息設定
-                </el-button>
-              </el-form-item>
-            </el-form>
-          </div>
-        </div>
-      </el-tab-pane>
-
-      <!-- 5) 員工個人國定假日挪移/簽名 -->
+      <!-- 3) 員工個人國定假日挪移/簽名 -->
       <el-tab-pane name="holidayMove">
         <template #label>
           <div class="tab-label">
@@ -582,72 +467,7 @@ async function deleteShift(index) {
   await fetchShifts()
 }
   
-// =========== 3) 部門排班規則 ===========
-const deptScheduleForm = ref({
-  defaultTwoDayOff: true,
-  tempChangeAllowed: false,
-  deptManager: ''
-})
-const managerList = ref([])
-
-async function fetchManagers() {
-  const res = await apiFetch('/api/dept-managers', {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${getToken()}`
-    }
-  })
-  if (res.ok) {
-    managerList.value = await res.json()
-  }
-}
-
-async function saveDeptSchedule() {
-  const method = deptScheduleForm.value._id ? 'PUT' : 'POST'
-  let url = '/api/dept-schedules'
-  if (method === 'PUT') {
-    url += `/${deptScheduleForm.value._id}`
-  }
-  const res = await apiFetch(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${getToken()}`
-    },
-    body: JSON.stringify(deptScheduleForm.value)
-  })
-  if (res.ok) {
-    alert('已儲存「部門排班規則」設定')
-  }
-}
-
-// =========== 4) 中場休息時間 ===========
-const breakSettingForm = ref({
-  enableGlobalBreak: false,
-  breakMinutes: 60,
-  allowMultiBreak: false
-})
-  
-async function saveBreakSetting() {
-  const method = breakSettingForm.value._id ? 'PUT' : 'POST'
-  let url = '/api/break-settings'
-  if (method === 'PUT') {
-    url += `/${breakSettingForm.value._id}`
-  }
-  const res = await apiFetch(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${getToken()}`
-    },
-    body: JSON.stringify(breakSettingForm.value)
-  })
-  if (res.ok) {
-    alert('已儲存「中場休息」設定')
-  }
-}
-  
-// =========== 5) 員工個人國定假日挪移設定 ===========
+// =========== 3) 員工個人國定假日挪移設定 ===========
 const holidayMoveForm = ref({
   enableHolidayMove: false,
   needSignature: false,
@@ -676,7 +496,6 @@ async function saveHolidayMove() {
 onMounted(() => {
   fetchHolidays()
   fetchShifts()
-  fetchManagers()
 })
   
 function getHolidayTagType(type) {

--- a/client/tests/orgDepartmentSetting.spec.js
+++ b/client/tests/orgDepartmentSetting.spec.js
@@ -11,6 +11,7 @@ vi.mock('../src/api', () => ({
 describe('OrgDepartmentSetting.vue', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
+    vi.stubGlobal('alert', vi.fn())
   })
 
   afterEach(() => {
@@ -23,6 +24,7 @@ describe('OrgDepartmentSetting.vue', () => {
     expect(calls.find(c => c[0] === '/api/organizations')).toBeTruthy()
     expect(calls.find(c => c[0] === '/api/departments')).toBeTruthy()
     expect(calls.find(c => c[0] === '/api/sub-departments')).toBeTruthy()
+    expect(calls.find(c => c[0] === '/api/dept-managers')).toBeTruthy()
   })
 
   it('posts to correct endpoint when creating org', async () => {
@@ -47,5 +49,19 @@ describe('OrgDepartmentSetting.vue', () => {
     apiFetch.mockClear()
     await wrapper.vm.fetchList('dept', '123')
     expect(apiFetch).toHaveBeenCalledWith('/api/departments?organization=123', expect.anything())
+  })
+
+  it('saves dept schedule to correct endpoint', async () => {
+    const wrapper = mount(OrgDepartmentSetting, { global: { plugins: [ElementPlus] } })
+    apiFetch.mockClear()
+    await wrapper.vm.saveDeptSchedule()
+    expect(apiFetch).toHaveBeenCalledWith('/api/dept-schedules', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('saves break setting to correct endpoint', async () => {
+    const wrapper = mount(OrgDepartmentSetting, { global: { plugins: [ElementPlus] } })
+    apiFetch.mockClear()
+    await wrapper.vm.saveBreakSetting()
+    expect(apiFetch).toHaveBeenCalledWith('/api/break-settings', expect.objectContaining({ method: 'POST' }))
   })
 })

--- a/client/tests/shiftScheduleSetting.spec.js
+++ b/client/tests/shiftScheduleSetting.spec.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import ShiftScheduleSetting from '../src/components/backComponents/ShiftScheduleSetting.vue'
+import { apiFetch } from '../src/api'
+
+vi.mock('../src/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }))
+}))
+
+describe('ShiftScheduleSetting.vue', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not render removed tabs', () => {
+    const wrapper = mount(ShiftScheduleSetting, { global: { plugins: [ElementPlus] } })
+    expect(wrapper.text()).not.toContain('部門排班規則')
+    expect(wrapper.text()).not.toContain('中場休息設定')
+  })
+
+  it('does not fetch department managers', () => {
+    mount(ShiftScheduleSetting, { global: { plugins: [ElementPlus] } })
+    const calls = apiFetch.mock.calls
+    expect(calls.find(c => c[0] === '/api/dept-managers')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## 摘要
- 部門管理頁新增排班規則與中場休息設定
- 移除排班頁面內的相關標籤與資料結構
- 增補相對應單元測試

## 測試
- `npm test` （部分測試失敗，7 failed）

------
https://chatgpt.com/codex/tasks/task_e_68c10f96b0748329af64a09e8915604b