### PR TITLE
feat: 匯出測試帳號密碼清單

### DIFF
--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import path from 'path';
+import { writeFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import { connectDB } from '../src/config/db.js';
 
@@ -9,7 +10,13 @@ const __dirname = path.dirname(__filename);
 
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
-const { seedSampleData, seedTestUsers, seedApprovalTemplates, seedApprovalRequests } = await import('../src/seedUtils.js');
+const {
+  seedSampleData,
+  seedTestUsers,
+  seedApprovalTemplates,
+  seedApprovalRequests,
+  SEED_TEST_PASSWORD,
+} = await import('../src/seedUtils.js');
 
 if (!process.env.MONGODB_URI) {
   console.error('MONGODB_URI is not defined in the environment');
@@ -23,6 +30,40 @@ async function seed() {
     console.log(`Seeded organizations: ${structure.organizations.map((org) => org.name).join(', ')}`);
   }
   const { supervisors, employees } = await seedTestUsers();
+
+  const accounts = [];
+  const formatUserAccount = (user) => ({
+    username: user.username,
+    password: SEED_TEST_PASSWORD,
+    name: user.name,
+    title: user.title ?? '',
+    role: user.role,
+    signTags: Array.isArray(user.signTags) ? [...user.signTags] : [],
+  });
+
+  supervisors.forEach((supervisor) => {
+    accounts.push(formatUserAccount(supervisor));
+  });
+
+  employees.forEach((employee) => {
+    accounts.push(formatUserAccount(employee));
+  });
+
+  if (process.env.DEFAULT_ADMIN_USERNAME) {
+    accounts.unshift({
+      username: process.env.DEFAULT_ADMIN_USERNAME,
+      password: process.env.DEFAULT_ADMIN_PASSWORD ?? SEED_TEST_PASSWORD,
+      name: process.env.DEFAULT_ADMIN_NAME ?? '系統管理員',
+      title: process.env.DEFAULT_ADMIN_TITLE ?? '系統管理員',
+      role: 'admin',
+      signTags: [],
+    });
+  }
+
+  const outputPath = path.resolve(__dirname, 'seed-accounts.json');
+  await writeFile(outputPath, JSON.stringify(accounts, null, 2), 'utf8');
+  console.log(`種子帳號資訊已輸出至 ${outputPath}`);
+
   await seedApprovalTemplates();
   await seedApprovalRequests({ supervisors, employees });
   await mongoose.disconnect();

--- a/server/src/seedUtils.js
+++ b/server/src/seedUtils.js
@@ -13,6 +13,8 @@ import AttendanceRecord from './models/AttendanceRecord.js';
 import ShiftSchedule from './models/ShiftSchedule.js';
 import { getLeaveFieldIds, resetLeaveFieldCache } from './services/leaveFieldService.js';
 
+export const SEED_TEST_PASSWORD = 'password';
+
 const CITY_OPTIONS = ['台北市', '新北市', '桃園市', '台中市', '台南市', '高雄市'];
 const PRINCIPAL_NAMES = ['林經理', '張主管', '王負責人', '李主任', '陳董事'];
 const PHONE_PREFIXES = ['02', '03', '04', '05', '06', '07'];
@@ -424,7 +426,7 @@ export async function seedTestUsers() {
       name: config.name,
       email: `${emailSeed}@example.com`,
       username: usernameSeed,
-      password: 'password',
+      password: SEED_TEST_PASSWORD,
       role: 'supervisor',
       organization: toStringId(assignment.organization._id),
       department: assignment.department._id,
@@ -447,7 +449,7 @@ export async function seedTestUsers() {
       name: EMPLOYEE_NAMES[i % EMPLOYEE_NAMES.length],
       email: `${emailSeed}@example.com`,
       username: usernameSeed,
-      password: 'password',
+      password: SEED_TEST_PASSWORD,
       role: 'employee',
       organization: toStringId(assignment.organization._id),
       department: assignment.department._id,

--- a/server/tests/seedScript.test.js
+++ b/server/tests/seedScript.test.js
@@ -3,19 +3,61 @@ import path from 'path';
 
 test('seed script loads env from server/.env', async () => {
   process.env.MONGODB_URI = 'mongodb://localhost/test';
+  process.env.DEFAULT_ADMIN_USERNAME = 'admin';
+  process.env.DEFAULT_ADMIN_PASSWORD = 'admin-secret';
   const configMock = jest.fn();
+  const writeFileMock = jest.fn().mockResolvedValue();
+  const supervisors = [
+    { username: 'sup-01', name: '主管甲', title: '部門主管', role: 'supervisor', signTags: ['人資'] },
+  ];
+  const employees = [
+    { username: 'emp-01', name: '員工甲', title: '專員', role: 'employee', signTags: [] },
+  ];
 
+  await jest.unstable_mockModule('fs/promises', () => ({ writeFile: writeFileMock }));
   await jest.unstable_mockModule('dotenv', () => ({ default: { config: configMock } }));
   await jest.unstable_mockModule('../src/config/db.js', () => ({ connectDB: jest.fn() }));
   await jest.unstable_mockModule('../src/seedUtils.js', () => ({
     seedSampleData: jest.fn(),
-    seedTestUsers: jest.fn().mockResolvedValue({ supervisors: [], employees: [] }),
+    seedTestUsers: jest.fn().mockResolvedValue({ supervisors, employees }),
     seedApprovalTemplates: jest.fn(),
     seedApprovalRequests: jest.fn(),
+    SEED_TEST_PASSWORD: 'mocked-password',
   }));
   await jest.unstable_mockModule('mongoose', () => ({ default: { disconnect: jest.fn() } }));
 
   await import('../scripts/seed.js');
 
   expect(configMock).toHaveBeenCalledWith({ path: path.resolve(process.cwd(), '.env') });
+  expect(writeFileMock).toHaveBeenCalledWith(
+    expect.stringContaining('seed-accounts.json'),
+    expect.any(String),
+    'utf8',
+  );
+
+  const [, accountJson] = writeFileMock.mock.calls[0];
+  const accounts = JSON.parse(accountJson);
+  expect(accounts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        username: 'admin',
+        password: 'admin-secret',
+        role: 'admin',
+      }),
+      expect.objectContaining({
+        username: 'sup-01',
+        password: 'mocked-password',
+        role: 'supervisor',
+        signTags: ['人資'],
+      }),
+      expect.objectContaining({
+        username: 'emp-01',
+        password: 'mocked-password',
+        role: 'employee',
+      }),
+    ]),
+  );
+
+  delete process.env.DEFAULT_ADMIN_USERNAME;
+  delete process.env.DEFAULT_ADMIN_PASSWORD;
 });


### PR DESCRIPTION
## Summary
- 匯出 SEED_TEST_PASSWORD 常數並讓測試主管與員工帳號共用
- 種子腳本寫出帳號清單 JSON 檔並提示檔案位置
- 更新種子腳本測試以驗證 JSON 內容與預設管理員資訊

## Testing
- npm --prefix server test
- npm --prefix client test *(失敗：現有 Vitest 測試依賴完整前端環境與 Pinia 啟動設定)*

------
https://chatgpt.com/codex/tasks/task_e_68ce791e3d388329842ba59bf52d733e