### PR TITLE
feat: 動態建立多層級種子資料

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -18,7 +18,10 @@ if (!process.env.MONGODB_URI) {
 
 async function seed() {
   await connectDB(process.env.MONGODB_URI);
-  await seedSampleData();
+  const structure = await seedSampleData();
+  if (structure?.organizations?.length) {
+    console.log(`Seeded organizations: ${structure.organizations.map((org) => org.name).join(', ')}`);
+  }
   await seedTestUsers();
   await seedApprovalTemplates();
   await mongoose.disconnect();

--- a/server/src/seedUtils.js
+++ b/server/src/seedUtils.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import Employee from './models/Employee.js';
 import Organization from './models/Organization.js';
 import Department from './models/Department.js';
@@ -6,55 +8,111 @@ import FormTemplate from './models/form_template.js';
 import FormField from './models/form_field.js';
 import ApprovalWorkflow from './models/approval_workflow.js';
 
+const CITY_OPTIONS = ['台北市', '新北市', '桃園市', '台中市', '台南市', '高雄市'];
+const PRINCIPAL_NAMES = ['林經理', '張主管', '王負責人', '李主任', '陳董事'];
+const PHONE_PREFIXES = ['02', '03', '04', '05', '06', '07'];
+
+function randomElement(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function randomDigits(length) {
+  let digits = '';
+  while (digits.length < length) {
+    digits += Math.floor(Math.random() * 10).toString();
+  }
+  return digits.slice(0, length);
+}
+
+function randomPhone() {
+  const prefix = randomElement(PHONE_PREFIXES);
+  return `${prefix}-${randomDigits(8)}`;
+}
+
+function generateUniqueValue(prefix, usedSet) {
+  let value;
+  do {
+    value = `${prefix}-${randomUUID().split('-')[0].toUpperCase()}`;
+  } while (usedSet.has(value));
+  usedSet.add(value);
+  return value;
+}
+
 export async function seedSampleData() {
-  let org = await Organization.findOne({ name: '示範機構' });
-  if (!org) {
-    org = await Organization.create({
-      name: '示範機構',
-      systemCode: 'ORG001',
-      unitName: '總院',
-      orgCode: '001',
-      taxIdNumber: '12345678',
-      phone: '02-12345678',
-      address: '台北市信義路1號',
-      principal: '示範負責人'
+  await Promise.all([
+    Organization.deleteMany({}),
+    Department.deleteMany({}),
+    SubDepartment.deleteMany({}),
+  ]);
+
+  const organizations = [];
+  const departments = [];
+  const subDepartments = [];
+
+  const usedOrgNames = new Set();
+  const usedOrgUnitNames = new Set();
+  const usedOrgCodes = new Set();
+  const usedSystemCodes = new Set();
+  const usedDeptNames = new Set();
+  const usedDeptUnitNames = new Set();
+  const usedDeptCodes = new Set();
+  const usedSubDeptNames = new Set();
+  const usedSubDeptUnitNames = new Set();
+  const usedSubDeptCodes = new Set();
+
+  for (let i = 0; i < 2; i += 1) {
+    const organization = await Organization.create({
+      name: generateUniqueValue('機構', usedOrgNames),
+      systemCode: generateUniqueValue('SYS', usedSystemCodes),
+      unitName: generateUniqueValue('單位', usedOrgUnitNames),
+      orgCode: generateUniqueValue('ORG', usedOrgCodes),
+      taxIdNumber: randomDigits(8),
+      phone: randomPhone(),
+      address: `${randomElement(CITY_OPTIONS)}${randomDigits(3)}號`,
+      principal: randomElement(PRINCIPAL_NAMES),
     });
-    console.log('Created sample organization');
+    organizations.push(organization);
+
+    for (let j = 0; j < 2; j += 1) {
+      const department = await Department.create({
+        name: generateUniqueValue('部門', usedDeptNames),
+        code: generateUniqueValue('DEPT', usedDeptCodes),
+        organization: organization._id,
+        unitName: generateUniqueValue('部門單位', usedDeptUnitNames),
+        location: randomElement(CITY_OPTIONS),
+        phone: randomPhone(),
+        manager: `主管-${randomDigits(3)}`,
+      });
+      departments.push(department);
+
+      for (let k = 0; k < 3; k += 1) {
+        const subDept = await SubDepartment.create({
+          department: department._id,
+          code: generateUniqueValue('SUB', usedSubDeptCodes),
+          name: generateUniqueValue('小組', usedSubDeptNames),
+          unitName: generateUniqueValue('小組單位', usedSubDeptUnitNames),
+          location: randomElement(CITY_OPTIONS),
+          phone: randomPhone(),
+          manager: `組長-${randomDigits(3)}`,
+        });
+        subDepartments.push(subDept);
+      }
+    }
   }
 
-  let dept = await Department.findOne({ code: 'HR' });
-  if (!dept) {
-    dept = await Department.create({
-      name: '人力資源部',
-      code: 'HR',
-      organization: org._id,
-      unitName: '人力資源',
-      location: '台北',
-      phone: '02-23456789',
-      manager: 'supervisor'
-    });
-    console.log('Created sample department');
-  }
+  console.log(
+    `Created ${organizations.length} organizations, ` +
+      `${departments.length} departments, ` +
+      `${subDepartments.length} sub-departments`,
+  );
 
-  const subDeptExists = await SubDepartment.findOne({ code: 'HR1' });
-  if (!subDeptExists) {
-    await SubDepartment.create({
-      department: dept._id,
-      code: 'HR1',
-      name: '招聘組',
-      unitName: '招聘組',
-      location: '台北',
-      phone: '02-23456789',
-      manager: 'supervisor'
-    });
-    console.log('Created sample sub-department');
-  }
+  return { organizations, departments, subDepartments };
 }
 
 export async function seedTestUsers() {
-  const org = await Organization.findOne({ name: '示範機構' });
-  const dept = await Department.findOne({ code: 'HR' });
-  const subDept = await SubDepartment.findOne({ code: 'HR1' });
+  const org = await Organization.findOne({});
+  const dept = org ? await Department.findOne({ organization: org._id }) : null;
+  const subDept = dept ? await SubDepartment.findOne({ department: dept._id }) : null;
 
   if (!org) throw new Error('Organization not found');
   if (!dept) throw new Error('Department not found');

--- a/server/tests/seedData.test.js
+++ b/server/tests/seedData.test.js
@@ -1,20 +1,73 @@
 import { jest } from '@jest/globals';
 
-const mockOrg = { findOne: jest.fn(), create: jest.fn() };
-const mockDept = { findOne: jest.fn(), create: jest.fn() };
-const mockSubDept = { findOne: jest.fn(), create: jest.fn() };
-
+const mockOrganizations = [];
+const mockDepartments = [];
+const mockSubDepartments = [];
 const mockEmployees = [];
+
+const matchDocument = (doc, filter) =>
+  Object.entries(filter).every(([key, value]) => doc[key] === value);
+
+const buildFindOne = (collection) =>
+  async (filter = {}) => {
+    if (!filter || Object.keys(filter).length === 0) {
+      return collection[0] ?? null;
+    }
+    return collection.find((doc) => matchDocument(doc, filter)) ?? null;
+  };
+
+const orgFindOneDefault = buildFindOne(mockOrganizations);
+const deptFindOneDefault = buildFindOne(mockDepartments);
+const subDeptFindOneDefault = buildFindOne(mockSubDepartments);
+
+const mockOrg = {
+  deleteMany: jest.fn(async () => {
+    mockOrganizations.length = 0;
+  }),
+  create: jest.fn(async (data) => {
+    const document = { _id: `org-${mockOrganizations.length + 1}`, ...data };
+    mockOrganizations.push(document);
+    return document;
+  }),
+  findOne: jest.fn(orgFindOneDefault),
+};
+
+const mockDept = {
+  deleteMany: jest.fn(async () => {
+    mockDepartments.length = 0;
+  }),
+  create: jest.fn(async (data) => {
+    const document = { _id: `dept-${mockDepartments.length + 1}`, ...data };
+    mockDepartments.push(document);
+    return document;
+  }),
+  findOne: jest.fn(deptFindOneDefault),
+};
+
+const mockSubDept = {
+  deleteMany: jest.fn(async () => {
+    mockSubDepartments.length = 0;
+  }),
+  create: jest.fn(async (data) => {
+    const document = { _id: `sub-${mockSubDepartments.length + 1}`, ...data };
+    mockSubDepartments.push(document);
+    return document;
+  }),
+  findOne: jest.fn(subDeptFindOneDefault),
+};
+
 const mockEmployee = {
   findOne: jest.fn(async ({ username }) => mockEmployees.find((e) => e.username === username) || null),
   create: jest.fn(async (data) => {
-    const emp = { _id: data.username, ...data };
-    mockEmployees.push(emp);
-    return emp;
+    const employee = { _id: data.username, ...data };
+    mockEmployees.push(employee);
+    return employee;
   }),
   updateMany: jest.fn(async (filter, update) => {
-    mockEmployees.forEach((e) => {
-      if (e.role === filter.role) e.supervisor = update.supervisor;
+    mockEmployees.forEach((employee) => {
+      if (employee.role === filter.role) {
+        employee.supervisor = update.supervisor;
+      }
     });
   }),
 };
@@ -27,66 +80,85 @@ beforeAll(async () => {
   process.env.MONGODB_URI = 'mongodb://localhost/test';
   process.env.JWT_SECRET = 'secret';
   process.env.NODE_ENV = 'test';
+
   await jest.unstable_mockModule('../src/models/Organization.js', () => ({ default: mockOrg }));
   await jest.unstable_mockModule('../src/models/Department.js', () => ({ default: mockDept }));
   await jest.unstable_mockModule('../src/models/SubDepartment.js', () => ({ default: mockSubDept }));
   await jest.unstable_mockModule('../src/models/Employee.js', () => ({ default: mockEmployee }));
-  const mod = await import('../src/seedUtils.js');
-  seedSampleData = mod.seedSampleData;
-  seedTestUsers = mod.seedTestUsers;
+
+  const module = await import('../src/seedUtils.js');
+  seedSampleData = module.seedSampleData;
+  seedTestUsers = module.seedTestUsers;
 });
 
 beforeEach(() => {
-  Object.values(mockOrg).forEach((fn) => fn.mockReset && fn.mockReset());
-  Object.values(mockDept).forEach((fn) => fn.mockReset && fn.mockReset());
-  Object.values(mockSubDept).forEach((fn) => fn.mockReset && fn.mockReset());
-  Object.values(mockEmployee).forEach((fn) => fn.mockClear());
+  mockOrganizations.length = 0;
+  mockDepartments.length = 0;
+  mockSubDepartments.length = 0;
   mockEmployees.length = 0;
+
+  jest.clearAllMocks();
+
+  mockOrg.findOne.mockImplementation(orgFindOneDefault);
+  mockDept.findOne.mockImplementation(deptFindOneDefault);
+  mockSubDept.findOne.mockImplementation(subDeptFindOneDefault);
 });
 
+const countBy = (list, key) =>
+  list.reduce((acc, item) => {
+    const value = item[key];
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+
 describe('seedSampleData', () => {
-  it('creates organization, department and sub-department when missing', async () => {
-    mockOrg.findOne.mockResolvedValue(null);
-    mockDept.findOne.mockResolvedValue(null);
-    mockSubDept.findOne.mockResolvedValue(null);
-    mockOrg.create.mockResolvedValue({ _id: 'org1' });
-    mockDept.create.mockResolvedValue({ _id: 'dept1' });
-    mockSubDept.create.mockResolvedValue({ _id: 'sub1' });
-    await seedSampleData();
-    expect(mockOrg.create).toHaveBeenCalledWith(expect.objectContaining({ name: '示範機構' }));
-    expect(mockDept.create).toHaveBeenCalledWith(expect.objectContaining({ code: 'HR' }));
-    expect(mockSubDept.create).toHaveBeenCalledWith(expect.objectContaining({ code: 'HR1' }));
+  it('建立多層機構資料並維持唯一代碼', async () => {
+    const result = await seedSampleData();
+
+    expect(mockOrg.deleteMany).toHaveBeenCalledWith({});
+    expect(mockDept.deleteMany).toHaveBeenCalledWith({});
+    expect(mockSubDept.deleteMany).toHaveBeenCalledWith({});
+
+    expect(result.organizations).toHaveLength(2);
+    expect(result.departments).toHaveLength(4);
+    expect(result.subDepartments).toHaveLength(12);
+
+    expect(new Set(result.organizations.map((org) => org.systemCode)).size).toBe(2);
+    expect(new Set(result.departments.map((dept) => dept.code)).size).toBe(4);
+    expect(new Set(result.subDepartments.map((sub) => sub.code)).size).toBe(12);
+
+    const deptCounts = countBy(result.departments, 'organization');
+    expect(Object.values(deptCounts).sort()).toEqual([2, 2]);
+
+    const subDeptCounts = countBy(result.subDepartments, 'department');
+    Object.values(subDeptCounts).forEach((count) => expect(count).toBe(3));
   });
 });
 
 describe('seedTestUsers', () => {
-  it('creates test users and assigns supervisor', async () => {
-    const orgId = { toString: () => 'org1' };
-    mockOrg.findOne.mockResolvedValue({ _id: orgId });
-    mockDept.findOne.mockResolvedValue({ _id: 'dept1' });
-    mockSubDept.findOne.mockResolvedValue({ _id: 'sub1' });
+  it('使用最新的組織層級建立測試帳號', async () => {
+    const { organizations, departments, subDepartments } = await seedSampleData();
+
+    mockOrg.findOne.mockResolvedValue(organizations[0]);
+    mockDept.findOne.mockImplementation(async ({ organization }) =>
+      departments.find((dept) => dept.organization === organization) ?? null,
+    );
+    mockSubDept.findOne.mockImplementation(async ({ department }) =>
+      subDepartments.find((sub) => sub.department === department) ?? null,
+    );
+
     await seedTestUsers();
-    expect(mockOrg.findOne).toHaveBeenCalledWith({ name: '示範機構' });
-    expect(mockDept.findOne).toHaveBeenCalledWith({ code: 'HR' });
-    expect(mockSubDept.findOne).toHaveBeenCalledWith({ code: 'HR1' });
+
     expect(mockEmployee.create).toHaveBeenCalledTimes(8);
-    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({
-      username: 'scheduler',
-      signTags: ['排班負責人'],
-      organization: 'org1',
-      department: 'dept1',
-      subDepartment: 'sub1'
-    }));
-    expect(mockEmployee.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'hr', signTags: ['人資'] }));
+    const createdUser = mockEmployee.create.mock.calls[0][0];
+    expect(createdUser.organization).toBe(organizations[0]._id.toString());
+    expect(createdUser.department).toBe(departments[0]._id);
+    expect(createdUser.subDepartment).toBe(subDepartments[0]._id);
     expect(mockEmployee.updateMany).toHaveBeenCalledWith({ role: 'employee' }, { supervisor: 'supervisor' });
-    const user = mockEmployees.find((e) => e.username === 'user');
-    expect(user.supervisor).toBe('supervisor');
   });
 
-  it('throws when required data is missing', async () => {
+  it('缺少層級資料時拋出錯誤', async () => {
     mockOrg.findOne.mockResolvedValue(null);
-    mockDept.findOne.mockResolvedValue({ _id: 'dept1' });
-    mockSubDept.findOne.mockResolvedValue({ _id: 'sub1' });
     await expect(seedTestUsers()).rejects.toThrow('Organization not found');
     expect(mockEmployee.create).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- 清空組織、部門與小組集合並使用亂數建立多層級的樣本資料
- 更新測試帳號種子流程以連結最新的組織階層
- 擴充種子腳本與測試以驗證多機構結構與資料唯一性

## Testing
- npm test -- seedData.test.js
- npm test -- seedScript.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd9788632483299d2ffa088dce4157