### PR TITLE
新增部門請假匯出與測試

### DIFF
--- a/server/src/controllers/reportController.js
+++ b/server/src/controllers/reportController.js
@@ -2,6 +2,9 @@ import Report from '../models/Report.js';
 import Employee from '../models/Employee.js';
 import ShiftSchedule from '../models/ShiftSchedule.js';
 import AttendanceRecord from '../models/AttendanceRecord.js';
+import ApprovalRequest from '../models/approval_request.js';
+import { getLeaveFieldIds } from '../services/leaveFieldService.js';
+import { exportTabularReport } from '../services/reportExportHelper.js';
 
 export async function listReports(req, res) {
   try {
@@ -66,9 +69,68 @@ function normalizeDateKey(dateLike) {
   return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
 }
 
+function formatYMD(dateLike) {
+  if (!dateLike) return '';
+  const date = new Date(dateLike);
+  if (Number.isNaN(date.getTime())) return '';
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function calculateInclusiveDays(start, end) {
+  const startDate = start ? new Date(start) : null;
+  const endDate = end ? new Date(end) : null;
+  if (!startDate || !endDate) return 0;
+  const startTime = startDate.getTime();
+  const endTime = endDate.getTime();
+  if (Number.isNaN(startTime) || Number.isNaN(endTime)) return 0;
+  if (endTime < startTime) return 0;
+  const diff = endTime - startTime;
+  return Math.floor(diff / (24 * 60 * 60 * 1000)) + 1;
+}
+
+function createTypeMap(options = []) {
+  const map = new Map();
+  options.forEach((opt) => {
+    if (!opt) return;
+    const value = opt.value ?? opt.code ?? opt.id ?? opt.key;
+    const label = opt.label ?? opt.name ?? opt.title ?? opt.text ?? opt.display ?? value;
+    if (value !== undefined && value !== null) {
+      const strValue = String(value);
+      map.set(strValue, label !== undefined && label !== null ? String(label) : strValue);
+    }
+    if (label !== undefined && label !== null) {
+      const labelStr = String(label);
+      if (!map.has(labelStr)) map.set(labelStr, labelStr);
+    }
+  });
+  return map;
+}
+
+function humanizeLeaveType(raw, typeMap) {
+  if (raw === undefined || raw === null) return { label: '', code: '' };
+  if (typeof raw === 'object') {
+    const codeCandidate =
+      raw.code ?? raw.value ?? raw.id ?? raw._id ?? (typeof raw.toString === 'function' ? raw.toString() : '');
+    const code = codeCandidate ? String(codeCandidate) : '';
+    const labelCandidate = raw.label ?? raw.name ?? raw.title ?? (code ? typeMap.get(code) : undefined);
+    const label = labelCandidate ? String(labelCandidate) : code;
+    return { label, code: code || label };
+  }
+  const code = String(raw);
+  const label =
+    typeMap.get(code) ??
+    typeMap.get(code.toUpperCase?.() ?? code) ??
+    typeMap.get(code.toLowerCase?.() ?? code) ??
+    code;
+  return { label: String(label), code };
+}
+
 export async function exportDepartmentAttendance(req, res) {
   try {
-    const { month, department } = req.query;
+    const { month, department, format: rawFormat } = req.query;
     if (!month || !department) {
       return res.status(400).json({ error: 'month and department required' });
     }
@@ -79,6 +141,8 @@ export async function exportDepartmentAttendance(req, res) {
     }
     const end = new Date(start);
     end.setMonth(end.getMonth() + 1);
+
+    const format = typeof rawFormat === 'string' ? rawFormat.toLowerCase() : 'json';
 
     const role = req.user?.role;
     const actorId = req.user?.id;
@@ -161,11 +225,190 @@ export async function exportDepartmentAttendance(req, res) {
       { scheduled: 0, attended: 0, absent: 0 }
     );
 
+    if (format === 'excel' || format === 'pdf') {
+      const rows = results.map((record) => ({
+        employee: record.name,
+        scheduled: record.scheduled,
+        attended: record.attended,
+        absent: record.absent,
+      }));
+      await exportTabularReport(res, {
+        format,
+        fileName: `attendance-${department}-${month}`,
+        sheetName: 'Attendance',
+        title: `${month} ${department} 出勤統計`,
+        columns: [
+          { header: '員工姓名', key: 'employee', width: 24 },
+          { header: '排班天數', key: 'scheduled', width: 14 },
+          { header: '實際出勤', key: 'attended', width: 14 },
+          { header: '缺勤天數', key: 'absent', width: 14 },
+        ],
+        rows,
+        summaryRows: [
+          { label: '排班總計', value: summary.scheduled },
+          { label: '出勤總計', value: summary.attended },
+          { label: '缺勤總計', value: summary.absent },
+        ],
+      });
+      return;
+    }
+
     res.json({
       month,
       department,
       summary,
       records: results,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function exportDepartmentLeave(req, res) {
+  try {
+    const { month, department, format: rawFormat } = req.query;
+    if (!month || !department) {
+      return res.status(400).json({ error: 'month and department required' });
+    }
+
+    const role = req.user?.role;
+    if (!['admin', 'supervisor'].includes(role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const start = new Date(`${month}-01`);
+    if (Number.isNaN(start.getTime())) {
+      return res.status(400).json({ error: 'invalid month' });
+    }
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+
+    const format = typeof rawFormat === 'string' ? rawFormat.toLowerCase() : 'json';
+
+    const { formId, startId, endId, typeId, typeOptions } = await getLeaveFieldIds();
+    if (!formId || !startId || !endId) {
+      return res.status(400).json({ error: 'leave form not configured' });
+    }
+
+    const actorId = req.user?.id;
+    let employees = [];
+    if (role === 'supervisor') {
+      if (!actorId) return res.status(403).json({ error: 'Forbidden' });
+      employees = await Employee.find({ department, supervisor: actorId });
+      if (!employees.length) {
+        const exists = await Employee.exists({ department });
+        if (exists) return res.status(403).json({ error: 'Forbidden' });
+        return res.status(404).json({ error: 'No data' });
+      }
+    } else {
+      employees = await Employee.find({ department });
+      if (!employees.length) {
+        return res.status(404).json({ error: 'No data' });
+      }
+    }
+
+    const employeeIds = employees.map((emp) => normalizeId(emp._id)).filter(Boolean);
+    if (!employeeIds.length) {
+      return res.status(404).json({ error: 'No data' });
+    }
+
+    const approvals = await ApprovalRequest.find({
+      form: formId,
+      status: 'approved',
+      applicant_employee: { $in: employeeIds },
+      createdAt: { $gte: start, $lt: end },
+    })
+      .populate('applicant_employee', 'name')
+      .lean();
+
+    if (!approvals.length) {
+      return res.status(404).json({ error: 'No data' });
+    }
+
+    const typeMap = createTypeMap(typeOptions);
+    const records = approvals.map((approval) => {
+      const startValue = startId ? approval.form_data?.[startId] : undefined;
+      const endValue = endId ? approval.form_data?.[endId] : undefined;
+      const typeValue = typeId ? approval.form_data?.[typeId] : undefined;
+      const { label: leaveType, code: leaveCode } = humanizeLeaveType(typeValue, typeMap);
+      const days = calculateInclusiveDays(startValue, endValue);
+      return {
+        approvalId: normalizeId(approval._id),
+        employee: normalizeId(approval.applicant_employee?._id ?? approval.applicant_employee),
+        name: approval.applicant_employee?.name ?? '',
+        leaveType,
+        leaveCode,
+        startDate: formatYMD(startValue),
+        endDate: formatYMD(endValue),
+        days,
+      };
+    });
+
+    const typeSummaryMap = new Map();
+    let totalDays = 0;
+    records.forEach((record) => {
+      totalDays += Number.isFinite(record.days) ? record.days : 0;
+      const key = record.leaveCode || record.leaveType || '';
+      const existing = typeSummaryMap.get(key) || {
+        leaveType: record.leaveType || record.leaveCode || '',
+        leaveCode: record.leaveCode || '',
+        count: 0,
+        days: 0,
+      };
+      existing.count += 1;
+      existing.days += Number.isFinite(record.days) ? record.days : 0;
+      if (!existing.leaveType && record.leaveType) existing.leaveType = record.leaveType;
+      if (!existing.leaveCode && record.leaveCode) existing.leaveCode = record.leaveCode;
+      typeSummaryMap.set(key, existing);
+    });
+
+    const summary = {
+      totalLeaves: records.length,
+      totalDays,
+      byType: Array.from(typeSummaryMap.values()),
+    };
+
+    if (format === 'excel' || format === 'pdf') {
+      const rows = records.map((record) => ({
+        employee: record.name,
+        leaveType: record.leaveType || record.leaveCode,
+        leaveCode: record.leaveCode,
+        startDate: record.startDate,
+        endDate: record.endDate,
+        days: record.days,
+      }));
+      const summaryRows = [
+        { label: '總請假件數', value: summary.totalLeaves },
+        { label: '總請假天數', value: summary.totalDays },
+        ...summary.byType.map((item) => ({
+          label: `${item.leaveType || item.leaveCode} 件數`,
+          value: `${item.count} 筆 / ${item.days} 天`,
+        })),
+      ];
+      await exportTabularReport(res, {
+        format,
+        fileName: `leave-${department}-${month}`,
+        sheetName: 'Department Leave',
+        title: `${month} ${department} 請假統計`,
+        columns: [
+          { header: '員工姓名', key: 'employee', width: 24 },
+          { header: '假別', key: 'leaveType', width: 18 },
+          { header: '假別代碼', key: 'leaveCode', width: 16 },
+          { header: '開始日期', key: 'startDate', width: 16 },
+          { header: '結束日期', key: 'endDate', width: 16 },
+          { header: '天數', key: 'days', width: 10 },
+        ],
+        rows,
+        summaryRows,
+      });
+      return;
+    }
+
+    res.json({
+      month,
+      department,
+      summary,
+      records,
     });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -1,9 +1,8 @@
 import ShiftSchedule from '../models/ShiftSchedule.js';
 import Employee from '../models/Employee.js';
 import ApprovalRequest from '../models/approval_request.js';
-import FormTemplate from '../models/form_template.js';
-import FormField from '../models/form_field.js';
 import AttendanceSetting from '../models/AttendanceSetting.js';
+import { getLeaveFieldIds } from '../services/leaveFieldService.js';
 
 function formatDate(date) {
   const d = new Date(date);
@@ -24,24 +23,6 @@ async function attachShiftInfo(schedules) {
     date: formatDate(s.date),
     shiftName: map[s.shiftId?.toString()] || '',
   }));
-}
-
-let leaveFieldCache = null;
-async function getLeaveFieldIds() {
-  if (leaveFieldCache) return leaveFieldCache;
-  const form = await FormTemplate.findOne({ name: '請假' });
-  if (!form) return {};
-  const fields = await FormField.find({ form: form._id });
-  const startField = fields.find(f => f.label === '開始日期');
-  const endField = fields.find(f => f.label === '結束日期');
-  const typeField = fields.find(f => f.label === '假別');
-  leaveFieldCache = {
-    formId: form._id.toString(),
-    startId: startField?._id.toString(),
-    endId: endField?._id.toString(),
-    typeId: typeField?._id.toString(),
-  };
-  return leaveFieldCache;
 }
 
 async function hasLeaveConflict(employeeId, date) {

--- a/server/src/routes/reportRoutes.js
+++ b/server/src/routes/reportRoutes.js
@@ -5,14 +5,21 @@ import {
   getReport,
   updateReport,
   deleteReport,
-  exportDepartmentAttendance
+  exportDepartmentAttendance,
+  exportDepartmentLeave
 } from '../controllers/reportController.js';
+import { authorizeRoles } from '../middleware/auth.js';
 
 const router = Router();
 
 router.get('/', listReports);
 router.post('/', createReport);
 router.get('/department/attendance/export', exportDepartmentAttendance);
+router.get(
+  '/department/leave/export',
+  authorizeRoles('supervisor', 'admin'),
+  exportDepartmentLeave
+);
 router.get('/:id', getReport);
 router.put('/:id', updateReport);
 router.delete('/:id', deleteReport);

--- a/server/src/services/leaveFieldService.js
+++ b/server/src/services/leaveFieldService.js
@@ -1,0 +1,104 @@
+import FormTemplate from '../models/form_template.js';
+import FormField from '../models/form_field.js';
+
+let leaveFieldCache = null;
+
+function normalizeOption(value, label) {
+  if (value === undefined || value === null) return null;
+  const normalizedValue = String(value);
+  const normalizedLabel = label !== undefined && label !== null ? String(label) : normalizedValue;
+  return { value: normalizedValue, label: normalizedLabel };
+}
+
+function extractOptions(field) {
+  const { options } = field ?? {};
+  if (!options) return [];
+
+  const results = [];
+  const pushOption = (value, label) => {
+    const option = normalizeOption(value, label);
+    if (option) results.push(option);
+  };
+
+  if (Array.isArray(options)) {
+    options.forEach((opt) => {
+      if (opt === undefined || opt === null) return;
+      if (typeof opt === 'string' || typeof opt === 'number' || typeof opt === 'boolean') {
+        pushOption(opt, opt);
+      } else if (typeof opt === 'object') {
+        const value = opt.value ?? opt.code ?? opt.id ?? opt._id ?? opt.key;
+        const label =
+          opt.label ?? opt.name ?? opt.title ?? opt.text ?? opt.display ?? opt.caption ?? value;
+        pushOption(value ?? label, label ?? value);
+      }
+    });
+  } else if (typeof options === 'object') {
+    if (Array.isArray(options.choices)) {
+      options.choices.forEach((choice) => {
+        if (choice === undefined || choice === null) return;
+        if (typeof choice === 'string' || typeof choice === 'number') {
+          pushOption(choice, choice);
+        } else if (typeof choice === 'object') {
+          const value = choice.value ?? choice.code ?? choice.id ?? choice._id ?? choice.key;
+          const label =
+            choice.label ?? choice.name ?? choice.title ?? choice.text ?? choice.display ?? value;
+          pushOption(value ?? label, label ?? value);
+        }
+      });
+    } else {
+      Object.entries(options).forEach(([key, value]) => {
+        if (value === undefined || value === null) return;
+        if (typeof value === 'string' || typeof value === 'number') {
+          pushOption(key, value);
+        } else if (typeof value === 'object') {
+          const optValue = value.value ?? value.code ?? value.id ?? value._id ?? key;
+          const optLabel =
+            value.label ?? value.name ?? value.title ?? value.text ?? value.display ?? value.value;
+          pushOption(optValue ?? optLabel ?? key, optLabel ?? optValue ?? key);
+        } else {
+          pushOption(key, value);
+        }
+      });
+    }
+  }
+
+  const seen = new Set();
+  return results.filter((opt) => {
+    if (seen.has(opt.value)) return false;
+    seen.add(opt.value);
+    return true;
+  });
+}
+
+export function resetLeaveFieldCache() {
+  leaveFieldCache = null;
+}
+
+export async function getLeaveFieldIds() {
+  if (leaveFieldCache) return leaveFieldCache;
+
+  const form = await FormTemplate.findOne({ name: '請假' }).lean();
+  if (!form) {
+    leaveFieldCache = {};
+    return leaveFieldCache;
+  }
+
+  const fields = await FormField.find({ form: form._id }).lean();
+  const startField = fields.find((f) => f.label === '開始日期');
+  const endField = fields.find((f) => f.label === '結束日期');
+  const typeField = fields.find((f) => f.label === '假別');
+
+  leaveFieldCache = {
+    formId: form._id?.toString(),
+    startId: startField?._id?.toString(),
+    endId: endField?._id?.toString(),
+    typeId: typeField?._id?.toString(),
+    typeOptions: typeField ? extractOptions(typeField) : [],
+  };
+
+  return leaveFieldCache;
+}
+
+export async function getLeaveFieldConfig() {
+  return getLeaveFieldIds();
+}

--- a/server/src/services/reportExportHelper.js
+++ b/server/src/services/reportExportHelper.js
@@ -1,0 +1,98 @@
+function sanitizeFileName(name = 'report') {
+  return String(name)
+    .trim()
+    .replace(/[^a-zA-Z0-9-_]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'report';
+}
+
+export async function exportTabularReport(
+  res,
+  { format = 'excel', fileName = 'report', sheetName = 'Report', title, columns = [], rows = [], summaryRows = [] }
+) {
+  const safeName = sanitizeFileName(fileName);
+  const finalColumns = Array.isArray(columns) ? columns : [];
+  const dataRows = Array.isArray(rows) ? rows : [];
+  const summaries = Array.isArray(summaryRows) ? summaryRows : [];
+
+  if (format === 'pdf') {
+    let PDFDocument;
+    try {
+      PDFDocument = (await import('pdfkit')).default;
+    } catch (err) {
+      throw new Error('pdfkit module not installed');
+    }
+    const doc = new PDFDocument({ margin: 36 });
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${safeName}.pdf"`);
+    doc.pipe(res);
+
+    if (title) {
+      doc.fontSize(16).text(String(title), { align: 'center' });
+      doc.moveDown();
+    }
+
+    if (finalColumns.length) {
+      doc.fontSize(12);
+      doc.text(finalColumns.map((col) => col.header ?? col.key ?? '').join(' | '));
+      doc.moveDown(0.5);
+      dataRows.forEach((row) => {
+        const line = finalColumns
+          .map((col) => {
+            const value = row[col.key];
+            return value === undefined || value === null ? '' : String(value);
+          })
+          .join(' | ');
+        doc.text(line);
+      });
+    }
+
+    if (summaries.length) {
+      doc.moveDown();
+      summaries.forEach(({ label, value }) => {
+        doc.text(`${label ?? ''}: ${value ?? ''}`);
+      });
+    }
+
+    doc.end();
+    return;
+  }
+
+  let ExcelJS;
+  try {
+    ExcelJS = (await import('exceljs')).default;
+  } catch (err) {
+    throw new Error('exceljs module not installed');
+  }
+
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet(sheetName || 'Report');
+  worksheet.columns = finalColumns.map((col) => ({
+    header: col.header,
+    key: col.key,
+    width: col.width ?? 20,
+  }));
+
+  dataRows.forEach((row) => {
+    worksheet.addRow(row);
+  });
+
+  if (summaries.length && finalColumns.length >= 2) {
+    worksheet.addRow({});
+    const labelKey = finalColumns[0].key;
+    const valueKey = finalColumns[1].key;
+    summaries.forEach(({ label, value }) => {
+      const summaryRow = {};
+      summaryRow[labelKey] = label;
+      summaryRow[valueKey] = value;
+      worksheet.addRow(summaryRow);
+    });
+  }
+
+  res.setHeader(
+    'Content-Type',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  );
+  res.setHeader('Content-Disposition', `attachment; filename="${safeName}.xlsx"`);
+  const buffer = await workbook.xlsx.writeBuffer();
+  res.send(buffer);
+}

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -9,11 +9,17 @@ mockReport.find = jest.fn();
 const mockEmployee = { find: jest.fn(), exists: jest.fn() };
 const mockShiftSchedule = { find: jest.fn() };
 const mockAttendanceRecord = { find: jest.fn() };
+const mockApprovalRequest = { find: jest.fn() };
+const mockGetLeaveFieldIds = jest.fn();
 
 jest.unstable_mockModule('../src/models/Report.js', () => ({ default: mockReport }));
 jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
 jest.unstable_mockModule('../src/models/AttendanceRecord.js', () => ({ default: mockAttendanceRecord }));
+jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }));
+jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+  getLeaveFieldIds: mockGetLeaveFieldIds,
+}));
 
 let app;
 let reportRoutes;
@@ -38,11 +44,20 @@ beforeEach(() => {
   mockEmployee.exists.mockReset();
   mockShiftSchedule.find.mockReset();
   mockAttendanceRecord.find.mockReset();
+  mockApprovalRequest.find.mockReset();
+  mockGetLeaveFieldIds.mockReset();
 
   mockEmployee.find.mockResolvedValue([]);
   mockEmployee.exists.mockResolvedValue(null);
   mockShiftSchedule.find.mockResolvedValue([]);
   mockAttendanceRecord.find.mockResolvedValue([]);
+  mockGetLeaveFieldIds.mockResolvedValue({
+    formId: 'leaveForm',
+    startId: 'start',
+    endId: 'end',
+    typeId: 'type',
+    typeOptions: [],
+  });
 });
 
 describe('Report API', () => {
@@ -125,6 +140,125 @@ describe('Report API', () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ error: 'No data' });
+  });
+
+  it('exports department leave for supervisor', async () => {
+    mockEmployee.find.mockResolvedValueOnce([
+      { _id: 'emp1', name: 'Alice' },
+      { _id: 'emp2', name: 'Bob' },
+    ]);
+    mockGetLeaveFieldIds.mockResolvedValueOnce({
+      formId: 'leaveForm',
+      startId: 'start',
+      endId: 'end',
+      typeId: 'type',
+      typeOptions: [
+        { value: 'SICK', label: '病假' },
+        { value: 'ANNUAL', label: '特休' },
+      ],
+    });
+    const approvals = [
+      {
+        _id: 'a1',
+        applicant_employee: { _id: 'emp1', name: 'Alice' },
+        form_data: { start: '2024-01-05', end: '2024-01-06', type: 'SICK' },
+      },
+      {
+        _id: 'a2',
+        applicant_employee: { _id: 'emp2', name: 'Bob' },
+        form_data: {
+          start: '2024-01-10',
+          end: '2024-01-10',
+          type: { code: 'ANNUAL', label: '特休' },
+        },
+      },
+    ];
+    const populate = jest.fn().mockReturnThis();
+    const lean = jest.fn().mockResolvedValue(approvals);
+    mockApprovalRequest.find.mockReturnValue({ populate, lean });
+
+    const res = await request(app)
+      .get('/api/reports/department/leave/export?month=2024-01&department=dept1&format=json')
+      .set('x-user-role', 'supervisor')
+      .set('x-user-id', 'sup1');
+
+    expect(mockEmployee.find).toHaveBeenCalledWith({ department: 'dept1', supervisor: 'sup1' });
+    const queryArg = mockApprovalRequest.find.mock.calls[0][0];
+    expect(queryArg.form).toBe('leaveForm');
+    expect(queryArg.status).toBe('approved');
+    expect(queryArg.applicant_employee).toEqual({ $in: ['emp1', 'emp2'] });
+    expect(queryArg.createdAt.$gte).toBeInstanceOf(Date);
+    expect(queryArg.createdAt.$lt).toBeInstanceOf(Date);
+    expect(queryArg.createdAt.$gte.toISOString()).toBe(
+      new Date('2024-01-01T00:00:00.000Z').toISOString()
+    );
+    expect(queryArg.createdAt.$lt.toISOString()).toBe(
+      new Date('2024-02-01T00:00:00.000Z').toISOString()
+    );
+    expect(populate).toHaveBeenCalledWith('applicant_employee', 'name');
+    expect(lean).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      month: '2024-01',
+      department: 'dept1',
+      summary: {
+        totalLeaves: 2,
+        totalDays: 3,
+        byType: [
+          { leaveType: '病假', leaveCode: 'SICK', count: 1, days: 2 },
+          { leaveType: '特休', leaveCode: 'ANNUAL', count: 1, days: 1 },
+        ],
+      },
+      records: [
+        {
+          approvalId: 'a1',
+          employee: 'emp1',
+          name: 'Alice',
+          leaveType: '病假',
+          leaveCode: 'SICK',
+          startDate: '2024-01-05',
+          endDate: '2024-01-06',
+          days: 2,
+        },
+        {
+          approvalId: 'a2',
+          employee: 'emp2',
+          name: 'Bob',
+          leaveType: '特休',
+          leaveCode: 'ANNUAL',
+          startDate: '2024-01-10',
+          endDate: '2024-01-10',
+          days: 1,
+        },
+      ],
+    });
+  });
+
+  it('returns 404 when no leave data', async () => {
+    mockEmployee.find.mockResolvedValueOnce([
+      { _id: 'emp1', name: 'Alice' },
+    ]);
+    mockApprovalRequest.find.mockReturnValue({
+      populate: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    });
+
+    const res = await request(app)
+      .get('/api/reports/department/leave/export?month=2024-01&department=dept1&format=json')
+      .set('x-user-role', 'admin');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'No data' });
+  });
+
+  it('rejects employee leave export', async () => {
+    const res = await request(app)
+      .get('/api/reports/department/leave/export?month=2024-01&department=dept1')
+      .set('x-user-role', 'employee')
+      .set('x-user-id', 'emp0');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
   });
 });
 

