### PR TITLE
限制員工濫用主管排班查詢

### DIFF
--- a/client/src/views/front/MySchedule.vue
+++ b/client/src/views/front/MySchedule.vue
@@ -41,8 +41,12 @@ async function loadSchedules() {
   try {
     await fetchShifts()
     const payload = JSON.parse(atob(token.split('.')[1]))
-    const userId = payload.id || payload._id || payload.sub
-    const res = await apiFetch(`/api/schedules/monthly?month=${selectedMonth.value}&employee=${userId}`)
+    const userId =
+      payload.employeeId || payload.id || payload._id || payload.sub
+    if (!userId) return
+    const params = new URLSearchParams({ month: selectedMonth.value })
+    params.set('employee', userId)
+    const res = await apiFetch(`/api/schedules/monthly?${params.toString()}`)
     if (res.ok) {
       const data = await res.json()
       schedules.value = data.map(s => ({

--- a/server/src/controllers/scheduleController.js
+++ b/server/src/controllers/scheduleController.js
@@ -49,6 +49,11 @@ export async function listMonthlySchedules(req, res) {
     const query = { date: { $gte: start, $lt: end } };
 
     if (supervisor) {
+      const role = req.user?.role;
+      const allowedRoles = ['supervisor', 'admin'];
+      if (!allowedRoles.includes(role)) {
+        return res.status(403).json({ error: 'forbidden' });
+      }
       const emps = await Employee.find({ supervisor }).select('_id');
       const ids = emps.map((e) => e._id.toString());
       query.employee = { $in: ids };


### PR DESCRIPTION
## Summary
- 限制後端 listMonthlySchedules 僅允許主管與管理員使用 supervisor 查詢參數
- 擴充伺服器與前端測試涵蓋主管參數濫用與合法使用情境
- 前端排班與個人班表頁依角色決定查詢條件並補強錯誤處理

## Testing
- npm --prefix server test -- schedule.test.js
- npx vitest run tests/schedule.spec.js tests/mySchedule.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68ced19f74b48329b52e16484676932f