### PR TITLE
新增學歷畢業狀態選項與後端驗證

### DIFF
--- a/server/tests/employeeEducationStatus.test.js
+++ b/server/tests/employeeEducationStatus.test.js
@@ -1,0 +1,31 @@
+import { buildEmployeeDoc, buildEmployeePatch } from '../src/controllers/employeeController.js'
+
+describe('學歷狀態轉換', () => {
+  it('建立文件時保留允許的畢業狀態', () => {
+    const doc = buildEmployeeDoc({ graduationStatus: '畢業' })
+    expect(doc.education.status).toBe('畢業')
+  })
+
+  it('建立文件時過濾不合法的狀態值', () => {
+    const doc = buildEmployeeDoc({ graduationStatus: '其他' })
+    expect(doc.education.status).toBeUndefined()
+  })
+
+  it('部份更新時寫入合法狀態', () => {
+    const { $set, $unset } = buildEmployeePatch({ graduationStatus: '肄業' })
+    expect($set['education.status']).toBe('肄業')
+    expect($unset).toEqual({})
+  })
+
+  it('部份更新時清空狀態會執行 unset', () => {
+    const { $set, $unset } = buildEmployeePatch({ graduationStatus: '' })
+    expect($set['education.status']).toBeUndefined()
+    expect($unset['education.status']).toBe(1)
+  })
+
+  it('部份更新時忽略不合法的狀態值', () => {
+    const { $set, $unset } = buildEmployeePatch({ graduationStatus: '其他' })
+    expect($set['education.status']).toBeUndefined()
+    expect($unset).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- 在員工管理表單新增畢業狀態選擇並處理清除行為，確保學歷欄位完整顯示
- 載入員工資料時同步回填學歷資訊並格式化畢業年度文字
- 後端限制畢業狀態的合法值並補充對應的單元測試

## Testing
- npm test *(Vitest 前端測試因現有環境限制失敗，Jest 後端測試皆通過)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3fadbcb8832998c9834e6b58e118