### PR TITLE
調整出勤列表權限與排序

### DIFF
--- a/server/src/controllers/attendanceController.js
+++ b/server/src/controllers/attendanceController.js
@@ -2,7 +2,18 @@ import AttendanceRecord from '../models/AttendanceRecord.js';
 
 export async function listRecords(req, res) {
   try {
-    const records = await AttendanceRecord.find().populate('employee');
+    const isEmployee = req.user?.role === 'employee';
+    const query = {};
+
+    if (isEmployee) {
+      query.employee = req.user?.id;
+    } else if (req.query.employee) {
+      query.employee = req.query.employee;
+    }
+
+    const records = await AttendanceRecord.find(query)
+      .sort({ timestamp: -1 })
+      .populate('employee');
     res.json(records);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/tests/attendance.test.js
+++ b/server/tests/attendance.test.js
@@ -7,54 +7,96 @@ const mockAttendanceRecord = jest.fn().mockImplementation((data = {}) => ({
   ...data,
   save: saveMock
 }));
-mockAttendanceRecord.find = jest.fn(() => ({ populate: jest.fn().mockResolvedValue([]) }));
+mockAttendanceRecord.find = jest.fn();
 
 jest.unstable_mockModule('../src/models/AttendanceRecord.js', () => ({ default: mockAttendanceRecord }));
 
 let app;
 let attendanceRoutes;
+let currentUser;
+
+const setupFindChain = ({ records = [], error } = {}) => {
+  const populateMock = error
+    ? jest.fn().mockRejectedValue(error)
+    : jest.fn().mockResolvedValue(records);
+  const sortMock = jest.fn().mockReturnValue({ populate: populateMock });
+  mockAttendanceRecord.find.mockReturnValue({ sort: sortMock });
+  return { sortMock, populateMock };
+};
 
 beforeAll(async () => {
   attendanceRoutes = (await import('../src/routes/attendanceRoutes.js')).default;
   app = express();
   app.use(express.json());
+  app.use((req, res, next) => {
+    if (currentUser) {
+      req.user = currentUser;
+    }
+    next();
+  });
   app.use('/api/attendance', attendanceRoutes);
 });
 
 beforeEach(() => {
   saveMock.mockReset();
   mockAttendanceRecord.find.mockReset();
+  currentUser = undefined;
 });
 
 describe('Attendance API', () => {
-  it('lists records', async () => {
+  it('lists records for privileged roles with newest first', async () => {
     const fakeRecords = [{ action: 'clockIn' }];
-    mockAttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(fakeRecords) });
+    const { sortMock, populateMock } = setupFindChain({ records: fakeRecords });
+    currentUser = { id: 'sup1', role: 'supervisor' };
+
     const res = await request(app).get('/api/attendance');
+
+    expect(mockAttendanceRecord.find).toHaveBeenCalledWith({});
+    expect(sortMock).toHaveBeenCalledWith({ timestamp: -1 });
+    expect(populateMock).toHaveBeenCalledWith('employee');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fakeRecords);
+  });
+
+  it('restricts employees to their own records and sorts by newest first', async () => {
+    const fakeRecords = [{ action: 'clockOut' }];
+    const { sortMock } = setupFindChain({ records: fakeRecords });
+    currentUser = { id: 'emp1', role: 'employee' };
+
+    const res = await request(app).get('/api/attendance').query({ employee: 'someoneElse' });
+
+    expect(mockAttendanceRecord.find).toHaveBeenCalledWith({ employee: 'emp1' });
+    expect(sortMock).toHaveBeenCalledWith({ timestamp: -1 });
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeRecords);
   });
 
   it('returns 500 if listing fails', async () => {
-    mockAttendanceRecord.find.mockReturnValue({ populate: jest.fn().mockRejectedValue(new Error('fail')) });
+    setupFindChain({ error: new Error('fail') });
+
     const res = await request(app).get('/api/attendance');
+
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
   });
 
-    it('creates record with remark', async () => {
-      const payload = { action: 'clockIn', employee: 'emp1', remark: 'test' };
-      saveMock.mockResolvedValue();
-      const res = await request(app).post('/api/attendance').send(payload);
-      expect(res.status).toBe(201);
-      expect(saveMock).toHaveBeenCalled();
-      expect(res.body).toMatchObject(payload);
-    });
+  it('creates record with remark', async () => {
+    const payload = { action: 'clockIn', employee: 'emp1', remark: 'test' };
+    saveMock.mockResolvedValue();
 
-    it('returns 400 when employee is missing', async () => {
-      const payload = { action: 'clockIn' };
-      const res = await request(app).post('/api/attendance').send(payload);
-      expect(res.status).toBe(400);
-      expect(saveMock).not.toHaveBeenCalled();
-    });
+    const res = await request(app).post('/api/attendance').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(saveMock).toHaveBeenCalled();
+    expect(res.body).toMatchObject(payload);
   });
+
+  it('returns 400 when employee is missing', async () => {
+    const payload = { action: 'clockIn' };
+
+    const res = await request(app).post('/api/attendance').send(payload);
+
+    expect(res.status).toBe(400);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 摘要
- 依照登入者角色調整出勤紀錄查詢條件，員工僅能查詢自身資料，主管可查詢全部或依參數篩選
- 出勤紀錄查詢結果加入時間由新到舊的排序
- 測試新增 req.user 模擬並驗證角色查詢邏輯與排序

## 測試
- npm --prefix server test -- attendance.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca7f43f1f083298e9e3fb6367bf632