### PR TITLE
擴充種子資料建立簽核申請範例

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -9,7 +9,7 @@ const __dirname = path.dirname(__filename);
 
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
-const { seedSampleData, seedTestUsers, seedApprovalTemplates } = await import('../src/seedUtils.js');
+const { seedSampleData, seedTestUsers, seedApprovalTemplates, seedApprovalRequests } = await import('../src/seedUtils.js');
 
 if (!process.env.MONGODB_URI) {
   console.error('MONGODB_URI is not defined in the environment');
@@ -22,8 +22,9 @@ async function seed() {
   if (structure?.organizations?.length) {
     console.log(`Seeded organizations: ${structure.organizations.map((org) => org.name).join(', ')}`);
   }
-  await seedTestUsers();
+  const { supervisors, employees } = await seedTestUsers();
   await seedApprovalTemplates();
+  await seedApprovalRequests({ supervisors, employees });
   await mongoose.disconnect();
 }
 

--- a/server/tests/seedApprovalRequests.test.js
+++ b/server/tests/seedApprovalRequests.test.js
@@ -1,0 +1,198 @@
+import { jest } from '@jest/globals';
+
+const mockFormFindOne = jest.fn();
+const mockFieldFind = jest.fn();
+const mockWorkflowFindOne = jest.fn();
+const mockApprovalDeleteMany = jest.fn();
+const mockApprovalInsertMany = jest.fn();
+const mockEmployeeUpdateOne = jest.fn();
+const mockGetLeaveFieldIds = jest.fn();
+
+let seedApprovalRequests;
+
+const formDocs = {
+  請假: { _id: 'form-leave', name: '請假' },
+  支援申請: { _id: 'form-support', name: '支援申請' },
+  特休保留: { _id: 'form-retain', name: '特休保留' },
+  在職證明: { _id: 'form-employ', name: '在職證明' },
+  離職證明: { _id: 'form-resign', name: '離職證明' },
+};
+
+const fieldDocs = {
+  'form-leave': [
+    { _id: 'leave-type', label: '假別', options: [{ value: '特休' }, { value: '事假' }] },
+    { _id: 'leave-start', label: '開始日期' },
+    { _id: 'leave-end', label: '結束日期' },
+    { _id: 'leave-reason', label: '事由' },
+  ],
+  'form-support': [
+    { _id: 'support-reason', label: '申請事由' },
+    { _id: 'support-start', label: '開始日期' },
+    { _id: 'support-end', label: '結束日期' },
+    { _id: 'support-file', label: '附件' },
+  ],
+  'form-retain': [
+    { _id: 'retain-year', label: '年度' },
+    { _id: 'retain-days', label: '保留天數' },
+    { _id: 'retain-reason', label: '理由' },
+  ],
+  'form-employ': [
+    { _id: 'employ-purpose', label: '用途' },
+    { _id: 'employ-date', label: '開立日期' },
+  ],
+  'form-resign': [
+    { _id: 'resign-purpose', label: '用途' },
+    { _id: 'resign-date', label: '離職日期' },
+  ],
+};
+
+const workflowDocs = {
+  'form-leave': {
+    _id: 'wf-leave',
+    steps: [
+      { step_order: 1, approver_type: 'manager' },
+      { step_order: 2, approver_type: 'tag', approver_value: '人資' },
+    ],
+  },
+  'form-support': {
+    _id: 'wf-support',
+    steps: [
+      { step_order: 1, approver_type: 'manager' },
+      { step_order: 2, approver_type: 'tag', approver_value: '支援單位主管' },
+      { step_order: 3, approver_type: 'tag', approver_value: '人資' },
+    ],
+  },
+  'form-retain': {
+    _id: 'wf-retain',
+    steps: [
+      { step_order: 1, approver_type: 'manager' },
+      { step_order: 2, approver_type: 'tag', approver_value: '人資' },
+    ],
+  },
+  'form-employ': {
+    _id: 'wf-employ',
+    steps: [{ step_order: 1, approver_type: 'tag', approver_value: '人資' }],
+  },
+  'form-resign': {
+    _id: 'wf-resign',
+    steps: [
+      { step_order: 1, approver_type: 'manager' },
+      { step_order: 2, approver_type: 'tag', approver_value: '人資' },
+    ],
+  },
+};
+
+beforeAll(async () => {
+  process.env.PORT = '3000';
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  process.env.JWT_SECRET = 'secret';
+  process.env.NODE_ENV = 'test';
+
+  await jest.unstable_mockModule('../src/models/form_template.js', () => ({
+    default: { findOne: mockFormFindOne },
+  }));
+  await jest.unstable_mockModule('../src/models/form_field.js', () => ({
+    default: { find: mockFieldFind },
+  }));
+  await jest.unstable_mockModule('../src/models/approval_workflow.js', () => ({
+    default: { findOne: mockWorkflowFindOne },
+  }));
+  await jest.unstable_mockModule('../src/models/approval_request.js', () => ({
+    default: { deleteMany: mockApprovalDeleteMany, insertMany: mockApprovalInsertMany },
+  }));
+  await jest.unstable_mockModule('../src/models/Employee.js', () => ({
+    default: {
+      updateOne: mockEmployeeUpdateOne,
+      find: jest.fn().mockResolvedValue([]),
+    },
+  }));
+  await jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+    getLeaveFieldIds: mockGetLeaveFieldIds,
+    resetLeaveFieldCache: jest.fn(),
+  }));
+
+  const mod = await import('../src/seedUtils.js');
+  seedApprovalRequests = mod.seedApprovalRequests;
+});
+
+beforeEach(() => {
+  mockFormFindOne.mockReset();
+  mockFieldFind.mockReset();
+  mockWorkflowFindOne.mockReset();
+  mockApprovalDeleteMany.mockReset();
+  mockApprovalInsertMany.mockReset();
+  mockEmployeeUpdateOne.mockReset();
+  mockGetLeaveFieldIds.mockReset();
+
+  mockFormFindOne.mockImplementation(async ({ name }) => formDocs[name] ?? null);
+  mockFieldFind.mockImplementation(({ form }) => {
+    const query = {
+      sort: jest.fn(),
+      lean: jest.fn().mockResolvedValue(fieldDocs[form] ?? []),
+    };
+    query.sort.mockReturnValue(query);
+    return query;
+  });
+  mockWorkflowFindOne.mockImplementation(async ({ form }) => workflowDocs[form] ?? null);
+  mockApprovalDeleteMany.mockResolvedValue({});
+  mockApprovalInsertMany.mockImplementation(async (docs) => docs);
+  mockEmployeeUpdateOne.mockResolvedValue({});
+  mockGetLeaveFieldIds.mockResolvedValue({
+    formId: 'form-leave',
+    startId: 'leave-start',
+    endId: 'leave-end',
+    typeId: 'leave-type',
+    typeOptions: [{ value: '特休' }, { value: '事假' }],
+  });
+});
+
+describe('seedApprovalRequests', () => {
+  it('creates approval requests with workflow steps and approvers', async () => {
+    const supervisors = [
+      { _id: 'sup-hr', organization: 'org1', department: 'dept1', signTags: ['人資'] },
+      { _id: 'sup-support', organization: 'org2', department: 'dept2', signTags: ['支援單位主管'] },
+    ];
+    const employees = [
+      { _id: 'emp-1', organization: 'org1', department: 'dept1', supervisor: 'sup-hr', signTags: [] },
+      { _id: 'emp-2', organization: 'org2', department: 'dept2', supervisor: 'sup-support', signTags: [] },
+    ];
+
+    const result = await seedApprovalRequests({ supervisors, employees });
+
+    expect(mockApprovalDeleteMany).toHaveBeenCalledWith({});
+    expect(mockApprovalInsertMany).toHaveBeenCalledTimes(1);
+
+    const inserted = mockApprovalInsertMany.mock.calls[0][0];
+    expect(inserted).toHaveLength(employees.length * 3);
+
+    const statuses = new Set(inserted.map((req) => req.status));
+    expect(statuses).toEqual(new Set(['approved', 'pending', 'rejected', 'returned']));
+
+    inserted.forEach((req) => {
+      expect(req.steps.length).toBeGreaterThan(0);
+      req.steps.forEach((step) => {
+        expect(step.approvers.every((approver) => !!approver.approver)).toBe(true);
+      });
+      expect(req.logs[0].action).toBe('create');
+    });
+
+    const leaveRequests = inserted.filter((req) => req.form === 'form-leave');
+    leaveRequests.forEach((req, index) => {
+      const employeeIndex = Math.floor(index / 2);
+      const managerStep = req.steps.find((step) => step.step_order === 1);
+      const tagStep = req.steps.find((step) => step.step_order === 2);
+      expect(managerStep.approvers.map((a) => a.approver)).toContain(employees[employeeIndex].supervisor);
+      expect(tagStep.approvers.map((a) => a.approver)).toContain('sup-hr');
+      expect(Object.keys(req.form_data)).toEqual(
+        expect.arrayContaining(['leave-type', 'leave-start', 'leave-end', 'leave-reason']),
+      );
+    });
+
+    const supportRequest = inserted.find((req) => req.form === 'form-support');
+    expect(Object.keys(supportRequest.form_data)).toEqual(
+      expect.arrayContaining(['support-reason', 'support-start', 'support-end', 'support-file']),
+    );
+
+    expect(result.requests).toHaveLength(inserted.length);
+  });
+});

