### PR TITLE
新增部門報表前台頁面與測試

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -31,6 +31,7 @@ const Approval = () => import('@/views/front/Approval.vue')
 const PreviewWeek = () => import('@/views/front/PreviewWeek.vue')
 const PreviewMonth = () => import('@/views/front/PreviewMonth.vue')
 const MySchedule = () => import('@/views/front/MySchedule.vue')
+const DepartmentReports = () => import('@/views/front/DepartmentReports.vue')
 
 const routes = [
   // 首頁重導至前台登入
@@ -93,6 +94,12 @@ const routes = [
         path: 'schedule',
         name: 'Schedule',
         component: Schedule,
+        meta: { roles: ['supervisor', 'admin'] },
+      },
+      {
+        path: 'department-reports',
+        name: 'DepartmentReports',
+        component: DepartmentReports,
         meta: { roles: ['supervisor', 'admin'] },
       },
       {

--- a/client/src/views/front/DepartmentReports.vue
+++ b/client/src/views/front/DepartmentReports.vue
@@ -1,0 +1,493 @@
+<template>
+  <div class="department-reports-page">
+    <header class="page-header">
+      <h1 class="page-title">部門報表中心</h1>
+      <p class="page-subtitle">彙整各部門出勤、請假、薪資與保險統計</p>
+    </header>
+
+    <el-card class="filters-card" shadow="never">
+      <template #header>
+        <div class="card-header">
+          <h2>匯出條件</h2>
+          <span class="card-tip">請先選擇月份、部門與報表種類</span>
+        </div>
+      </template>
+      <div class="filters-grid">
+        <div class="filter-item">
+          <label class="filter-label">月份</label>
+          <el-date-picker
+            v-model="selectedMonth"
+            type="month"
+            placeholder="選擇月份"
+            format="YYYY 年 MM 月"
+            value-format="YYYY-MM"
+            :disabled="loading.departments"
+            class="w-full"
+          />
+        </div>
+        <div class="filter-item">
+          <label class="filter-label">部門</label>
+          <el-select
+            v-model="selectedDepartment"
+            placeholder="選擇部門"
+            filterable
+            :loading="loading.departments"
+            :disabled="loading.departments || departments.length === 0"
+            class="w-full"
+          >
+            <el-option
+              v-for="dept in departments"
+              :key="dept._id"
+              :label="dept.name"
+              :value="dept._id"
+            />
+          </el-select>
+        </div>
+        <div class="filter-item">
+          <label class="filter-label">報表種類</label>
+          <el-select v-model="reportType" placeholder="選擇報表" class="w-full">
+            <el-option
+              v-for="type in reportTypes"
+              :key="type.value"
+              :label="type.label"
+              :value="type.value"
+            />
+          </el-select>
+        </div>
+        <div class="filter-item">
+          <label class="filter-label">匯出格式</label>
+          <el-select v-model="exportFormat" placeholder="選擇格式" class="w-full">
+            <el-option
+              v-for="format in exportFormats"
+              :key="format.value"
+              :label="format.label"
+              :value="format.value"
+            />
+          </el-select>
+        </div>
+      </div>
+      <div class="actions">
+        <el-button
+          :disabled="!canPreview || preview.loading"
+          :loading="preview.loading"
+          @click="handlePreview"
+        >
+          預覽摘要
+        </el-button>
+        <el-button
+          type="primary"
+          :disabled="!canExport || exporting"
+          :loading="exporting"
+          @click="exportReport"
+        >
+          匯出報表
+        </el-button>
+      </div>
+    </el-card>
+
+    <el-alert
+      v-if="preview.state === 'empty'"
+      type="info"
+      show-icon
+      class="mt-4"
+      title="目前條件下沒有可供預覽的資料"
+    />
+
+    <el-card v-if="preview.state === 'success'" class="preview-card" shadow="never">
+      <template #header>
+        <div class="card-header">
+          <h2>報表摘要</h2>
+          <span class="card-tip">以下內容來自後端 JSON 預覽</span>
+        </div>
+      </template>
+      <div v-if="preview.summary" class="summary-grid">
+        <div class="summary-item" v-for="item in summaryItems" :key="item.label">
+          <span class="summary-label">{{ item.label }}</span>
+          <span class="summary-value">{{ item.value }}</span>
+        </div>
+      </div>
+      <el-table
+        v-if="preview.records.length"
+        :data="preview.records"
+        border
+        class="preview-table"
+      >
+        <el-table-column prop="name" label="員工" min-width="140" />
+        <el-table-column
+          v-for="column in dynamicColumns"
+          :key="column.prop"
+          :prop="column.prop"
+          :label="column.label"
+          :min-width="column.minWidth || 120"
+        />
+      </el-table>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted } from 'vue'
+import dayjs from 'dayjs'
+import { ElMessage } from 'element-plus'
+import { apiFetch } from '../../api'
+
+const departments = ref([])
+const reportTypes = [
+  { value: 'attendance', label: '出勤統計' },
+  { value: 'leave', label: '請假統計' },
+  { value: 'salary', label: '薪資試算' },
+  { value: 'insurance', label: '保險申報' },
+]
+const exportFormats = [
+  { value: 'excel', label: 'Excel (.xlsx)' },
+  { value: 'pdf', label: 'PDF (.pdf)' },
+]
+
+const selectedMonth = ref(dayjs().format('YYYY-MM'))
+const selectedDepartment = ref('')
+const reportType = ref('attendance')
+const exportFormat = ref('excel')
+const exporting = ref(false)
+
+const preview = reactive({
+  loading: false,
+  state: 'idle',
+  summary: null,
+  records: [],
+})
+
+const loading = reactive({
+  departments: false,
+})
+
+const reportEndpointMap = {
+  attendance: '/api/reports/department/attendance/export',
+  leave: '/api/reports/department/leave/export',
+  salary: '/api/reports/department/salary/export',
+  insurance: '/api/reports/department/insurance/export',
+}
+
+const formatExtensionMap = {
+  excel: 'xlsx',
+  pdf: 'pdf',
+}
+
+const canExport = computed(
+  () => Boolean(selectedMonth.value && selectedDepartment.value && reportEndpointMap[reportType.value])
+)
+
+const canPreview = computed(() => canExport.value)
+
+const dynamicColumns = computed(() => {
+  if (reportType.value === 'attendance') {
+    return [
+      { prop: 'scheduled', label: '排班天數', minWidth: 120 },
+      { prop: 'attended', label: '出勤天數', minWidth: 120 },
+      { prop: 'absent', label: '缺勤天數', minWidth: 120 },
+    ]
+  }
+  if (reportType.value === 'leave') {
+    return [
+      { prop: 'leaveType', label: '假別', minWidth: 160 },
+      { prop: 'startDate', label: '開始日期', minWidth: 140 },
+      { prop: 'endDate', label: '結束日期', minWidth: 140 },
+      { prop: 'days', label: '天數', minWidth: 100 },
+    ]
+  }
+  if (reportType.value === 'salary') {
+    return [
+      { prop: 'baseSalary', label: '基本薪資', minWidth: 140 },
+      { prop: 'allowance', label: '津貼', minWidth: 120 },
+      { prop: 'deduction', label: '扣款', minWidth: 120 },
+      { prop: 'payable', label: '應發金額', minWidth: 140 },
+    ]
+  }
+  if (reportType.value === 'insurance') {
+    return [
+      { prop: 'insuranceType', label: '保險別', minWidth: 140 },
+      { prop: 'employeeShare', label: '員工自付', minWidth: 140 },
+      { prop: 'employerShare', label: '公司負擔', minWidth: 140 },
+      { prop: 'total', label: '總計', minWidth: 120 },
+    ]
+  }
+  return []
+})
+
+const summaryItems = computed(() => {
+  if (!preview.summary) return []
+  if (reportType.value === 'attendance') {
+    return [
+      { label: '排班總計', value: preview.summary.scheduled },
+      { label: '出勤總計', value: preview.summary.attended },
+      { label: '缺勤總計', value: preview.summary.absent },
+    ]
+  }
+  if (reportType.value === 'leave') {
+    const base = [
+      { label: '總請假件數', value: preview.summary.totalLeaves },
+      { label: '總請假天數', value: preview.summary.totalDays },
+    ]
+    const byType = Array.isArray(preview.summary.byType)
+      ? preview.summary.byType.map((item) => ({
+          label: `${item.leaveType || item.leaveCode} 件數`,
+          value: `${item.count ?? 0} 筆 / ${item.days ?? 0} 天`,
+        }))
+      : []
+    return [...base, ...byType]
+  }
+  if (reportType.value === 'salary') {
+    return [
+      { label: '總人數', value: preview.summary.totalEmployees ?? preview.records.length },
+      { label: '應發總額', value: preview.summary.totalPayable ?? preview.summary.total ?? 0 },
+      { label: '實發總額', value: preview.summary.totalActual ?? preview.summary.actual ?? 0 },
+    ]
+  }
+  if (reportType.value === 'insurance') {
+    return [
+      { label: '投保人數', value: preview.summary.totalEmployees ?? preview.records.length },
+      { label: '員工自付總額', value: preview.summary.employeeShare ?? 0 },
+      { label: '公司負擔總額', value: preview.summary.employerShare ?? 0 },
+    ]
+  }
+  return []
+})
+
+onMounted(async () => {
+  loading.departments = true
+  try {
+    const res = await apiFetch('/api/departments')
+    if (!res.ok) {
+      throw new Error('無法取得部門清單')
+    }
+    const data = await res.json()
+    departments.value = Array.isArray(data) ? data : []
+    if (!selectedDepartment.value && departments.value.length) {
+      selectedDepartment.value = departments.value[0]._id
+    }
+  } catch (err) {
+    ElMessage.error(err.message || '取得部門資料失敗')
+  } finally {
+    loading.departments = false
+  }
+})
+
+function buildQuery(params) {
+  const usp = new URLSearchParams(params)
+  return `?${usp.toString()}`
+}
+
+async function handlePreview() {
+  if (!canPreview.value) return
+  const endpoint = reportEndpointMap[reportType.value]
+  if (!endpoint) {
+    ElMessage.warning('此報表尚未開放預覽')
+    return
+  }
+  preview.loading = true
+  preview.state = 'loading'
+  try {
+    const query = buildQuery({
+      month: selectedMonth.value,
+      department: selectedDepartment.value,
+      format: 'json',
+    })
+    const res = await apiFetch(`${endpoint}${query}`, {
+      headers: { Accept: 'application/json' },
+    })
+    const contentType = res.headers?.get?.('content-type') || ''
+    if (!res.ok) {
+      const errorData = contentType.includes('application/json') ? await res.json() : null
+      throw new Error(errorData?.error || errorData?.message || '預覽失敗')
+    }
+    if (!contentType.includes('application/json')) {
+      preview.state = 'idle'
+      preview.summary = null
+      preview.records = []
+      ElMessage.info('此報表不提供預覽，請直接匯出')
+      return
+    }
+    const data = await res.json()
+    preview.summary = data?.summary ?? null
+    preview.records = Array.isArray(data?.records) ? data.records : []
+    if (!preview.records.length && !preview.summary) {
+      preview.state = 'empty'
+    } else {
+      preview.state = 'success'
+    }
+  } catch (err) {
+    preview.state = 'idle'
+    preview.summary = null
+    preview.records = []
+    ElMessage.error(err.message || '預覽失敗')
+  } finally {
+    preview.loading = false
+  }
+}
+
+async function exportReport() {
+  if (!canExport.value || exporting.value) return
+  const endpoint = reportEndpointMap[reportType.value]
+  if (!endpoint) {
+    ElMessage.error('尚未提供此報表的匯出服務')
+    return
+  }
+  exporting.value = true
+  try {
+    const query = buildQuery({
+      month: selectedMonth.value,
+      department: selectedDepartment.value,
+      format: exportFormat.value,
+    })
+    const res = await apiFetch(`${endpoint}${query}`, {
+      headers: { Accept: 'application/octet-stream' },
+    })
+    const contentType = res.headers?.get?.('content-type') || ''
+    if (!res.ok) {
+      const errorData = contentType.includes('application/json') ? await res.json() : null
+      throw new Error(errorData?.error || errorData?.message || '匯出失敗')
+    }
+    const blob = await res.blob()
+    const extension = formatExtensionMap[exportFormat.value] || 'dat'
+    const monthText = selectedMonth.value?.replace('-', '') || dayjs().format('YYYYMM')
+    const deptName =
+      departments.value.find((dept) => dept._id === selectedDepartment.value)?.name || 'department'
+    const typeKey = reportTypes.find((type) => type.value === reportType.value)?.value || 'report'
+    const sanitize = (text) =>
+      String(text)
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/[^\w\u4e00-\u9fa5-]+/gi, '')
+    const fileName = `${monthText}-${sanitize(deptName)}-${sanitize(typeKey)}.${extension}`
+
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+    ElMessage.success('匯出成功')
+  } catch (err) {
+    ElMessage.error(err.message || '匯出失敗')
+  } finally {
+    exporting.value = false
+  }
+}
+
+</script>
+
+<style scoped>
+.department-reports-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: #f8fafc;
+  min-height: 100vh;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.page-subtitle {
+  margin: 0;
+  font-size: 16px;
+  color: #475569;
+}
+
+.filters-card {
+  border-radius: 12px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #0f172a;
+}
+
+.card-tip {
+  font-size: 14px;
+  color: #64748b;
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.filter-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-label {
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.preview-card {
+  border-radius: 12px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.summary-item {
+  background: #f1f5f9;
+  border-radius: 10px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-label {
+  font-size: 14px;
+  color: #475569;
+}
+
+.summary-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.preview-table {
+  width: 100%;
+}
+</style>

--- a/client/tests/departmentReports.spec.js
+++ b/client/tests/departmentReports.spec.js
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import DepartmentReports from '../src/views/front/DepartmentReports.vue'
+import { apiFetch } from '../src/api'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+    },
+  }
+})
+
+
+function createWrapper() {
+  return mount(DepartmentReports, {
+    global: {
+      stubs: {
+        'el-card': { template: '<div><slot name="header" /><slot /></div>' },
+        'el-date-picker': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="month" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        'el-select': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+        },
+        'el-option': {
+          props: ['label', 'value'],
+          template: '<option :value="value">{{ label }}</option>',
+        },
+        'el-button': {
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        'el-alert': { template: '<div><slot /></div>' },
+        'el-table': { props: ['data'], template: '<table><slot /></table>' },
+        'el-table-column': { template: '<td></td>' },
+      },
+    },
+  })
+}
+
+describe('DepartmentReports.vue', () => {
+  let originalCreateObjectURL
+  let originalRevokeObjectURL
+  let createObjectURLSpy
+  let revokeObjectURLSpy
+  let createElementSpy
+  let realCreateElement
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    apiFetch.mockReset()
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ _id: 'dept1', name: '研發部' }],
+    })
+
+    originalCreateObjectURL = window.URL.createObjectURL
+    if (!originalCreateObjectURL) {
+      window.URL.createObjectURL = () => ''
+    }
+    createObjectURLSpy = vi
+      .spyOn(window.URL, 'createObjectURL')
+      .mockReturnValue('blob:mock')
+
+    originalRevokeObjectURL = window.URL.revokeObjectURL
+    if (!originalRevokeObjectURL) {
+      window.URL.revokeObjectURL = () => {}
+    }
+    revokeObjectURLSpy = vi
+      .spyOn(window.URL, 'revokeObjectURL')
+      .mockImplementation(() => {})
+
+    realCreateElement = document.createElement.bind(document)
+    createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const element = realCreateElement(tag)
+      if (tag === 'a') {
+        element.click = vi.fn()
+      }
+      return element
+    })
+  })
+
+  afterEach(() => {
+    createObjectURLSpy?.mockRestore()
+    revokeObjectURLSpy?.mockRestore()
+    createElementSpy?.mockRestore()
+    if (!originalCreateObjectURL) {
+      delete window.URL.createObjectURL
+    } else {
+      window.URL.createObjectURL = originalCreateObjectURL
+    }
+    if (!originalRevokeObjectURL) {
+      delete window.URL.revokeObjectURL
+    } else {
+      window.URL.revokeObjectURL = originalRevokeObjectURL
+    }
+  })
+
+  it('匯出成功時下載檔案', async () => {
+    const { ElMessage } = await import('element-plus')
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/octet-stream' },
+      blob: async () => new Blob(['excel']),
+    })
+
+    wrapper.vm.selectedMonth = '2024-05'
+    wrapper.vm.selectedDepartment = 'dept1'
+    wrapper.vm.reportType = 'attendance'
+    wrapper.vm.exportFormat = 'excel'
+
+    await wrapper.vm.exportReport()
+
+    expect(apiFetch).toHaveBeenLastCalledWith(
+      '/api/reports/department/attendance/export?month=2024-05&department=dept1&format=excel',
+      expect.objectContaining({ headers: { Accept: 'application/octet-stream' } })
+    )
+    expect(window.URL.createObjectURL).toHaveBeenCalled()
+    expect(ElMessage.success).toHaveBeenCalledWith('匯出成功')
+  })
+
+  it('顯示 JSON 預覽摘要', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: async () => ({
+        summary: { scheduled: 10, attended: 9, absent: 1 },
+        records: [
+          { name: '王小明', scheduled: 5, attended: 4, absent: 1 },
+          { name: '李小華', scheduled: 5, attended: 5, absent: 0 },
+        ],
+      }),
+    })
+
+    wrapper.vm.selectedMonth = '2024-05'
+    wrapper.vm.selectedDepartment = 'dept1'
+
+    await wrapper.vm.handlePreview()
+
+    expect(apiFetch).toHaveBeenLastCalledWith(
+      '/api/reports/department/attendance/export?month=2024-05&department=dept1&format=json',
+      expect.objectContaining({ headers: { Accept: 'application/json' } })
+    )
+    expect(wrapper.vm.preview.state).toBe('success')
+    expect(wrapper.vm.preview.records.length).toBe(2)
+    expect(wrapper.vm.summaryItems.length).toBeGreaterThan(0)
+  })
+
+  it('預覽失敗時顯示錯誤訊息', async () => {
+    const { ElMessage } = await import('element-plus')
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    apiFetch.mockResolvedValueOnce({
+      ok: false,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ error: 'Forbidden' }),
+    })
+
+    wrapper.vm.selectedMonth = '2024-05'
+    wrapper.vm.selectedDepartment = 'dept1'
+
+    await wrapper.vm.handlePreview()
+
+    expect(ElMessage.error).toHaveBeenCalledWith('Forbidden')
+    expect(wrapper.vm.preview.state).toBe('idle')
+  })
+})

