### PR TITLE
調整出勤紀錄顯示順序與時間戳保存

### DIFF
--- a/client/src/views/front/Attendance.vue
+++ b/client/src/views/front/Attendance.vue
@@ -131,11 +131,15 @@ async function fetchRecords() {
   const res = await apiFetch('/api/attendance')
   if (res.ok) {
     const data = await res.json()
-    records.value = data.map(r => ({
-      action: reverseActionMap[r.action] || r.action,
-      time: dayjs(r.timestamp).format('YYYY/MM/DD HH:mm:ss'),
-      remark: r.remark || ''
-    }))
+    records.value = data.map(r => {
+      const timestamp = r.timestamp
+      return {
+        action: reverseActionMap[r.action] || r.action,
+        time: timestamp ? dayjs(timestamp).format('YYYY/MM/DD HH:mm:ss') : '',
+        remark: r.remark || '',
+        timestamp
+      }
+    })
   }
 }
 
@@ -200,11 +204,14 @@ async function addRecord(action, remark = '') {
   })
   if (res.ok) {
     const saved = await res.json()
-    records.value.push({
+    const timestamp = saved.timestamp || payload.timestamp
+    const savedRecord = {
       action: reverseActionMap[saved.action] || saved.action,
-      time: dayjs(saved.timestamp).format('YYYY/MM/DD HH:mm:ss'),
-      remark: saved.remark || ''
-    })
+      time: timestamp ? dayjs(timestamp).format('YYYY/MM/DD HH:mm:ss') : '',
+      remark: saved.remark || '',
+      timestamp
+    }
+    records.value.unshift(savedRecord)
   }
 }
 


### PR DESCRIPTION
## Summary
- 更新前台考勤頁面，在新增打卡記錄時改為插入陣列開頭以確保最新資料顯示在前
- 於載入與新增打卡記錄時保留原始 timestamp 欄位，方便後續維持後端排序或擴充排序功能

## Testing
- `cd client && npm run test` *(失敗：專案既有測試環境缺少 Pinia 與樣式設定，並有 esbuild TextEncoder 相關錯誤)*

------
https://chatgpt.com/codex/tasks/task_e_68cee375f7fc83299fd75ae81f8d503f