### PR TITLE
新增更多資訊證照與訓練管理

### DIFF
--- a/client/src/components/backComponents/EmployeeManagement.vue
+++ b/client/src/components/backComponents/EmployeeManagement.vue
@@ -678,6 +678,143 @@
                     新增經歷
                   </el-button>
                 </div>
+
+                <!-- 證照資訊 -->
+                <div class="form-group">
+                  <h3 class="form-group-title">證照</h3>
+                  <div class="experience-list">
+                    <div
+                      v-for="(license, i) in employeeForm.licenses"
+                      :key="`license-${i}`"
+                      class="experience-item"
+                    >
+                      <div class="experience-header">
+                        <h4 class="experience-title">證照 {{ i + 1 }}</h4>
+                        <el-button type="danger" size="small" @click="removeLicense(i)" class="remove-btn">
+                          <i class="el-icon-delete"></i>
+                          刪除
+                        </el-button>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="證照名稱">
+                          <el-input v-model="license.name" placeholder="請輸入證照名稱" />
+                        </el-form-item>
+                        <el-form-item label="證照字號">
+                          <el-input v-model="license.number" placeholder="請輸入證照字號" />
+                        </el-form-item>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="核發日期">
+                          <el-date-picker v-model="license.startDate" type="date" placeholder="選擇核發日期" />
+                        </el-form-item>
+                        <el-form-item label="有效期限">
+                          <el-date-picker v-model="license.endDate" type="date" placeholder="選擇有效期限" />
+                        </el-form-item>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="證照檔案" class="full-width-item">
+                          <el-upload
+                            v-model:file-list="license.fileList"
+                            action="#"
+                            multiple
+                            list-type="text"
+                            :http-request="handleAttachmentRequest"
+                            :on-success="(res, file, fileList) => handleAttachmentSuccess('licenses', i, res, file, fileList)"
+                            :on-remove="(file, fileList) => handleAttachmentRemove('licenses', i, file, fileList)"
+                          >
+                            <el-button type="primary" plain>
+                              <i class="el-icon-upload2"></i>
+                              上傳檔案
+                            </el-button>
+                            <template #tip>
+                              <div class="upload-tip">可上傳多個檔案，將以連結形式儲存</div>
+                            </template>
+                          </el-upload>
+                        </el-form-item>
+                      </div>
+                    </div>
+                  </div>
+                  <el-button type="primary" @click="addLicense" class="add-item-btn">
+                    <i class="el-icon-plus"></i>
+                    新增證照
+                  </el-button>
+                </div>
+
+                <!-- 教育訓練 -->
+                <div class="form-group">
+                  <h3 class="form-group-title">教育訓練</h3>
+                  <div class="experience-list">
+                    <div
+                      v-for="(training, i) in employeeForm.trainings"
+                      :key="`training-${i}`"
+                      class="experience-item"
+                    >
+                      <div class="experience-header">
+                        <h4 class="experience-title">教育訓練 {{ i + 1 }}</h4>
+                        <el-button type="danger" size="small" @click="removeTraining(i)" class="remove-btn">
+                          <i class="el-icon-delete"></i>
+                          刪除
+                        </el-button>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="課程名稱">
+                          <el-input v-model="training.course" placeholder="請輸入課程名稱" />
+                        </el-form-item>
+                        <el-form-item label="課程代碼">
+                          <el-input v-model="training.courseNo" placeholder="請輸入課程代碼" />
+                        </el-form-item>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="上課日期">
+                          <el-date-picker v-model="training.date" type="date" placeholder="選擇日期" />
+                        </el-form-item>
+                        <el-form-item label="積分類別" class="full-width-item">
+                          <el-select
+                            v-model="training.category"
+                            multiple
+                            collapse-tags
+                            placeholder="選擇積分類別"
+                          >
+                            <el-option v-for="cat in CREDIT_CATEGORIES" :key="cat" :label="cat" :value="cat" />
+                          </el-select>
+                        </el-form-item>
+                      </div>
+                      <div class="form-row">
+                        <el-form-item label="積分">
+                          <el-input-number
+                            v-model="training.score"
+                            :min="0"
+                            :step="0.5"
+                            :value-on-clear="null"
+                          />
+                        </el-form-item>
+                        <el-form-item label="訓練檔案" class="full-width-item">
+                          <el-upload
+                            v-model:file-list="training.fileList"
+                            action="#"
+                            multiple
+                            list-type="text"
+                            :http-request="handleAttachmentRequest"
+                            :on-success="(res, file, fileList) => handleAttachmentSuccess('trainings', i, res, file, fileList)"
+                            :on-remove="(file, fileList) => handleAttachmentRemove('trainings', i, file, fileList)"
+                          >
+                            <el-button type="primary" plain>
+                              <i class="el-icon-upload2"></i>
+                              上傳檔案
+                            </el-button>
+                            <template #tip>
+                              <div class="upload-tip">支援多檔上傳，將以連結形式儲存</div>
+                            </template>
+                          </el-upload>
+                        </el-form-item>
+                      </div>
+                    </div>
+                  </div>
+                  <el-button type="primary" @click="addTraining" class="add-item-btn">
+                    <i class="el-icon-plus"></i>
+                    新增教育訓練
+                  </el-button>
+                </div>
               </div>
             </div>
           </el-tab-pane>
