### PR TITLE
feat: 部門出勤匯出與權限調整

### DIFF
--- a/server/src/controllers/reportController.js
+++ b/server/src/controllers/reportController.js
@@ -1,4 +1,7 @@
 import Report from '../models/Report.js';
+import Employee from '../models/Employee.js';
+import ShiftSchedule from '../models/ShiftSchedule.js';
+import AttendanceRecord from '../models/AttendanceRecord.js';
 
 export async function listReports(req, res) {
   try {
@@ -46,5 +49,125 @@ export async function deleteReport(req, res) {
     res.json({ success: true });
   } catch (err) {
     res.status(400).json({ error: err.message });
+  }
+}
+
+function normalizeId(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && value._id) return normalizeId(value._id);
+  if (typeof value.toString === 'function') return value.toString();
+  return String(value);
+}
+
+function normalizeDateKey(dateLike) {
+  const date = new Date(dateLike);
+  if (Number.isNaN(date.getTime())) return '';
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+export async function exportDepartmentAttendance(req, res) {
+  try {
+    const { month, department } = req.query;
+    if (!month || !department) {
+      return res.status(400).json({ error: 'month and department required' });
+    }
+
+    const start = new Date(`${month}-01`);
+    if (Number.isNaN(start.getTime())) {
+      return res.status(400).json({ error: 'invalid month' });
+    }
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+
+    const role = req.user?.role;
+    const actorId = req.user?.id;
+
+    let employees = [];
+    if (role === 'supervisor') {
+      if (!actorId) return res.status(403).json({ error: 'Forbidden' });
+      employees = await Employee.find({ department, supervisor: actorId });
+      if (!employees.length) {
+        const exists = await Employee.exists({ department });
+        if (exists) return res.status(403).json({ error: 'Forbidden' });
+        return res.status(404).json({ error: 'No data' });
+      }
+    } else {
+      employees = await Employee.find({ department });
+      if (!employees.length) {
+        return res.status(404).json({ error: 'No data' });
+      }
+    }
+
+    const employeeIds = employees.map((emp) => normalizeId(emp._id)).filter(Boolean);
+
+    const schedules = await ShiftSchedule.find({
+      employee: { $in: employeeIds },
+      date: { $gte: start, $lt: end },
+    });
+
+    const attendanceRecords = await AttendanceRecord.find({
+      employee: { $in: employeeIds },
+      action: 'clockIn',
+      timestamp: { $gte: start, $lt: end },
+    });
+
+    const recordMap = new Map();
+    const results = employees.map((emp) => {
+      const id = normalizeId(emp._id);
+      const record = {
+        employee: id,
+        name: emp.name,
+        scheduled: 0,
+        attended: 0,
+        absent: 0,
+      };
+      recordMap.set(id, record);
+      return record;
+    });
+
+    schedules.forEach((schedule) => {
+      const id = normalizeId(schedule.employee);
+      const record = recordMap.get(id);
+      if (record) {
+        record.scheduled += 1;
+      }
+    });
+
+    const attendanceKeys = new Set();
+    attendanceRecords.forEach((attendance) => {
+      const id = normalizeId(attendance.employee);
+      const dateKey = normalizeDateKey(attendance.timestamp);
+      if (!id || !dateKey) return;
+      const combined = `${id}-${dateKey}`;
+      if (!attendanceKeys.has(combined)) {
+        attendanceKeys.add(combined);
+        const record = recordMap.get(id);
+        if (record) record.attended += 1;
+      }
+    });
+
+    results.forEach((record) => {
+      record.absent = Math.max(record.scheduled - record.attended, 0);
+    });
+
+    const summary = results.reduce(
+      (acc, record) => {
+        acc.scheduled += record.scheduled;
+        acc.attended += record.attended;
+        acc.absent += record.absent;
+        return acc;
+      },
+      { scheduled: 0, attended: 0, absent: 0 }
+    );
+
+    res.json({
+      month,
+      department,
+      summary,
+      records: results,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
   }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -123,7 +123,17 @@ app.use(
   scheduleRoutes
 );
 app.use('/api/payroll', authenticate, authorizeRoles('admin'), payrollRoutes);
-app.use('/api/reports', authenticate, authorizeRoles('admin'), reportRoutes);
+app.use(
+  '/api/reports',
+  authenticate,
+  (req, res, next) => {
+    if (req.method === 'GET') {
+      return authorizeRoles('admin', 'supervisor')(req, res, next);
+    }
+    return authorizeRoles('admin')(req, res, next);
+  },
+  reportRoutes
+);
 app.use('/api/insurance', authenticate, authorizeRoles('admin'), insuranceRoutes);
 app.use('/api/approvals', authenticate, approvalRoutes);
 app.use('/api/menu', authenticate, menuRoutes);

--- a/server/src/routes/reportRoutes.js
+++ b/server/src/routes/reportRoutes.js
@@ -4,13 +4,15 @@ import {
   createReport,
   getReport,
   updateReport,
-  deleteReport
+  deleteReport,
+  exportDepartmentAttendance
 } from '../controllers/reportController.js';
 
 const router = Router();
 
 router.get('/', listReports);
 router.post('/', createReport);
+router.get('/department/attendance/export', exportDepartmentAttendance);
 router.get('/:id', getReport);
 router.put('/:id', updateReport);
 router.delete('/:id', deleteReport);

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -6,7 +6,14 @@ const saveMock = jest.fn();
 const mockReport = jest.fn().mockImplementation(() => ({ save: saveMock }));
 mockReport.find = jest.fn();
 
+const mockEmployee = { find: jest.fn(), exists: jest.fn() };
+const mockShiftSchedule = { find: jest.fn() };
+const mockAttendanceRecord = { find: jest.fn() };
+
 jest.unstable_mockModule('../src/models/Report.js', () => ({ default: mockReport }));
+jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
+jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
+jest.unstable_mockModule('../src/models/AttendanceRecord.js', () => ({ default: mockAttendanceRecord }));
 
 let app;
 let reportRoutes;
@@ -15,12 +22,27 @@ beforeAll(async () => {
   reportRoutes = (await import('../src/routes/reportRoutes.js')).default;
   app = express();
   app.use(express.json());
+  app.use((req, res, next) => {
+    const role = req.headers['x-user-role'] || 'admin';
+    const id = req.headers['x-user-id'] || 'admin';
+    req.user = { role, id };
+    next();
+  });
   app.use('/api/reports', reportRoutes);
 });
 
 beforeEach(() => {
   saveMock.mockReset();
   mockReport.find.mockReset();
+  mockEmployee.find.mockReset();
+  mockEmployee.exists.mockReset();
+  mockShiftSchedule.find.mockReset();
+  mockAttendanceRecord.find.mockReset();
+
+  mockEmployee.find.mockResolvedValue([]);
+  mockEmployee.exists.mockResolvedValue(null);
+  mockShiftSchedule.find.mockResolvedValue([]);
+  mockAttendanceRecord.find.mockResolvedValue([]);
 });
 
 describe('Report API', () => {
@@ -47,4 +69,62 @@ describe('Report API', () => {
     expect(saveMock).toHaveBeenCalled();
     expect(res.body).toEqual({});
   });
+
+  it('exports department attendance for supervisor', async () => {
+    mockEmployee.find.mockResolvedValueOnce([
+      { _id: 'emp1', name: 'Alice' },
+      { _id: 'emp2', name: 'Bob' },
+    ]);
+    mockShiftSchedule.find.mockResolvedValue([
+      { employee: 'emp1', date: new Date('2024-01-05') },
+      { employee: 'emp1', date: new Date('2024-01-10') },
+      { employee: 'emp2', date: new Date('2024-01-05') },
+    ]);
+    mockAttendanceRecord.find.mockResolvedValue([
+      { employee: 'emp1', action: 'clockIn', timestamp: new Date('2024-01-05T08:00:00Z') },
+      { employee: 'emp2', action: 'clockIn', timestamp: new Date('2024-01-05T09:00:00Z') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/department/attendance/export?month=2024-01&department=dept1')
+      .set('x-user-role', 'supervisor')
+      .set('x-user-id', 'sup1');
+
+    expect(mockEmployee.find).toHaveBeenCalledWith({ department: 'dept1', supervisor: 'sup1' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      month: '2024-01',
+      department: 'dept1',
+      summary: { scheduled: 3, attended: 2, absent: 1 },
+      records: [
+        { employee: 'emp1', name: 'Alice', scheduled: 2, attended: 1, absent: 1 },
+        { employee: 'emp2', name: 'Bob', scheduled: 1, attended: 1, absent: 0 },
+      ],
+    });
+  });
+
+  it('rejects supervisor export without access', async () => {
+    mockEmployee.find.mockResolvedValueOnce([]);
+    mockEmployee.exists.mockResolvedValueOnce(true);
+
+    const res = await request(app)
+      .get('/api/reports/department/attendance/export?month=2024-01&department=dept2')
+      .set('x-user-role', 'supervisor')
+      .set('x-user-id', 'sup1');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
+  });
+
+  it('returns 404 when no department data', async () => {
+    mockEmployee.find.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .get('/api/reports/department/attendance/export?month=2024-01&department=dept3')
+      .set('x-user-role', 'admin');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'No data' });
+  });
 });
+


### PR DESCRIPTION
## Summary
- 調整 /api/reports 註冊方式，讓 GET 要求允許主管角色存取
- 新增部門出勤匯出控制器與路由，提供排班、出勤、缺勤統計
- 擴充報表測試涵蓋主管成功、越權與無資料情境

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc450d9c8883298e2913b3021b5e5b