### PR TITLE
feat: 調整班表匯出與權限控制

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -111,6 +111,9 @@ app.use(
   authenticate,
   (req, res, next) => {
     if (req.method === 'GET') {
+      if (req.path?.startsWith('/export')) {
+        return authorizeRoles('admin', 'supervisor')(req, res, next);
+      }
       return authorizeRoles('employee', 'supervisor', 'admin')(req, res, next);
     }
     return authorizeRoles('supervisor', 'admin')(req, res, next);


### PR DESCRIPTION
## 摘要
- 匯出班表時依據 month、department（可加 subDepartment）過濾資料並驗證必要參數
- 依據查詢條件產生匯出檔案名稱，並為 PDF/Excel 統一採用
- 將 /api/schedules/export 限制為管理員與主管才能使用，並新增對應測試涵蓋權限與輸出內容

## 測試
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceccf61d548329b6015187916bd178