### PR TITLE
優化主管排班載入流程並修正相關測試

### DIFF
--- a/client/src/views/front/ScheduleDashboard.vue
+++ b/client/src/views/front/ScheduleDashboard.vue
@@ -11,6 +11,7 @@
 <script setup>
 import { computed } from 'vue'
 import { UserFilled, CircleCloseFilled, WarningFilled } from '@element-plus/icons-vue'
+defineOptions({ name: 'ScheduleDashboard' })
 const props = defineProps({
   summary: {
     type: Object,

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -40,7 +40,7 @@ describe('Schedule.vue', () => {
           'el-select': true,
           'el-option': true,
           'el-input': true,
-          ScheduleDashboard: { template: '<div class="dashboard-stub"></div>', props: ['summary'] }
+          ScheduleDashboard: { name: 'ScheduleDashboard', template: '<div class="dashboard-stub"></div>', props: ['summary'] }
         }
       }
     })
@@ -322,6 +322,7 @@ describe('Schedule.vue', () => {
 
   it('maps department ids to names', async () => {
     apiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: 'd1', name: 'Dept A' }] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: 'sd1', name: 'Sub A', department: 'd1' }] })

--- a/client/tests/scheduleDashboard.spec.js
+++ b/client/tests/scheduleDashboard.spec.js
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import dayjs from 'dayjs'
 import Schedule from '../src/views/front/Schedule.vue'
+import { createPinia, setActivePinia } from 'pinia'
 
 vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
 import { apiFetch } from '../src/api'
@@ -30,6 +31,10 @@ function flush() {
 }
 
 describe('排班儀表板', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
   it('顯示 API 回傳的指標數據', async () => {
     const month = dayjs().format('YYYY-MM')
     apiFetch


### PR DESCRIPTION
## Summary
- 排班頁面改為優先使用 sessionStorage 保存的主管員工編號，並在缺少資料時才回退至 localStorage
- 加入 callWarning 輔助函式，確保缺漏班表時的警示訊息於測試環境中仍能被攔截，並強化排班與請假資料處理流程
- 明確設定 ScheduleDashboard 元件名稱並調整排班測試資料與排班儀表板測試初始化 Pinia

## Testing
- CI=1 npm run test *(因多個既有測試缺少 Pinia 或路由設定而失敗)*
- npm --prefix client test -- --run tests/schedule.spec.js -t "fetches summary and passes"
- npm --prefix client test -- --run tests/scheduleDashboard.spec.js


------
https://chatgpt.com/codex/tasks/task_e_68ca6a4dbb408329b95341eaa2470ba5