### PR TITLE
feat: 調整前台班表班別來源

### DIFF
--- a/client/tests/mySchedule.spec.js
+++ b/client/tests/mySchedule.spec.js
@@ -36,14 +36,20 @@ describe('MySchedule.vue', () => {
     await flush()
     apiFetch.mockReset()
     apiFetch
-      .mockResolvedValueOnce({ ok: true, json: async () => [{ _id: '1', name: '早班' }] })
-      .mockResolvedValueOnce({ ok: true, json: async () => [{ date: '2023-02-01', shiftId: '1' }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ _id: '1', name: '早班', code: 'A1' }]
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ date: '2023-02-01', shiftId: '1' }]
+      })
     wrapper.vm.selectedMonth = '2023-02'
     await flush()
     await flush()
-    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/attendance-settings')
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/api/shifts')
     expect(apiFetch).toHaveBeenNthCalledWith(2, '/api/schedules/monthly?month=2023-02&employee=emp1')
-    expect(wrapper.vm.schedules[0].shiftName).toBe('早班')
+    expect(wrapper.vm.schedules[0].shiftName).toBe('早班 (A1)')
     expect(wrapper.vm.schedules[0].date).toBe('2023/02/01')
   })
 })


### PR DESCRIPTION
## Summary
- 前台我的班表改用員工可存取的 /api/shifts 取得班別資料，建立含名稱與代碼的對照表
- 將班表顯示邏輯改為先格式化班別名稱與代碼，失敗時退回排程回傳的 shiftName
- 更新 mySchedule.spec 模擬 /api/shifts 回應並驗證畫面同時呈現班別名稱與代碼

## Testing
- CI=1 npm test *(server 測試通過，client 端現有多項測試失敗，需額外修正環境或測資)*
- CI=1 npm --prefix client test -- --run tests/mySchedule.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cffca860f88329bb82f8b4ae7aac89