@@ -893,8 +1030,8 @@ function buildPhotoUploadFile(url, name = '') {
   }
 }
 
-function extractPhotoUrls(files = []) {
-  return files
+function extractUploadUrls(files = []) {
+  return (Array.isArray(files) ? files : [files])
     .map(file => {
       if (!file) return ''
       if (typeof file === 'string') return file
@@ -910,6 +1047,96 @@ function extractPhotoUrls(files = []) {
     .filter(url => typeof url === 'string' && url)
 }
 
+function extractPhotoUrls(files = []) {
+  return extractUploadUrls(files)
+}
+
+function normalizeAttachmentList(uploadFiles = [], namePrefix = '附件') {
+  return (Array.isArray(uploadFiles) ? uploadFiles : [uploadFiles])
+    .map((file, index) => {
+      if (!file) return null
+      if (typeof file === 'string') {
+        return {
+          name: `${namePrefix}${index + 1}`,
+          url: file,
+          status: 'success',
+          percentage: 100,
+          uid: `${namePrefix}-${index}`
+        }
+      }
+
+      if (typeof file === 'object') {
+        let url = file.url
+        if (!url) {
+          const response = file.response
+          if (typeof response === 'string') url = response
+          else if (response && typeof response === 'object') {
+            url = response.url || response?.data?.url || ''
+          }
+        }
+        if (!url) return null
+        const normalized = {
+          ...file,
+          name: file.name || `${namePrefix}${index + 1}`,
+          url,
+          status: 'success',
+          percentage: file.percentage ?? 100
+        }
+        if (!normalized.uid) normalized.uid = `${namePrefix}-${index}`
+        return normalized
+      }
+      return null
+    })
+    .filter(file => file && typeof file.url === 'string' && file.url)
+}
+
+function buildAttachmentFileList(source, namePrefix = '附件') {
+  if (!source) return []
+  const list = Array.isArray(source) ? source : [source]
+  return normalizeAttachmentList(list, namePrefix)
+}
+
+function ensureArrayValue(value) {
+  if (Array.isArray(value)) return value.filter(v => v !== '' && v !== null && v !== undefined)
+  if (value === '' || value === null || value === undefined) return []
+  return [value]
+}
+
+function getAttachmentPrefix(type, index) {
+  return type === 'licenses' ? `證照${index + 1}-附件` : `教育訓練${index + 1}-附件`
+}
+
+function updateAttachmentList(type, index, uploadFiles) {
+  const target = type === 'licenses' ? employeeForm.value.licenses : employeeForm.value.trainings
+  if (!Array.isArray(target) || !target[index]) return
+  const prefix = getAttachmentPrefix(type, index)
+  target[index].fileList = normalizeAttachmentList(uploadFiles, prefix)
+}
+
+async function handleAttachmentRequest({ file, onSuccess, onError }) {
+  try {
+    const dataUrl = await readFileAsDataUrl(file)
+    onSuccess?.({ url: dataUrl })
+  } catch (err) {
+    onError?.(err)
+    ElMessage.error('檔案載入失敗，請重新選擇')
+  }
+}
+
+function handleAttachmentSuccess(type, index, response, uploadFile, uploadFiles) {
+  if (!uploadFile.url) {
+    if (typeof response === 'string') uploadFile.url = response
+    else if (response && typeof response === 'object') {
+      uploadFile.url = response.url || response?.data?.url || uploadFile.url || ''
+    }
+  }
+  updateAttachmentList(type, index, uploadFiles)
+}
+
+function handleAttachmentRemove(type, index, _file, uploadFiles) {
+  updateAttachmentList(type, index, uploadFiles)
+}
+
 function toNumberOrNull(value) {
   if (value === '' || value === null || value === undefined) return null
   const num = Number(value)
@@ -919,6 +1146,35 @@ function toNumberOrNull(value) {
 function toStringOrEmpty(value) {
   if (value === undefined || value === null) return ''
   return String(value)
+}
+
+function formatLicensesForForm(list = []) {
+  if (!Array.isArray(list)) return []
+  return list.map((item = {}, index) => ({
+    name: item?.name ?? '',
+    number: item?.number ?? '',
+    startDate: item?.startDate ?? item?.issueDate ?? '',
+    endDate: item?.endDate ?? item?.expiryDate ?? '',
+    fileList: buildAttachmentFileList(
+      item?.fileList ?? item?.files ?? (item?.file ? [item.file] : []),
+      `證照${index + 1}-附件`
+    )
+  }))
+}
+
+function formatTrainingsForForm(list = []) {
+  if (!Array.isArray(list)) return []
+  return list.map((item = {}, index) => ({
+    course: item?.course ?? item?.name ?? '',
+    courseNo: item?.courseNo ?? item?.code ?? '',
+    date: item?.date ?? '',
+    category: ensureArrayValue(item?.category ?? item?.categories),
+    score: toNumberOrNull(item?.score),
+    fileList: buildAttachmentFileList(
+      item?.fileList ?? item?.files ?? (item?.file ? [item.file] : []),
+      `教育訓練${index + 1}-附件`
+    )
+  }))
 }
 
 /* 取資料 ------------------------------------------------------------------- */
@@ -1137,6 +1393,8 @@ async function openEmployeeDialog(index = null) {
     employeeForm.value.photo = employeeForm.value.photo || ''
     const existingPhotoFile = buildPhotoUploadFile(employeeForm.value.photo, employeeForm.value.name)
     employeeForm.value.photoList = existingPhotoFile ? [existingPhotoFile] : []
+    employeeForm.value.licenses = formatLicensesForForm(emp.licenses ?? [])
+    employeeForm.value.trainings = formatTrainingsForForm(emp.trainings ?? [])
     const education = emp.education ?? {}
     if (!employeeForm.value.educationLevel && education.level) {
       employeeForm.value.educationLevel = education.level
@@ -1167,6 +1425,8 @@ async function openEmployeeDialog(index = null) {
     editEmployeeId = ''
     employeeDialogTab.value = 'account'
     employeeForm.value = { ...structuredClone(emptyEmployee) }
+    employeeForm.value.licenses = []
+    employeeForm.value.trainings = []
   }
 
   await fetchDepartments()
@@ -1217,6 +1477,58 @@ async function saveEmployee() {
     : []
   if (payload.supervisor === '' || payload.supervisor === null) delete payload.supervisor
 
+  const normalizedLicenses = (Array.isArray(form.licenses) ? form.licenses : [])
+    .map(license => {
+      const fileList = extractUploadUrls(license?.fileList ?? [])
+      const name = typeof license?.name === 'string' ? license.name.trim() : license?.name ?? ''
+      const number = typeof license?.number === 'string' ? license.number.trim() : license?.number ?? ''
+      const startDate = license?.startDate || ''
+      const endDate = license?.endDate || ''
+      return {
+        name,
+        number,
+        startDate,
+        endDate,
+        fileList
+      }
+    })
+    .filter(license =>
+      license.name ||
+      license.number ||
+      license.startDate ||
+      license.endDate ||
+      (Array.isArray(license.fileList) && license.fileList.length)
+    )
+  payload.licenses = normalizedLicenses
+
+  const normalizedTrainings = (Array.isArray(form.trainings) ? form.trainings : [])
+    .map(training => {
+      const fileList = extractUploadUrls(training?.fileList ?? [])
+      const categories = ensureArrayValue(training?.category ?? training?.categories)
+      const course = typeof training?.course === 'string' ? training.course.trim() : training?.course ?? ''
+      const courseNo = typeof training?.courseNo === 'string' ? training.courseNo.trim() : training?.courseNo ?? ''
+      const date = training?.date || ''
+      const scoreValue = toNumberOrNull(training?.score)
+      const normalized = {
+        course,
+        courseNo,
+        date,
+        category: categories,
+        fileList
+      }
+      if (scoreValue !== null) normalized.score = scoreValue
+      return normalized
+    })
+    .filter(training =>
+      training.course ||
+      training.courseNo ||
+      training.date ||
+      (Array.isArray(training.category) && training.category.length) ||
+      (Array.isArray(training.fileList) && training.fileList.length) ||
+      training.score !== undefined
+    )
+  payload.trainings = normalizedTrainings
+
   let res
   if (editEmployeeIndex === null) {
     res = await apiFetch('/api/employees', {
@@ -1261,7 +1573,14 @@ function removeLicense(i) {
   employeeForm.value.licenses.splice(i, 1)
 }
 function addTraining() {
-  employeeForm.value.trainings.push({ course: '', courseNo: '', date: '', fileList: [], category: '', score: '' })
+  employeeForm.value.trainings.push({
+    course: '',
+    courseNo: '',
+    date: '',
+    fileList: [],
+    category: [],
+    score: null
+  })
 }
 function removeTraining(i) {
   employeeForm.value.trainings.splice(i, 1)
@@ -1561,6 +1880,12 @@ function getStatusTagType(status) {
   color: #64748b;
   font-size: 14px;
   gap: 6px;
+}
+
+.upload-tip {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #64748b;
 }
 
 .upload-placeholder i {

--- a/client/tests/employeeManagement.spec.js
+++ b/client/tests/employeeManagement.spec.js
@@ -16,7 +16,7 @@ vi.mock('element-plus', () => ({
   ElMessageBox: { alert: vi.fn() }
 }))
 
-const elStubs = ['el-table','el-table-column','el-button','el-tabs','el-tab-pane','el-form','el-form-item','el-input','el-select','el-option','el-dialog','el-avatar','el-tag','el-radio','el-radio-group','el-date-picker','el-input-number','el-switch']
+const elStubs = ['el-table','el-table-column','el-button','el-tabs','el-tab-pane','el-form','el-form-item','el-input','el-select','el-option','el-dialog','el-avatar','el-tag','el-radio','el-radio-group','el-date-picker','el-input-number','el-upload','el-switch']
 
 describe('EmployeeManagement.vue', () => {
   beforeEach(() => {
@@ -106,7 +106,26 @@ describe('EmployeeManagement.vue', () => {
           organization: 'org1',
           department: 'dep1',
           subDepartment: 'sub1',
-          medicalCheck: { height: 172.5, weight: 65.3, bloodType: 'B' }
+          medicalCheck: { height: 172.5, weight: 65.3, bloodType: 'B' },
+          licenses: [
+            {
+              name: '專業證照',
+              number: 'LIC-1',
+              startDate: '2024-01-01',
+              endDate: '2025-01-01',
+              fileList: ['https://file.example/license.png']
+            }
+          ],
+          trainings: [
+            {
+              course: '院內教育',
+              courseNo: 'TR-01',
+              date: '2024-06-01',
+              category: ['院內'],
+              score: 4,
+              fileList: ['https://file.example/train.pdf']
+            }
+          ]
         }
       ]
     }
@@ -121,5 +140,85 @@ describe('EmployeeManagement.vue', () => {
     expect(wrapper.vm.employeeForm.height).toBe(172.5)
     expect(wrapper.vm.employeeForm.weight).toBe(65.3)
     expect(wrapper.vm.employeeForm.medicalBloodType).toBe('B')
+    expect(wrapper.vm.employeeForm.licenses).toHaveLength(1)
+    expect(wrapper.vm.employeeForm.licenses[0].fileList[0].url).toBe('https://file.example/license.png')
+    expect(wrapper.vm.employeeForm.trainings[0].category).toEqual(['院內'])
+    expect(wrapper.vm.employeeForm.trainings[0].score).toBe(4)
+    expect(wrapper.vm.employeeForm.trainings[0].fileList[0].url).toBe('https://file.example/train.pdf')
+  })
+
+  it('儲存時會帶入證照與訓練檔案連結', async () => {
+    const wrapper = mount(EmployeeManagement, { global: { stubs: elStubs } })
+    const validate = vi.fn(() => Promise.resolve(true))
+    wrapper.vm.formRef = { validate }
+    apiFetch.mockClear()
+    apiFetch.mockImplementation((url, opts) =>
+      Promise.resolve({ ok: true, json: async () => (opts?.method === 'POST' ? {} : []) })
+    )
+
+    wrapper.vm.employeeForm = {
+      ...wrapper.vm.employeeForm,
+      name: '測試員工',
+      username: 'user1',
+      password: 'pass1',
+      role: 'employee',
+      organization: 'org1',
+      department: 'dep1',
+      gender: 'M',
+      email: 'user1@example.com',
+      licenses: [
+        {
+          name: '專業證照',
+          number: 'L-1',
+          startDate: '2024-01-01',
+          endDate: '2025-01-01',
+          fileList: [
+            { name: 'l1', url: 'https://file.example/license.png' },
+            { response: { data: { url: 'https://file.example/license2.png' } } }
+          ]
+        },
+        { name: '', number: '', startDate: '', endDate: '', fileList: [] }
+      ],
+      trainings: [
+        {
+          course: '教育訓練',
+          courseNo: 'TR-01',
+          date: '2024-06-01',
+          category: ['院內', '線上'],
+          score: 3,
+          fileList: [{ response: { url: 'https://file.example/train.pdf' } }]
+        },
+        { course: '', courseNo: '', date: '', category: [], score: null, fileList: [] }
+      ]
+    }
+    wrapper.vm.editEmployeeIndex = null
+    await wrapper.vm.saveEmployee()
+
+    expect(validate).toHaveBeenCalled()
+    const postCall = apiFetch.mock.calls.find(c => c[1]?.method === 'POST')
+    expect(postCall).toBeTruthy()
+    const body = JSON.parse(postCall[1].body)
+    expect(body.licenses).toEqual([
+      {
+        name: '專業證照',
+        number: 'L-1',
+        startDate: '2024-01-01',
+        endDate: '2025-01-01',
+        fileList: [
+          'https://file.example/license.png',
+          'https://file.example/license2.png'
+        ]
+      }
+    ])
+    expect(body.trainings).toEqual([
+      {
+        course: '教育訓練',
+        courseNo: 'TR-01',
+        date: '2024-06-01',
+        category: ['院內', '線上'],
+        score: 3,
+        fileList: ['https://file.example/train.pdf']
+      }
+    ])
   })
 })

--- a/server/src/models/Employee.js
+++ b/server/src/models/Employee.js
@@ -39,7 +39,7 @@ const trainingSchema = new Schema(
     date: Date,
     // 多檔
     files: { type: [String], default: [], alias: 'fileList' },
-    category: String,
+    category: { type: [String], default: [] },
     score: Number,
   },
   { _id: false }

--- a/server/src/utils/licenseReminder.js
+++ b/server/src/utils/licenseReminder.js
@@ -1,0 +1,39 @@
+// 提供證照到期提醒的共用工具，可供排程或背景工作使用
+// 由於目前尚未串接通知機制，先以純函式計算到期資料，之後可由 cron job / queue 取用
+
+export function collectExpiringLicenses(employees = [], { daysAhead = 30, referenceDate = new Date() } = {}) {
+  const baseDate = referenceDate instanceof Date ? referenceDate : new Date(referenceDate)
+  if (Number.isNaN(baseDate.getTime())) {
+    throw new TypeError('referenceDate 必須為可轉換的日期物件或字串')
+  }
+  const now = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate())
+  const threshold = new Date(now)
+  threshold.setDate(threshold.getDate() + Number(daysAhead || 0))
+
+  const results = []
+  employees.forEach(employee => {
+    const licenses = Array.isArray(employee?.licenses) ? employee.licenses : []
+    licenses.forEach(license => {
+      const endDate = license?.endDate || license?.expiryDate
+      if (!endDate) return
+      const expiry = new Date(endDate)
+      if (Number.isNaN(expiry.getTime())) return
+      const normalizedExpiry = new Date(expiry.getFullYear(), expiry.getMonth(), expiry.getDate())
+      if (normalizedExpiry < now) return
+      if (normalizedExpiry > threshold) return
+
+      const msPerDay = 24 * 60 * 60 * 1000
+      const daysRemaining = Math.ceil((normalizedExpiry - now) / msPerDay)
+      results.push({
+        employeeId: employee?._id?.toString?.() ?? employee?.id ?? null,
+        employeeName: employee?.name ?? '',
+        licenseName: license?.name ?? '',
+        licenseNumber: license?.number ?? '',
+        endDate: normalizedExpiry,
+        daysRemaining
+      })
+    })
+  })
+
+  return results.sort((a, b) => a.endDate - b.endDate)
+}

--- a/server/tests/licenseReminderService.test.js
+++ b/server/tests/licenseReminderService.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals'
+import { collectExpiringLicenses } from '../src/utils/licenseReminder.js'
+
+describe('collectExpiringLicenses', () => {
+  it('returns licenses that will expire within the given window', () => {
+    const employees = [
+      {
+        _id: { toString: () => 'emp1' },
+        name: '王小明',
+        licenses: [
+          { name: '照護證照', number: 'A123', endDate: '2025-06-20' },
+          { name: '英文證照', number: 'B456', endDate: '2025-09-01' }
+        ]
+      },
+      {
+        _id: { toString: () => 'emp2' },
+        name: '林小華',
+        licenses: [
+          { name: '醫事證照', number: 'C789', endDate: '2025-06-22' },
+          { name: '過期證照', number: 'C000', endDate: '2024-01-01' }
+        ]
+      }
+    ]
+
+    const list = collectExpiringLicenses(employees, { daysAhead: 100, referenceDate: '2025-05-31' })
+    expect(list).toHaveLength(3)
+    expect(list[0]).toMatchObject({ employeeId: 'emp1', licenseName: '照護證照', daysRemaining: 20 })
+    expect(list[1]).toMatchObject({ employeeId: 'emp2', licenseName: '醫事證照', daysRemaining: 22 })
+    expect(list[2]).toMatchObject({ employeeId: 'emp1', licenseName: '英文證照' })
+  })
+
+  it('ignores invalid dates and out-of-range data', () => {
+    const employees = [
+      {
+        id: 'emp3',
+        name: '測試',
+        licenses: [
+          { name: 'bad', endDate: 'invalid' },
+          { name: '太晚', endDate: '2030-01-01' }
+        ]
+      }
+    ]
+    const list = collectExpiringLicenses(employees, { daysAhead: 30, referenceDate: '2025-01-01' })
+    expect(list).toHaveLength(0)
+  })
+
+  it('throws when referenceDate is invalid', () => {
+    expect(() => collectExpiringLicenses([], { referenceDate: 'not-a-date' })).toThrow(TypeError)
+  })
+})


### PR DESCRIPTION
## Summary
- 在更多資訊分頁新增證照與教育訓練表單，支援多筆資料與檔案上傳。
- 強化前端附件處理、表單還原與送出時的資料正規化，並同步更新後端模型與正規化邏輯。
- 新增證照到期提醒工具與對應測試，補強員工管理自動化情境。

## Testing
- `npm test` *(失敗：現有部份 Vitest 套件環境缺少 Pinia/Element Plus 初始化，維持原有失敗狀態。)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4679213c8329a8c6ff0fedc718af