### PR TITLE
新增小單位班別選擇與後端對應

### DIFF
--- a/server/src/models/SubDepartment.js
+++ b/server/src/models/SubDepartment.js
@@ -15,6 +15,7 @@ const subDepartmentSchema = new mongoose.Schema({
   // 部門主管
   manager: String,
   headcount: Number,
+  shift: { type: mongoose.Schema.Types.ObjectId, ref: 'Shift' },
   scheduleSetting: String
 }, { timestamps: true });
 

--- a/server/tests/subDepartment.test.js
+++ b/server/tests/subDepartment.test.js
@@ -33,9 +33,10 @@ beforeEach(() => {
 
 describe('SubDepartment API', () => {
   it('lists sub-departments', async () => {
-    mockSubDepartment.find.mockResolvedValue([{ name: 'Sub' }]);
+    mockSubDepartment.find.mockResolvedValue([{ name: 'Sub', shift: '507f1f77bcf86cd799439014' }]);
     const res = await request(app).get('/api/sub-departments');
     expect(res.status).toBe(200);
+    expect(res.body[0]).toMatchObject({ shiftId: '507f1f77bcf86cd799439014' });
   });
 
   it('lists sub-departments by department id', async () => {
@@ -64,16 +65,32 @@ describe('SubDepartment API', () => {
 
   it('creates sub-department', async () => {
     saveMock.mockResolvedValue();
-    const res = await request(app).post('/api/sub-departments').send({ name: 'Sub', department: 'dept1' });
+    const payload = { name: 'Sub', department: 'dept1', shiftId: 'shift1' };
+    const res = await request(app).post('/api/sub-departments').send(payload);
     expect(res.status).toBe(201);
     expect(saveMock).toHaveBeenCalled();
+    expect(mockSubDepartment).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Sub',
+      department: 'dept1',
+      shift: 'shift1'
+    }));
+    const constructed = mockSubDepartment.mock.calls[0][0];
+    expect(constructed).not.toHaveProperty('shiftId');
   });
 
   it('updates sub-department', async () => {
-    mockSubDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'Sub' });
-    const res = await request(app).put('/api/sub-departments/1').send({ name: 'Sub', department: 'dept1' });
+    mockSubDepartment.findByIdAndUpdate.mockResolvedValue({ name: 'Sub', shift: 'shift2' });
+    const res = await request(app)
+      .put('/api/sub-departments/1')
+      .send({ name: 'Sub', department: 'dept1', shiftId: 'shift2' });
     expect(res.status).toBe(200);
-    expect(mockSubDepartment.findByIdAndUpdate).toHaveBeenCalled();
+    expect(mockSubDepartment.findByIdAndUpdate).toHaveBeenCalledWith(
+      '1',
+      expect.objectContaining({ shift: 'shift2' }),
+      { new: true }
+    );
+    const body = res.body;
+    expect(body.shiftId).toBe('shift2');
   });
 
   it('deletes sub-department', async () => {


### PR DESCRIPTION
## Summary
- 將小單位表單的班別欄改為下拉選單並在載入時取得班別資料
- 更新 SubDepartment 模型與控制器以保存班別參照並回傳 shiftId
- 補充前後端測試以涵蓋班別載入與儲存流程

## Testing
- `npm --prefix server test`
- `npm --prefix client test -- --run tests/orgDepartmentSetting.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68c86d662184832999fb7fcf4614f9f6