--- a/server/tests/schedule.test.js
+++ b/server/tests/schedule.test.js
@@ -17,21 +17,21 @@ const mockShiftSchedule = {
 
 const mockApprovalRequest = { findOne: jest.fn(), find: jest.fn() };
 
-const mockFormTemplate = { findOne: jest.fn() };
-const mockFormField = { find: jest.fn() };
-
 const mockEmployee = { find: jest.fn() };
 const mockAttendanceSetting = { findOne: jest.fn() };
+
+const mockGetLeaveFieldIds = jest.fn();
 
 /* --------------------------- jest.mock 設定區 --------------------------- */
 
 
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
 jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }));
-jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: mockFormTemplate }));
-jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }));
 jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
 jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }));
+jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+  getLeaveFieldIds: mockGetLeaveFieldIds,
+}));
 
 // 驗證中介層直接放行
 jest.unstable_mockModule('../src/middleware/supervisor.js', () => ({ verifySupervisor: (req, res, next) => next() }));
@@ -56,12 +56,14 @@ beforeEach(() => {
 
   mockApprovalRequest.findOne.mockReset();
   mockApprovalRequest.find.mockReset();
-  mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
-  mockFormField.find.mockResolvedValue([
-    { _id: 's', label: '開始日期' },
-    { _id: 'e', label: '結束日期' },
-    { _id: 't', label: '假別' },
-  ]);
+  mockGetLeaveFieldIds.mockReset();
+  mockGetLeaveFieldIds.mockResolvedValue({
+    formId: 'form1',
+    startId: 's',
+    endId: 'e',
+    typeId: 't',
+    typeOptions: [],
+  });
   mockEmployee.find.mockReset();
   mockAttendanceSetting.findOne.mockReset();
   mockAttendanceSetting.findOne.mockReturnValue({

--- a/server/tests/schedule.unit.test.js
+++ b/server/tests/schedule.unit.test.js
@@ -7,15 +7,15 @@ const mockShiftSchedule = {
   insertMany: jest.fn(),
 };
 const mockApprovalRequest = { findOne: jest.fn() };
-const mockFormTemplate = { findOne: jest.fn() };
-const mockFormField = { find: jest.fn() };
+const mockGetLeaveFieldIds = jest.fn();
 const mockAttendanceSetting = { findOne: jest.fn() };
 
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
 jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }));
-jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: mockFormTemplate }));
-jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }));
 jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({ default: mockAttendanceSetting }));
+jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+  getLeaveFieldIds: mockGetLeaveFieldIds,
+}));
 
 const { createSchedule, createSchedulesBatch, updateSchedule } = await import('../src/controllers/scheduleController.js');
 
@@ -24,11 +24,14 @@ describe('createSchedule validations', () => {
     mockShiftSchedule.findOne.mockReset();
     mockShiftSchedule.create.mockReset();
     mockApprovalRequest.findOne.mockReset();
-    mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
-    mockFormField.find.mockResolvedValue([
-      { _id: 's', label: '開始日期' },
-      { _id: 'e', label: '結束日期' },
-    ]);
+    mockGetLeaveFieldIds.mockReset();
+    mockGetLeaveFieldIds.mockResolvedValue({
+      formId: 'form1',
+      startId: 's',
+      endId: 'e',
+      typeId: 't',
+      typeOptions: [],
+    });
   });
 
   it('returns department overlap when existing schedule in other dept', async () => {
@@ -48,11 +51,14 @@ describe('createSchedulesBatch validations', () => {
     mockShiftSchedule.findOne.mockReset();
     mockShiftSchedule.insertMany.mockReset();
     mockApprovalRequest.findOne.mockReset();
-    mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
-    mockFormField.find.mockResolvedValue([
-      { _id: 's', label: '開始日期' },
-      { _id: 'e', label: '結束日期' },
-    ]);
+    mockGetLeaveFieldIds.mockReset();
+    mockGetLeaveFieldIds.mockResolvedValue({
+      formId: 'form1',
+      startId: 's',
+      endId: 'e',
+      typeId: 't',
+      typeOptions: [],
+    });
   });
 
   it('returns leave conflict when batch has approved leave', async () => {
@@ -73,11 +79,14 @@ describe('updateSchedule validations', () => {
     mockShiftSchedule.findOne.mockReset();
     mockShiftSchedule.findById.mockReset();
     mockApprovalRequest.findOne.mockReset();
-    mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
-    mockFormField.find.mockResolvedValue([
-      { _id: 's', label: '開始日期' },
-      { _id: 'e', label: '結束日期' },
-    ]);
+    mockGetLeaveFieldIds.mockReset();
+    mockGetLeaveFieldIds.mockResolvedValue({
+      formId: 'form1',
+      startId: 's',
+      endId: 'e',
+      typeId: 't',
+      typeOptions: [],
+    });
   });
 
   it('returns department overlap when updating to other dept with existing schedule', async () => {

--- a/server/tests/supervisorSchedule.test.js
+++ b/server/tests/supervisorSchedule.test.js
@@ -4,15 +4,15 @@ import { jest } from '@jest/globals';
 
 const mockShiftSchedule = { findOne: jest.fn(), create: jest.fn(), insertMany: jest.fn() };
 const mockApprovalRequest = { findOne: jest.fn() };
-const mockFormTemplate = { findOne: jest.fn() };
-const mockFormField = { find: jest.fn() };
+const mockGetLeaveFieldIds = jest.fn();
 const mockEmployee = { findById: jest.fn(), find: jest.fn() };
 
 jest.unstable_mockModule('../src/models/ShiftSchedule.js', () => ({ default: mockShiftSchedule }));
 jest.unstable_mockModule('../src/models/approval_request.js', () => ({ default: mockApprovalRequest }));
-jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: mockFormTemplate }));
-jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: mockFormField }));
 jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
+jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+  getLeaveFieldIds: mockGetLeaveFieldIds,
+}));
 
 let app;
 let scheduleRoutes;
@@ -36,11 +36,14 @@ beforeEach(() => {
   mockShiftSchedule.create.mockReset();
   mockShiftSchedule.insertMany.mockReset();
   mockApprovalRequest.findOne.mockReset();
-  mockFormTemplate.findOne.mockResolvedValue({ _id: 'form1' });
-  mockFormField.find.mockResolvedValue([
-    { _id: 's', label: '開始日期' },
-    { _id: 'e', label: '結束日期' },
-  ]);
+  mockGetLeaveFieldIds.mockReset();
+  mockGetLeaveFieldIds.mockResolvedValue({
+    formId: 'form1',
+    startId: 's',
+    endId: 'e',
+    typeId: 't',
+    typeOptions: [],
+  });
   mockEmployee.findById.mockReset();
   mockEmployee.find.mockReset();
 });


### PR DESCRIPTION
## Summary
- 新增請假欄位服務與共用報表匯出 helper，整合部門請假/出勤匯出
- 實作部門請假報表匯出 API，支援 Excel/PDF、人性化假別名稱
- 新增路由權限與 Jest 測試，涵蓋成功、無資料、越權情境

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4cb23f788329a7c09ae0b23e3b0e