### PR TITLE
調整考勤管理設定 API 與前端班表存取

### DIFF
--- a/client/src/views/front/MySchedule.vue
+++ b/client/src/views/front/MySchedule.vue
@@ -21,10 +21,10 @@ const selectedMonth = ref(dayjs().format('YYYY-MM'))
 
 async function fetchShifts() {
   try {
-    const res = await apiFetch('/api/attendance-settings')
+    const res = await apiFetch('/api/shifts')
     if (res.ok) {
       const data = await res.json()
-      const list = Array.isArray(data?.shifts) ? data.shifts : data
+      const list = Array.isArray(data) ? data : []
       shiftMap.value = Object.fromEntries(list.map(s => [s._id, s.name]))
     }
   } catch (err) {

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -390,10 +390,10 @@ const days = computed(() => {
 })
 
 async function fetchShiftOptions() {
-  const res = await apiFetch('/api/attendance-settings')
+  const res = await apiFetch('/api/shifts')
   if (res.ok) {
     const data = await res.json()
-    const list = Array.isArray(data?.shifts) ? data.shifts : data
+    const list = Array.isArray(data) ? data : []
     if (Array.isArray(list)) {
       shifts.value = list.map(s => ({
         _id: s._id,

--- a/server/src/controllers/attendanceSettingController.js
+++ b/server/src/controllers/attendanceSettingController.js
@@ -1,8 +1,17 @@
+import mongoose from 'mongoose';
 import AttendanceManagementSetting from '../models/AttendanceManagementSetting.js';
+
+function validateObjectId(id) {
+  return mongoose.Types.ObjectId.isValid(id);
+}
+
+function notFound(res) {
+  return res.status(404).json({ error: '找不到考勤管理設定' });
+}
 
 export async function listSettings(req, res) {
   try {
-    const settings = await AttendanceManagementSetting.find();
+    const settings = await AttendanceManagementSetting.find().sort({ createdAt: -1 });
     res.json(settings);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -20,31 +29,52 @@ export async function createSetting(req, res) {
 }
 
 export async function getSetting(req, res) {
+  const { id } = req.params;
+  if (!validateObjectId(id)) {
+    return res.status(400).json({ error: '設定編號格式不正確' });
+  }
   try {
-    const setting = await AttendanceManagementSetting.findById(req.params.id);
-    if (!setting) return res.status(404).json({ error: 'Not found' });
+    const setting = await AttendanceManagementSetting.findById(id);
+    if (!setting) {
+      return notFound(res);
+    }
     res.json(setting);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    res.status(500).json({ error: err.message });
   }
 }
 
 export async function updateSetting(req, res) {
+  const { id } = req.params;
+  if (!validateObjectId(id)) {
+    return res.status(400).json({ error: '設定編號格式不正確' });
+  }
   try {
-    const setting = await AttendanceManagementSetting.findByIdAndUpdate(req.params.id, req.body, { new: true });
-    if (!setting) return res.status(404).json({ error: 'Not found' });
+    const setting = await AttendanceManagementSetting.findByIdAndUpdate(id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!setting) {
+      return notFound(res);
+    }
     res.json(setting);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    res.status(500).json({ error: err.message });
   }
 }
 
 export async function deleteSetting(req, res) {
+  const { id } = req.params;
+  if (!validateObjectId(id)) {
+    return res.status(400).json({ error: '設定編號格式不正確' });
+  }
   try {
-    const setting = await AttendanceManagementSetting.findByIdAndDelete(req.params.id);
-    if (!setting) return res.status(404).json({ error: 'Not found' });
+    const setting = await AttendanceManagementSetting.findByIdAndDelete(id);
+    if (!setting) {
+      return notFound(res);
+    }
     res.json({ success: true });
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    res.status(500).json({ error: err.message });
   }
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,7 +26,7 @@ import salarySettingRoutes from './routes/salarySettingRoutes.js';
 import breakSettingRoutes from './routes/breakSettingRoutes.js';
 import holidayMoveSettingRoutes from './routes/holidayMoveSettingRoutes.js';
 
-import attendanceShiftRoutes from './routes/attendanceShiftRoutes.js';
+import attendanceSettingRoutes from './routes/attendanceSettingRoutes.js';
 import shiftRoutes from './routes/shiftRoutes.js';
 import deptManagerRoutes from './routes/deptManagerRoutes.js';
 
@@ -89,13 +89,8 @@ app.use('/api/roles', authenticate, authorizeRoles('admin', 'supervisor'), roleR
 app.use(
   '/api/attendance-settings',
   authenticate,
-  (req, res, next) => {
-    if (req.method === 'GET') {
-      return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
-    }
-    return authorizeRoles('admin')(req, res, next);
-  },
-  attendanceShiftRoutes
+  authorizeRoles('admin'),
+  attendanceSettingRoutes
 );
 
 app.use(
@@ -103,7 +98,7 @@ app.use(
   authenticate,
   (req, res, next) => {
     if (req.method === 'GET') {
-      return authorizeRoles('supervisor', 'admin')(req, res, next);
+      return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
     }
     return authorizeRoles('admin')(req, res, next);
   },

--- a/server/tests/attendanceSettingsAccess.test.js
+++ b/server/tests/attendanceSettingsAccess.test.js
@@ -2,48 +2,88 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
-const findOne = jest.fn().mockResolvedValue({ shifts: [{ name: '日班' }] });
+const sort = jest.fn();
+const find = jest.fn();
+const findById = jest.fn();
+const findByIdAndUpdate = jest.fn();
 
-jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({
-  default: { findOne }
+jest.unstable_mockModule('../src/models/AttendanceManagementSetting.js', () => ({
+  default: {
+    find,
+    findById,
+    findByIdAndUpdate,
+    findByIdAndDelete: jest.fn(),
+  },
 }));
 
 let app;
 let authorizeRoles;
-let attendanceShiftRoutes;
+let attendanceSettingRoutes;
 
 beforeAll(async () => {
   ({ authorizeRoles } = await import('../src/middleware/auth.js'));
-  attendanceShiftRoutes = (await import('../src/routes/attendanceShiftRoutes.js')).default;
+  attendanceSettingRoutes = (await import('../src/routes/attendanceSettingRoutes.js')).default;
 
   app = express();
   app.use(express.json());
-  // 模擬已驗證的員工使用者
+  // 模擬已驗證的管理員
   app.use((req, res, next) => {
-    req.user = { role: 'employee' };
+    req.user = { role: 'admin' };
     next();
   });
-  app.use(
-    '/api/attendance-settings',
-    (req, res, next) => {
-      if (req.method === 'GET') {
-        return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
-      }
-      return authorizeRoles('admin')(req, res, next);
+  app.use('/api/attendance-settings', authorizeRoles('admin'), attendanceSettingRoutes);
+});
+
+beforeEach(() => {
+  find.mockImplementation(() => ({ sort }));
+  sort.mockResolvedValue([
+    {
+      _id: '65f9e8a5f5d2c2a1b1234567',
+      enableImport: true,
     },
-    attendanceShiftRoutes
-  );
+  ]);
 });
 
 afterEach(() => {
-  findOne.mockClear();
+  jest.clearAllMocks();
 });
 
-describe('Attendance settings access', () => {
-  it('允許員工取得班別資料', async () => {
+describe('Attendance management settings routes', () => {
+  it('允許管理員取得考勤管理設定列表', async () => {
     const res = await request(app).get('/api/attendance-settings');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ name: '日班' }]);
-    expect(findOne).toHaveBeenCalled();
+    expect(res.body).toEqual([
+      {
+        _id: '65f9e8a5f5d2c2a1b1234567',
+        enableImport: true,
+      },
+    ]);
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+  });
+
+  it('允許管理員更新指定設定', async () => {
+    const payload = { enableImport: false };
+    const updated = { _id: '65f9e8a5f5d2c2a1b1234567', enableImport: false };
+    findByIdAndUpdate.mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put('/api/attendance-settings/65f9e8a5f5d2c2a1b1234567')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+    expect(findByIdAndUpdate).toHaveBeenCalledWith(
+      '65f9e8a5f5d2c2a1b1234567',
+      payload,
+      expect.objectContaining({ new: true, runValidators: true })
+    );
+  });
+
+  it('回報不正確的編號格式', async () => {
+    const res = await request(app).get('/api/attendance-settings/not-a-valid-id');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: '設定編號格式不正確' });
+    expect(findById).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 摘要
- 改以 attendanceSettingController 掛載 `/api/attendance-settings` 並調整權限
- 補強考勤管理設定控制器的單筆查詢與錯誤訊息
- 更新前端班表頁面改用 `/api/shifts` 取得班別資料並調整相關測試

## 測試
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cea94784908329b48efff9f8b704d7