--- a/client/tests/router.spec.js
+++ b/client/tests/router.spec.js
@@ -53,7 +53,15 @@ describe('router', () => {
     expect(childRoles.find(c => c.name === 'Attendance').roles).toEqual(['employee', 'supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'MySchedule').roles).toEqual(['employee', 'supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Schedule').roles).toEqual(['supervisor', 'admin'])
+    expect(childRoles.find(c => c.name === 'DepartmentReports').roles).toEqual(['supervisor', 'admin'])
     expect(childRoles.find(c => c.name === 'Approval').roles).toEqual(['employee', 'supervisor', 'admin'])
+  })
+
+  it('forwards employees to forbidden when opening department reports', () => {
+    sessionStorage.setItem('role', 'employee')
+    const next = vi.fn()
+    capturedGuard({ matched: [], meta: { roles: ['supervisor', 'admin'], name: 'DepartmentReports' } }, {}, next)
+    expect(next).toHaveBeenCalledWith({ name: 'Forbidden' })
   })
 
   it('role guard blocks unauthorized user', () => {

--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -9,6 +9,7 @@ export function getMenu(req, res) {
     supervisor: [
       { name: 'Attendance', label: '出勤打卡', icon: 'el-icon-postcard' },
       { name: 'Schedule', label: '排班管理', icon: 'el-icon-timer' },
+      { name: 'DepartmentReports', label: '部門報表', icon: 'el-icon-data-analysis' },
       { name: 'Approval', label: '簽核流程', icon: 'el-icon-s-operation' }
     ],
     hr: [


### PR DESCRIPTION
## Summary
- 新增前台 DepartmentReports 頁面，提供月份、部門、報表種類選擇並串接匯出與 JSON 預覽流程
- 調整前台路由與選單，加入部門報表項目並限制 supervisor/admin 權限
- 補充 router 與部門報表互動測試，驗證授權導向與匯出行為

## Testing
- npm test -- --run tests/departmentReports.spec.js tests/router.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cc54253aec832987ceed30ee837496