--- a/server/tests/seedApprovalTemplates.test.js
+++ b/server/tests/seedApprovalTemplates.test.js
@@ -4,8 +4,11 @@ const mockTemplateFindOne = jest.fn();
 const mockTemplateCreate = jest.fn(async data => ({ _id: `${data.name}_id`, ...data }));
 const mockFieldFindOne = jest.fn();
 const mockFieldCreate = jest.fn();
+const mockFieldFind = jest.fn();
 const mockWorkflowFindOne = jest.fn();
 const mockWorkflowCreate = jest.fn();
+const mockResetLeaveFieldCache = jest.fn();
+const mockGetLeaveFieldIds = jest.fn();
 
 let seedApprovalTemplates;
 
@@ -15,9 +18,19 @@ beforeAll(async () => {
   process.env.JWT_SECRET = 'secret';
   process.env.NODE_ENV = 'test';
 
-  await jest.unstable_mockModule('../src/models/form_template.js', () => ({ default: { findOne: mockTemplateFindOne, create: mockTemplateCreate } }));
-  await jest.unstable_mockModule('../src/models/form_field.js', () => ({ default: { findOne: mockFieldFindOne, create: mockFieldCreate } }));
-  await jest.unstable_mockModule('../src/models/approval_workflow.js', () => ({ default: { findOne: mockWorkflowFindOne, create: mockWorkflowCreate } }));
+  await jest.unstable_mockModule('../src/models/form_template.js', () => ({
+    default: { findOne: mockTemplateFindOne, create: mockTemplateCreate },
+  }));
+  await jest.unstable_mockModule('../src/models/form_field.js', () => ({
+    default: { findOne: mockFieldFindOne, create: mockFieldCreate, find: mockFieldFind },
+  }));
+  await jest.unstable_mockModule('../src/models/approval_workflow.js', () => ({
+    default: { findOne: mockWorkflowFindOne, create: mockWorkflowCreate },
+  }));
+  await jest.unstable_mockModule('../src/services/leaveFieldService.js', () => ({
+    resetLeaveFieldCache: mockResetLeaveFieldCache,
+    getLeaveFieldIds: mockGetLeaveFieldIds,
+  }));
 
   const mod = await import('../src/seedUtils.js');
   seedApprovalTemplates = mod.seedApprovalTemplates;
@@ -28,7 +41,28 @@ describe('seedApprovalTemplates', () => {
     mockTemplateFindOne.mockResolvedValue(null);
     mockFieldFindOne.mockResolvedValue(null);
     mockWorkflowFindOne.mockResolvedValue(null);
-    await seedApprovalTemplates();
+    mockWorkflowCreate.mockImplementation(async ({ form, steps }) => ({ _id: `${form}-wf`, steps }));
+    mockFieldFind.mockImplementation(() => {
+      const query = {
+        sort: jest.fn(),
+        lean: jest.fn().mockResolvedValue([
+          { _id: 'field1', label: '假別' },
+          { _id: 'field2', label: '開始日期' },
+          { _id: 'field3', label: '結束日期' },
+        ]),
+      };
+      query.sort.mockReturnValue(query);
+      return query;
+    });
+    mockGetLeaveFieldIds.mockResolvedValue({
+      formId: 'leaveForm',
+      startId: 'field2',
+      endId: 'field3',
+      typeId: 'field1',
+      typeOptions: [],
+    });
+
+    const result = await seedApprovalTemplates();
     expect(mockTemplateCreate).toHaveBeenCalledWith(expect.objectContaining({ name: '支援申請' }));
     expect(mockTemplateCreate).toHaveBeenCalledWith(expect.objectContaining({ name: '特休保留' }));
     expect(mockTemplateCreate).toHaveBeenCalledWith(expect.objectContaining({ name: '請假' }));
@@ -40,5 +74,8 @@ describe('seedApprovalTemplates', () => {
         expect.objectContaining({ approver_type: 'tag', approver_value: '支援單位主管' }),
       ]),
     }));
+    expect(mockResetLeaveFieldCache).toHaveBeenCalled();
+    expect(mockGetLeaveFieldIds).toHaveBeenCalled();
+    expect(result.templates['請假'].fields).toHaveLength(3);
   });
 });

--- a/server/tests/seedScript.test.js
+++ b/server/tests/seedScript.test.js
@@ -9,8 +9,9 @@ test('seed script loads env from server/.env', async () => {
   await jest.unstable_mockModule('../src/config/db.js', () => ({ connectDB: jest.fn() }));
   await jest.unstable_mockModule('../src/seedUtils.js', () => ({
     seedSampleData: jest.fn(),
-    seedTestUsers: jest.fn(),
-    seedApprovalTemplates: jest.fn()
+    seedTestUsers: jest.fn().mockResolvedValue({ supervisors: [], employees: [] }),
+    seedApprovalTemplates: jest.fn(),
+    seedApprovalRequests: jest.fn(),
   }));
   await jest.unstable_mockModule('mongoose', () => ({ default: { disconnect: jest.fn() } }));
 


### PR DESCRIPTION
## Summary
- 在種子流程建立後擷取請假等表單欄位並維護流程資訊
- 新增自動產生簽核申請資料的工具函式與批次請求步驟模擬
- 補齊種子流程腳本與對應單元測試，驗證流程欄位與狀態

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda8d3fd1c8329ad068d7da42ea729