### PR TITLE
feat: 依部門管理中場休息設定

### DIFF
--- a/server/src/controllers/breakSettingController.js
+++ b/server/src/controllers/breakSettingController.js
@@ -1,17 +1,95 @@
 import BreakSetting from '../models/BreakSetting.js';
 
+function readScope(req, sources = ['query']) {
+  const scope = {};
+
+  for (const source of sources) {
+    const data =
+      source === 'query'
+        ? req.query
+        : source === 'params'
+          ? req.params
+          : req.body || {};
+
+    if (!scope.department) {
+      scope.department =
+        data.department || data.departmentId || data.deptId || data.dept || null;
+    }
+
+    if (!scope.subDepartment) {
+      scope.subDepartment =
+        data.subDepartment ||
+        data.subDepartmentId ||
+        data.subDeptId ||
+        data.subDept ||
+        null;
+    }
+  }
+
+  const filter = {};
+  if (scope.department) filter.department = scope.department;
+  if (scope.subDepartment) filter.subDepartment = scope.subDepartment;
+  return filter;
+}
+
+function ensureScope(filter, { required = true } = {}) {
+  const hasDepartment = Boolean(filter.department);
+  const hasSubDepartment = Boolean(filter.subDepartment);
+
+  if (hasDepartment && hasSubDepartment) {
+    throw new Error('僅能指定部門或小單位其中之一');
+  }
+
+  if (required && !hasDepartment && !hasSubDepartment) {
+    throw new Error('必須提供部門或小單位識別碼');
+  }
+
+  return filter;
+}
+
 export async function listSettings(req, res) {
   try {
-    const settings = await BreakSetting.find();
+    const scope = ensureScope(readScope(req));
+    const settings = await BreakSetting.find(scope);
     res.json(settings);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    const status = err.message.includes('識別碼') || err.message.includes('之一') ? 400 : 500;
+    res.status(status).json({ error: err.message });
+  }
+}
+
+export async function getSettingForDepartment(req, res) {
+  try {
+    const scope = ensureScope(readScope(req, ['params']));
+    const setting = await BreakSetting.findOne(scope);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function getSettingForSubDepartment(req, res) {
+  try {
+    const scope = ensureScope(readScope(req, ['params']));
+    const setting = await BreakSetting.findOne(scope);
+    if (!setting) return res.status(404).json({ error: 'Not found' });
+    res.json(setting);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 }
 
 export async function createSetting(req, res) {
   try {
-    const setting = new BreakSetting(req.body);
+    const scope = ensureScope(readScope(req, ['body']));
+    const existing = await BreakSetting.findOne(scope);
+    if (existing) {
+      return res.status(409).json({ error: '該單位已存在休息設定' });
+    }
+
+    const { _id, ...rest } = req.body || {};
+    const setting = new BreakSetting({ ...rest, ...scope });
     await setting.save();
     res.status(201).json(setting);
   } catch (err) {
@@ -21,7 +99,8 @@ export async function createSetting(req, res) {
 
 export async function getSetting(req, res) {
   try {
-    const setting = await BreakSetting.findById(req.params.id);
+    const scope = ensureScope(readScope(req), { required: false });
+    const setting = await BreakSetting.findOne({ _id: req.params.id, ...scope });
     if (!setting) return res.status(404).json({ error: 'Not found' });
     res.json(setting);
   } catch (err) {
@@ -31,9 +110,13 @@ export async function getSetting(req, res) {
 
 export async function updateSetting(req, res) {
   try {
-    const setting = await BreakSetting.findByIdAndUpdate(req.params.id, req.body, {
-      new: true
-    });
+    const scope = ensureScope(readScope(req, ['body', 'query']));
+    const { _id, ...rest } = req.body || {};
+    const setting = await BreakSetting.findOneAndUpdate(
+      { _id: req.params.id, ...scope },
+      { ...rest, ...scope },
+      { new: true, runValidators: true }
+    );
     if (!setting) return res.status(404).json({ error: 'Not found' });
     res.json(setting);
   } catch (err) {
@@ -43,7 +126,8 @@ export async function updateSetting(req, res) {
 
 export async function deleteSetting(req, res) {
   try {
-    const setting = await BreakSetting.findByIdAndDelete(req.params.id);
+    const scope = ensureScope(readScope(req, ['query', 'body']));
+    const setting = await BreakSetting.findOneAndDelete({ _id: req.params.id, ...scope });
     if (!setting) return res.status(404).json({ error: 'Not found' });
     res.json({ success: true });
   } catch (err) {

--- a/server/src/models/BreakSetting.js
+++ b/server/src/models/BreakSetting.js
@@ -1,12 +1,36 @@
 import mongoose from 'mongoose';
 
-const breakSettingSchema = new mongoose.Schema(
+const { Schema } = mongoose;
+
+const breakSettingSchema = new Schema(
   {
+    department: { type: Schema.Types.ObjectId, ref: 'Department' },
+    subDepartment: { type: Schema.Types.ObjectId, ref: 'SubDepartment' },
     enableGlobalBreak: { type: Boolean, default: false },
     breakMinutes: { type: Number, default: 60 },
     allowMultiBreak: { type: Boolean, default: false }
   },
   { timestamps: true }
 );
+
+breakSettingSchema.pre('validate', function (next) {
+  const hasDepartment = Boolean(this.department);
+  const hasSubDepartment = Boolean(this.subDepartment);
+
+  if (!hasDepartment && !hasSubDepartment) {
+    next(new Error('BreakSetting 必須指定部門或小單位')); // 驗證：至少需有一個範圍
+    return;
+  }
+
+  if (hasDepartment && hasSubDepartment) {
+    next(new Error('BreakSetting 不能同時指定部門與小單位'));
+    return;
+  }
+
+  next();
+});
+
+breakSettingSchema.index({ department: 1 }, { unique: true, sparse: true });
+breakSettingSchema.index({ subDepartment: 1 }, { unique: true, sparse: true });
 
 export default mongoose.model('BreakSetting', breakSettingSchema);

--- a/server/src/routes/breakSettingRoutes.js
+++ b/server/src/routes/breakSettingRoutes.js
@@ -4,11 +4,15 @@ import {
   createSetting,
   getSetting,
   updateSetting,
-  deleteSetting
+  deleteSetting,
+  getSettingForDepartment,
+  getSettingForSubDepartment
 } from '../controllers/breakSettingController.js';
 
 const router = Router();
 
+router.get('/department/:departmentId', getSettingForDepartment);
+router.get('/sub-department/:subDepartmentId', getSettingForSubDepartment);
 router.get('/', listSettings);
 router.post('/', createSetting);
 router.get('/:id', getSetting);

--- a/server/tests/breakSetting.test.js
+++ b/server/tests/breakSetting.test.js
@@ -1,0 +1,124 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+
+const saveMock = jest.fn();
+const mockBreakSetting = jest.fn().mockImplementation(payload => ({
+  ...payload,
+  save: saveMock
+}));
+
+mockBreakSetting.find = jest.fn();
+mockBreakSetting.findOne = jest.fn();
+mockBreakSetting.findOneAndUpdate = jest.fn();
+mockBreakSetting.findOneAndDelete = jest.fn();
+
+jest.unstable_mockModule('../src/models/BreakSetting.js', () => ({
+  default: mockBreakSetting
+}));
+
+let app;
+let routes;
+
+beforeAll(async () => {
+  routes = (await import('../src/routes/breakSettingRoutes.js')).default;
+  app = express();
+  app.use(express.json());
+  app.use('/api/break-settings', routes);
+});
+
+beforeEach(() => {
+  saveMock.mockReset();
+  saveMock.mockResolvedValue(undefined);
+  mockBreakSetting.mockClear();
+  mockBreakSetting.find.mockReset();
+  mockBreakSetting.findOne.mockReset();
+  mockBreakSetting.findOneAndUpdate.mockReset();
+  mockBreakSetting.findOneAndDelete.mockReset();
+});
+
+describe('BreakSetting routes', () => {
+  it('requires scope when listing', async () => {
+    const res = await request(app).get('/api/break-settings');
+    expect(res.status).toBe(400);
+    expect(mockBreakSetting.find).not.toHaveBeenCalled();
+  });
+
+  it('lists settings filtered by department', async () => {
+    mockBreakSetting.find.mockResolvedValue([{ department: 'dept1' }]);
+    const res = await request(app).get('/api/break-settings?department=dept1');
+    expect(res.status).toBe(200);
+    expect(mockBreakSetting.find).toHaveBeenCalledWith({ department: 'dept1' });
+  });
+
+  it('rejects conflicting scope filters', async () => {
+    const res = await request(app).get('/api/break-settings?department=d1&subDepartment=s1');
+    expect(res.status).toBe(400);
+  });
+
+  it('gets setting for department via path', async () => {
+    mockBreakSetting.findOne.mockResolvedValue({ department: 'dept2' });
+    const res = await request(app).get('/api/break-settings/department/dept2');
+    expect(res.status).toBe(200);
+    expect(mockBreakSetting.findOne).toHaveBeenCalledWith({ department: 'dept2' });
+  });
+
+  it('creates new setting with department scope', async () => {
+    mockBreakSetting.findOne.mockResolvedValueOnce(null);
+    saveMock.mockResolvedValue({});
+
+    const payload = {
+      department: 'dept3',
+      enableGlobalBreak: true,
+      breakMinutes: 50,
+      allowMultiBreak: true
+    };
+
+    const res = await request(app).post('/api/break-settings').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockBreakSetting.findOne).toHaveBeenCalledWith({ department: 'dept3' });
+    expect(mockBreakSetting).toHaveBeenCalledWith(expect.objectContaining(payload));
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('prevents duplicate settings per scope', async () => {
+    mockBreakSetting.findOne.mockResolvedValueOnce({ _id: 'existing' });
+    const res = await request(app).post('/api/break-settings').send({ department: 'dept4' });
+    expect(res.status).toBe(409);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('updates setting when scope matches', async () => {
+    mockBreakSetting.findOneAndUpdate.mockResolvedValue({ _id: 'id1', department: 'dept5' });
+    const res = await request(app)
+      .put('/api/break-settings/id1')
+      .send({ department: 'dept5', breakMinutes: 40 });
+
+    expect(res.status).toBe(200);
+    expect(mockBreakSetting.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'id1', department: 'dept5' },
+      expect.objectContaining({ department: 'dept5', breakMinutes: 40 }),
+      expect.objectContaining({ runValidators: true })
+    );
+  });
+
+  it('rejects update without scope', async () => {
+    const res = await request(app).put('/api/break-settings/id2').send({ breakMinutes: 35 });
+    expect(res.status).toBe(400);
+    expect(mockBreakSetting.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('deletes setting when scope matches', async () => {
+    mockBreakSetting.findOneAndDelete.mockResolvedValue({ _id: 'id3', department: 'dept6' });
+    const res = await request(app).delete('/api/break-settings/id3?department=dept6');
+    expect(res.status).toBe(200);
+    expect(mockBreakSetting.findOneAndDelete).toHaveBeenCalledWith({ _id: 'id3', department: 'dept6' });
+  });
+
+  it('rejects delete without scope', async () => {
+    const res = await request(app).delete('/api/break-settings/id4');
+    expect(res.status).toBe(400);
+    expect(mockBreakSetting.findOneAndDelete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 BreakSetting 模型的部門／小單位欄位與唯一索引，並調整 controller 與路由依據單位存取
- 讓後台 OrgDepartmentSetting.vue 按所選部門載入與儲存休息設定
- 補強前後端測試涵蓋依部門存取情境

## Testing
- npm test *(client 測試受現有環境限制失敗，多項 Vitest 與 ViteConfig 測試未通過；伺服器測試全部通過)*

------
https://chatgpt.com/codex/tasks/task_e_68ca63216c608329ac1c0c332ca7a6bb