### PR TITLE
限制主管排班僅限直屬員工

### DIFF
--- a/server/src/middleware/supervisor.js
+++ b/server/src/middleware/supervisor.js
@@ -17,13 +17,12 @@ export async function verifySupervisor(req, res, next) {
     }
     if (!employeeIds.length) return res.status(400).json({ error: 'Missing employee' });
 
-    const supervisorIds = [actor._id.toString()];
-    if (actor.supervisor) supervisorIds.push(actor.supervisor.toString());
+    const supervisorId = actor._id.toString();
 
     for (const id of employeeIds) {
       const emp = await Employee.findById(id);
       if (!emp) return res.status(404).json({ error: 'Employee not found' });
-      if (!(emp.supervisor && supervisorIds.includes(emp.supervisor.toString()))) {
+      if (!(emp.supervisor && emp.supervisor.toString() === supervisorId)) {
         return res.status(403).json({ error: 'Forbidden' });
       }
     }


### PR DESCRIPTION
## Summary
- 調整主管驗證中僅保留登入主管自身可被授權
- 新增並更新排班測試，覆蓋拒絕非直屬員工情境

## Testing
- npm --prefix server test -- supervisorSchedule

------
https://chatgpt.com/codex/tasks/task_e_68cee125b5848329acd20428a895bfaa