### PR TITLE
整合出勤設定 API 與前端設定

### DIFF
--- a/client/src/components/backComponents/AttendanceManagementSetting.vue
+++ b/client/src/components/backComponents/AttendanceManagementSetting.vue
@@ -106,33 +106,28 @@ import { apiFetch } from '../../api'
 
   async function fetchSetting() {
     const res = await apiFetch('/api/attendance-settings')
-    if (res.ok) {
-      const data = await res.json()
-      if (data.length) {
-        Object.assign(form.value, data[0])
-        settingId.value = data[0]._id || ''
-      }
+    if (!res.ok) return
+    const data = await res.json()
+    const target = Array.isArray(data) ? data[0] : data
+    if (target) {
+      const management = target.management || target
+      Object.assign(form.value, management)
+      settingId.value = target._id || ''
     }
   }
-  
+
   async function saveSettings() {
-    const payload = { ...form.value }
-    let res
-    if (settingId.value) {
-      res = await apiFetch(`/api/attendance-settings/${settingId.value}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
-    } else {
-      res = await apiFetch('/api/attendance-settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
-    }
+    const payload = { management: { ...form.value } }
+    const res = await apiFetch('/api/attendance-settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
     if (res.ok) {
       const saved = await res.json()
+      if (saved.management) {
+        Object.assign(form.value, saved.management)
+      }
       settingId.value = saved._id || settingId.value
       alert('已儲存「考勤管理設定」')
     }

--- a/client/src/components/backComponents/OrgDepartmentSetting.vue
+++ b/client/src/components/backComponents/OrgDepartmentSetting.vue
@@ -736,7 +736,11 @@ async function fetchShifts(force = false) {
     const res = await apiFetch('/api/shifts')
     if (res.ok) {
       const data = await res.json()
-      shiftOptions.value = Array.isArray(data) ? data : []
+      shiftOptions.value = Array.isArray(data?.shifts)
+        ? data.shifts
+        : Array.isArray(data)
+          ? data
+          : []
       shiftsLoaded.value = true
     }
   } catch (err) {

--- a/client/src/components/backComponents/ShiftScheduleSetting.vue
+++ b/client/src/components/backComponents/ShiftScheduleSetting.vue
@@ -412,7 +412,12 @@ async function fetchShifts() {
     }
   })
   if (res.ok) {
-    shiftList.value = await res.json()
+    const data = await res.json()
+    shiftList.value = Array.isArray(data?.shifts)
+      ? data.shifts
+      : Array.isArray(data)
+        ? data
+        : []
   }
 }
   

--- a/client/src/views/front/MySchedule.vue
+++ b/client/src/views/front/MySchedule.vue
@@ -21,12 +21,15 @@ const selectedMonth = ref(dayjs().format('YYYY-MM'))
 
 async function fetchShifts() {
   try {
-    const res = await apiFetch('/api/shifts')
-    if (res.ok) {
-      const data = await res.json()
-      const list = Array.isArray(data) ? data : []
-      shiftMap.value = Object.fromEntries(list.map(s => [s._id, s.name]))
-    }
+    const res = await apiFetch('/api/attendance-settings')
+    const data = await res.json().catch(() => null)
+    if (!res.ok) return
+    const list = Array.isArray(data?.shifts)
+      ? data.shifts
+      : Array.isArray(data)
+        ? data
+        : []
+    shiftMap.value = Object.fromEntries(list.map(s => [s._id, s.name]))
   } catch (err) {
     console.error(err)
   }

--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -393,7 +393,11 @@ async function fetchShiftOptions() {
   const res = await apiFetch('/api/shifts')
   if (res.ok) {
     const data = await res.json()
-    const list = Array.isArray(data) ? data : []
+    const list = Array.isArray(data?.shifts)
+      ? data.shifts
+      : Array.isArray(data)
+        ? data
+        : []
     if (Array.isArray(list)) {
       shifts.value = list.map(s => ({
         _id: s._id,

--- a/server/src/models/AttendanceSetting.js
+++ b/server/src/models/AttendanceSetting.js
@@ -27,6 +27,20 @@ const attendanceSettingSchema = new mongoose.Schema({
     weekdayThreshold: Number,
     holidayRate: Number,
     toCompRate: Number
+  },
+  management: {
+    enableImport: { type: Boolean, default: false },
+    importFormat: String,
+    importMapping: String,
+    allowMakeUpClock: { type: Boolean, default: true },
+    makeUpDays: Number,
+    makeUpNeedApprove: { type: Boolean, default: true },
+    supervisorCrossDept: { type: Boolean, default: false },
+    hrAllDept: { type: Boolean, default: true },
+    employeeHistoryMonths: Number,
+    nonExtWorkAlert: { type: Boolean, default: false },
+    overtimeNoClockNotify: { type: Boolean, default: true },
+    notifyTargets: [String]
   }
 });
 

--- a/server/src/routes/attendanceSettingRoutes.js
+++ b/server/src/routes/attendanceSettingRoutes.js
@@ -1,19 +1,13 @@
 import { Router } from 'express';
 
 import {
-  listSettings,
-  createSetting,
-  getSetting,
-  updateSetting,
-  deleteSetting
+  getAttendanceSetting,
+  updateAttendanceSetting,
 } from '../controllers/attendanceSettingController.js';
 
 const router = Router();
 
-router.get('/', listSettings);
-router.post('/', createSetting);
-router.get('/:id', getSetting);
-router.put('/:id', updateSetting);
-router.delete('/:id', deleteSetting);
+router.get('/', getAttendanceSetting);
+router.put('/', updateAttendanceSetting);
 
 export default router;

--- a/server/tests/attendanceSettingsAccess.test.js
+++ b/server/tests/attendanceSettingsAccess.test.js
@@ -2,17 +2,13 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
-const sort = jest.fn();
-const find = jest.fn();
-const findById = jest.fn();
-const findByIdAndUpdate = jest.fn();
+const findOne = jest.fn();
+const create = jest.fn();
 
-jest.unstable_mockModule('../src/models/AttendanceManagementSetting.js', () => ({
+jest.unstable_mockModule('../src/models/AttendanceSetting.js', () => ({
   default: {
-    find,
-    findById,
-    findByIdAndUpdate,
-    findByIdAndDelete: jest.fn(),
+    findOne,
+    create,
   },
 }));
 
@@ -20,13 +16,61 @@ let app;
 let authorizeRoles;
 let attendanceSettingRoutes;
 
+function buildDoc(overrides = {}) {
+  const doc = {
+    _id: 'setting-id',
+    shifts: [],
+    abnormalRules: {
+      lateGrace: 5,
+      earlyLeaveGrace: 5,
+      missingThreshold: 30,
+      autoNotify: true,
+    },
+    breakOutRules: {
+      enableBreakPunch: true,
+      breakInterval: 60,
+      outingNeedApprove: false,
+    },
+    overtimeRules: {
+      weekdayThreshold: 30,
+      holidayRate: 2,
+      toCompRate: 1.5,
+    },
+    management: {
+      enableImport: false,
+      importFormat: '',
+      importMapping: '',
+      allowMakeUpClock: true,
+      makeUpDays: 3,
+      makeUpNeedApprove: true,
+      supervisorCrossDept: false,
+      hrAllDept: true,
+      employeeHistoryMonths: 6,
+      nonExtWorkAlert: false,
+      overtimeNoClockNotify: true,
+      notifyTargets: ['員工', '主管'],
+    },
+    ...overrides,
+  };
+
+  doc.save = jest.fn().mockResolvedValue(doc);
+  doc.toObject = jest.fn(() => ({
+    _id: doc._id,
+    shifts: doc.shifts,
+    abnormalRules: doc.abnormalRules,
+    breakOutRules: doc.breakOutRules,
+    overtimeRules: doc.overtimeRules,
+    management: doc.management,
+  }));
+  return doc;
+}
+
 beforeAll(async () => {
   ({ authorizeRoles } = await import('../src/middleware/auth.js'));
   attendanceSettingRoutes = (await import('../src/routes/attendanceSettingRoutes.js')).default;
 
   app = express();
   app.use(express.json());
-  // 模擬已驗證的管理員
   app.use((req, res, next) => {
     req.user = { role: 'admin' };
     next();
@@ -35,55 +79,116 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  find.mockImplementation(() => ({ sort }));
-  sort.mockResolvedValue([
-    {
-      _id: '65f9e8a5f5d2c2a1b1234567',
-      enableImport: true,
-    },
-  ]);
-});
-
-afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('Attendance management settings routes', () => {
-  it('允許管理員取得考勤管理設定列表', async () => {
-    const res = await request(app).get('/api/attendance-settings');
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual([
-      {
-        _id: '65f9e8a5f5d2c2a1b1234567',
-        enableImport: true,
+describe('AttendanceSetting routes', () => {
+  it('returns existing setting with merged defaults', async () => {
+    const doc = buildDoc({
+      abnormalRules: {
+        lateGrace: 10,
+        autoNotify: false,
       },
-    ]);
-    expect(find).toHaveBeenCalledTimes(1);
-    expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+    });
+    findOne.mockResolvedValue(doc);
+
+    const res = await request(app).get('/api/attendance-settings');
+
+    expect(res.status).toBe(200);
+    expect(res.body.abnormalRules).toEqual({
+      lateGrace: 10,
+      earlyLeaveGrace: 5,
+      missingThreshold: 30,
+      autoNotify: false,
+    });
+    expect(res.body.breakOutRules).toEqual({
+      enableBreakPunch: true,
+      breakInterval: 60,
+      outingNeedApprove: false,
+    });
+    expect(res.body.management).toEqual({
+      enableImport: false,
+      importFormat: '',
+      importMapping: '',
+      allowMakeUpClock: true,
+      makeUpDays: 3,
+      makeUpNeedApprove: true,
+      supervisorCrossDept: false,
+      hrAllDept: true,
+      employeeHistoryMonths: 6,
+      nonExtWorkAlert: false,
+      overtimeNoClockNotify: true,
+      notifyTargets: ['員工', '主管'],
+    });
+    expect(findOne).toHaveBeenCalledTimes(1);
   });
 
-  it('允許管理員更新指定設定', async () => {
-    const payload = { enableImport: false };
-    const updated = { _id: '65f9e8a5f5d2c2a1b1234567', enableImport: false };
-    findByIdAndUpdate.mockResolvedValue(updated);
+  it('creates default setting if none exists', async () => {
+    const created = buildDoc();
+    findOne.mockResolvedValueOnce(null);
+    create.mockResolvedValueOnce(created);
+
+    const res = await request(app).get('/api/attendance-settings');
+
+    expect(res.status).toBe(200);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shifts: [],
+        abnormalRules: expect.objectContaining({ lateGrace: 5 }),
+        management: expect.objectContaining({ enableImport: false }),
+      })
+    );
+    expect(res.body.overtimeRules).toEqual({
+      weekdayThreshold: 30,
+      holidayRate: 2,
+      toCompRate: 1.5,
+    });
+  });
+
+  it('persists updated rules', async () => {
+    const doc = buildDoc();
+    findOne.mockResolvedValue(doc);
 
     const res = await request(app)
-      .put('/api/attendance-settings/65f9e8a5f5d2c2a1b1234567')
-      .send(payload);
+      .put('/api/attendance-settings')
+      .send({
+        abnormalRules: { lateGrace: 3, autoNotify: false },
+        breakOutRules: { breakInterval: 90 },
+        overtimeRules: { holidayRate: 2.5 },
+      });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(updated);
-    expect(findByIdAndUpdate).toHaveBeenCalledWith(
-      '65f9e8a5f5d2c2a1b1234567',
-      payload,
-      expect.objectContaining({ new: true, runValidators: true })
-    );
+    expect(doc.save).toHaveBeenCalledTimes(1);
+    expect(doc.abnormalRules).toEqual({
+      lateGrace: 3,
+      earlyLeaveGrace: 5,
+      missingThreshold: 30,
+      autoNotify: false,
+    });
+    expect(doc.breakOutRules.breakInterval).toBe(90);
+    expect(doc.overtimeRules.holidayRate).toBe(2.5);
+    expect(res.body.abnormalRules.lateGrace).toBe(3);
+    expect(res.body.breakOutRules.breakInterval).toBe(90);
   });
 
-  it('回報不正確的編號格式', async () => {
-    const res = await request(app).get('/api/attendance-settings/not-a-valid-id');
-    expect(res.status).toBe(400);
-    expect(res.body).toEqual({ error: '設定編號格式不正確' });
-    expect(findById).not.toHaveBeenCalled();
+  it('updates management preferences', async () => {
+    const doc = buildDoc();
+    findOne.mockResolvedValue(doc);
+
+    const res = await request(app)
+      .put('/api/attendance-settings')
+      .send({
+        management: {
+          enableImport: true,
+          notifyTargets: ['HR'],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(doc.save).toHaveBeenCalled();
+    expect(doc.management.enableImport).toBe(true);
+    expect(doc.management.notifyTargets).toEqual(['HR']);
+    expect(res.body.management.enableImport).toBe(true);
+    expect(res.body.management.notifyTargets).toEqual(['HR']);
   });
 });


### PR DESCRIPTION
## Summary
- 新增出勤設定 API 控制器，統一處理班別、規則與管理預設值
- 調整後台考勤設定與管理介面，改以單筆設定物件載入並補上儲存訊息
- 更新前台班表、組織與排班維護，支援從出勤設定取得班別資料

## Testing
- npm test (server)
- npx vitest run tests/mySchedule.spec.js
- npx vitest run tests/schedule.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cec105885c83299c390367c76a710a