### PR TITLE
擴充其他控制設定欄位與 API 支援

### DIFF
--- a/client/src/components/backComponents/OtherControlSetting.vue
+++ b/client/src/components/backComponents/OtherControlSetting.vue
@@ -355,17 +355,23 @@ const ipForm = ref({ label: '', address: '' })
 const fieldTypeOptions = [
   { label: '文字輸入', value: 'text' },
   { label: '多行文字', value: 'textarea' },
+  { label: '數字輸入', value: 'number' },
   { label: '單選選項', value: 'select' },
   { label: '複選', value: 'checkbox' },
-  { label: '日期', value: 'date' }
+  { label: '複合加選', value: 'composite' },
+  { label: '日期', value: 'date' },
+  { label: '時間區間', value: 'timeRange' },
+  { label: '布林選項', value: 'boolean' }
 ]
 const fieldTypeMap = fieldTypeOptions.reduce((map, option) => ({ ...map, [option.value]: option.label }), {})
 
-const customFields = ref([
+const defaultCustomFields = [
   {
     label: '員工證字號',
     fieldKey: 'nationalId',
     type: 'text',
+    category: 'employee',
+    group: '基本資料',
     required: true,
     description: '供報稅與投保使用'
   },
@@ -373,16 +379,175 @@ const customFields = ref([
     label: '制服尺寸',
     fieldKey: 'uniformSize',
     type: 'select',
+    category: 'employee',
+    group: '報到資訊',
     required: false,
     description: '入職前通知行政備貨'
+  },
+  {
+    label: '職稱選單 (C03)',
+    fieldKey: 'C03',
+    type: 'select',
+    category: 'dictionary',
+    group: '職務設定',
+    required: true,
+    description: '維護員工職稱清單'
+  },
+  {
+    label: '執業職稱選單 (C04)',
+    fieldKey: 'C04',
+    type: 'select',
+    category: 'dictionary',
+    group: '職務設定',
+    required: false,
+    description: '提供專業人員執業職稱選項'
+  },
+  {
+    label: '語言能力庫 (C05)',
+    fieldKey: 'C05',
+    type: 'composite',
+    category: 'dictionary',
+    group: '基本資料',
+    required: false,
+    description: '設定可勾選的語言能力與層級'
+  },
+  {
+    label: '身障等級 (C06)',
+    fieldKey: 'C06',
+    type: 'select',
+    category: 'dictionary',
+    group: '基本資料',
+    required: false,
+    description: '維護身心障礙手冊等級'
+  },
+  {
+    label: '身分類別 (C07)',
+    fieldKey: 'C07',
+    type: 'select',
+    category: 'dictionary',
+    group: '基本資料',
+    required: false,
+    description: '設定身份註記分類'
+  },
+  {
+    label: '教育程度 (C08)',
+    fieldKey: 'C08',
+    type: 'select',
+    category: 'dictionary',
+    group: '學歷資料',
+    required: false,
+    description: '維護教育程度選單'
+  },
+  {
+    label: '緊急聯絡人稱謂 (C09)',
+    fieldKey: 'C09',
+    type: 'select',
+    category: 'dictionary',
+    group: '聯絡資訊',
+    required: false,
+    description: '提供緊急聯絡人稱謂選項'
+  },
+  {
+    label: '教育訓練積分類別 (C10)',
+    fieldKey: 'C10',
+    type: 'select',
+    category: 'dictionary',
+    group: '教育訓練',
+    required: false,
+    description: '維護教育訓練積分類別'
+  },
+  {
+    label: '班別名稱 (C11)',
+    fieldKey: 'C11_name',
+    type: 'text',
+    category: 'dictionary',
+    group: '班別設定',
+    required: true,
+    description: '顯示於班別選單的名稱'
+  },
+  {
+    label: '班別說明 (C11)',
+    fieldKey: 'C11_content',
+    type: 'textarea',
+    category: 'dictionary',
+    group: '班別設定',
+    required: false,
+    description: '補充班別內容或注意事項'
+  },
+  {
+    label: '班別時段 (C11)',
+    fieldKey: 'C11_timeRange',
+    type: 'timeRange',
+    category: 'dictionary',
+    group: '班別設定',
+    required: true,
+    description: '設定班別的起訖時間'
+  },
+  {
+    label: '休息是否計薪 (C11)',
+    fieldKey: 'C11_paidBreak',
+    type: 'boolean',
+    category: 'dictionary',
+    group: '班別設定',
+    required: false,
+    description: '決定休息時間是否計薪'
+  },
+  {
+    label: '允許彈性時間 (C11)',
+    fieldKey: 'C11_allowFlexTime',
+    type: 'boolean',
+    category: 'dictionary',
+    group: '班別設定',
+    required: false,
+    description: '是否允許彈性前後時間'
+  },
+  {
+    label: '彈性區間分鐘數 (C11)',
+    fieldKey: 'C11_flexWindow',
+    type: 'number',
+    category: 'dictionary',
+    group: '班別設定',
+    required: false,
+    description: '可彈性調整的分鐘數'
+  },
+  {
+    label: '假別類別 (C12)',
+    fieldKey: 'C12',
+    type: 'select',
+    category: 'dictionary',
+    group: '假別設定',
+    required: true,
+    description: '維護假別類別與對應設定'
+  },
+  {
+    label: '加班原因 (C13)',
+    fieldKey: 'C13',
+    type: 'select',
+    category: 'dictionary',
+    group: '加班設定',
+    required: false,
+    description: '設定常用的加班原因'
+  },
+  {
+    label: '津貼項目 (C14)',
+    fieldKey: 'C14',
+    type: 'select',
+    category: 'dictionary',
+    group: '薪資設定',
+    required: false,
+    description: '維護津貼或補貼項目'
   }
-])
+]
+
+const customFields = ref([...defaultCustomFields])
 const fieldDialogVisible = ref(false)
 const editingFieldIndex = ref(-1)
 const fieldForm = ref({
   label: '',
   fieldKey: '',
   type: 'text',
+  category: '',
+  group: '',
   required: false,
   description: ''
 })
@@ -469,8 +634,10 @@ async function loadSettings() {
           ipWhitelist.value = data.security.ipWhitelist
         }
       }
-      if (Array.isArray(data.customFields)) {
+      if (Array.isArray(data.customFields) && data.customFields.length) {
         customFields.value = data.customFields
+      } else {
+        customFields.value = [...defaultCustomFields]
       }
       if (data.integration) {
         integrationForm.value = { ...integrationForm.value, ...data.integration }
@@ -563,6 +730,8 @@ function openFieldDialog(index = -1) {
       label: '',
       fieldKey: '',
       type: 'text',
+      category: '',
+      group: '',
       required: false,
       description: ''
     }

--- a/client/tests/otherControlSetting.spec.js
+++ b/client/tests/otherControlSetting.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ElementPlus from 'element-plus'
+import OtherControlSetting from '../src/components/backComponents/OtherControlSetting.vue'
+
+vi.mock('../src/api', () => ({ apiFetch: vi.fn() }))
+import { apiFetch } from '../src/api'
+
+describe('OtherControlSetting custom field defaults', () => {
+  beforeEach(() => {
+    apiFetch.mockReset()
+    apiFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    global.ElMessage = { success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+  })
+
+  it('initializes dictionary fields for C03~C14 with expected types', async () => {
+    const wrapper = mount(OtherControlSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+
+    const keyTypeMap = Object.fromEntries(wrapper.vm.customFields.map(field => [field.fieldKey, field.type]))
+    const requiredCodes = [
+      'C03',
+      'C04',
+      'C05',
+      'C06',
+      'C07',
+      'C08',
+      'C09',
+      'C10',
+      'C11_name',
+      'C11_content',
+      'C11_timeRange',
+      'C11_paidBreak',
+      'C11_allowFlexTime',
+      'C11_flexWindow',
+      'C12',
+      'C13',
+      'C14'
+    ]
+
+    expect(Object.keys(keyTypeMap)).toEqual(expect.arrayContaining(requiredCodes))
+    expect(keyTypeMap.C03).toBe('select')
+    expect(keyTypeMap.C05).toBe('composite')
+    expect(keyTypeMap.C11_timeRange).toBe('timeRange')
+    expect(keyTypeMap.C11_paidBreak).toBe('boolean')
+    expect(keyTypeMap.C11_flexWindow).toBe('number')
+    expect(keyTypeMap.C12).toBe('select')
+    expect(keyTypeMap.C14).toBe('select')
+  })
+
+  it('supports extended field type options when adding a new field', async () => {
+    const wrapper = mount(OtherControlSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+
+    const typeValues = wrapper.vm.fieldTypeOptions.map(option => option.value)
+    expect(typeValues).toEqual(expect.arrayContaining(['number', 'timeRange', 'boolean', 'composite']))
+
+    wrapper.vm.openFieldDialog()
+    wrapper.vm.fieldForm.label = '測試數字欄位'
+    wrapper.vm.fieldForm.fieldKey = 'testNumberField'
+    wrapper.vm.fieldForm.type = 'number'
+    await wrapper.vm.saveField()
+
+    const created = wrapper.vm.customFields.find(field => field.fieldKey === 'testNumberField')
+    expect(created).toBeTruthy()
+    expect(created.type).toBe('number')
+  })
+})

--- a/server/src/controllers/otherControlSettingController.js
+++ b/server/src/controllers/otherControlSettingController.js
@@ -1,0 +1,276 @@
+const defaultSettings = {
+  notification: {
+    enableEmail: true,
+    enableSMS: false,
+    defaultReminderMinutes: 30,
+    digestTime: '08:30',
+    escalationTargets: ['manager'],
+    frequency: 'immediate'
+  },
+  security: {
+    enforce2FA: true,
+    passwordExpiration: true,
+    passwordExpireDays: 90,
+    sessionTimeout: 30,
+    loginAlert: true,
+    maintenanceContacts: ['security'],
+    ipWhitelist: [
+      { label: '台北總部', address: '203.0.113.0/24' },
+      { label: '備援機房', address: '198.51.100.25' }
+    ]
+  },
+  customFields: [
+    {
+      label: '員工證字號',
+      fieldKey: 'nationalId',
+      type: 'text',
+      category: 'employee',
+      group: '基本資料',
+      required: true,
+      description: '供報稅與投保使用'
+    },
+    {
+      label: '制服尺寸',
+      fieldKey: 'uniformSize',
+      type: 'select',
+      category: 'employee',
+      group: '報到資訊',
+      required: false,
+      description: '入職前通知行政備貨'
+    },
+    {
+      label: '職稱選單 (C03)',
+      fieldKey: 'C03',
+      type: 'select',
+      category: 'dictionary',
+      group: '職務設定',
+      required: true,
+      description: '維護員工職稱清單'
+    },
+    {
+      label: '執業職稱選單 (C04)',
+      fieldKey: 'C04',
+      type: 'select',
+      category: 'dictionary',
+      group: '職務設定',
+      required: false,
+      description: '提供專業人員執業職稱選項'
+    },
+    {
+      label: '語言能力庫 (C05)',
+      fieldKey: 'C05',
+      type: 'composite',
+      category: 'dictionary',
+      group: '基本資料',
+      required: false,
+      description: '設定可勾選的語言能力與層級'
+    },
+    {
+      label: '身障等級 (C06)',
+      fieldKey: 'C06',
+      type: 'select',
+      category: 'dictionary',
+      group: '基本資料',
+      required: false,
+      description: '維護身心障礙手冊等級'
+    },
+    {
+      label: '身分類別 (C07)',
+      fieldKey: 'C07',
+      type: 'select',
+      category: 'dictionary',
+      group: '基本資料',
+      required: false,
+      description: '設定身份註記分類'
+    },
+    {
+      label: '教育程度 (C08)',
+      fieldKey: 'C08',
+      type: 'select',
+      category: 'dictionary',
+      group: '學歷資料',
+      required: false,
+      description: '維護教育程度選單'
+    },
+    {
+      label: '緊急聯絡人稱謂 (C09)',
+      fieldKey: 'C09',
+      type: 'select',
+      category: 'dictionary',
+      group: '聯絡資訊',
+      required: false,
+      description: '提供緊急聯絡人稱謂選項'
+    },
+    {
+      label: '教育訓練積分類別 (C10)',
+      fieldKey: 'C10',
+      type: 'select',
+      category: 'dictionary',
+      group: '教育訓練',
+      required: false,
+      description: '維護教育訓練積分類別'
+    },
+    {
+      label: '班別名稱 (C11)',
+      fieldKey: 'C11_name',
+      type: 'text',
+      category: 'dictionary',
+      group: '班別設定',
+      required: true,
+      description: '顯示於班別選單的名稱'
+    },
+    {
+      label: '班別說明 (C11)',
+      fieldKey: 'C11_content',
+      type: 'textarea',
+      category: 'dictionary',
+      group: '班別設定',
+      required: false,
+      description: '補充班別內容或注意事項'
+    },
+    {
+      label: '班別時段 (C11)',
+      fieldKey: 'C11_timeRange',
+      type: 'timeRange',
+      category: 'dictionary',
+      group: '班別設定',
+      required: true,
+      description: '設定班別的起訖時間'
+    },
+    {
+      label: '休息是否計薪 (C11)',
+      fieldKey: 'C11_paidBreak',
+      type: 'boolean',
+      category: 'dictionary',
+      group: '班別設定',
+      required: false,
+      description: '決定休息時間是否計薪'
+    },
+    {
+      label: '允許彈性時間 (C11)',
+      fieldKey: 'C11_allowFlexTime',
+      type: 'boolean',
+      category: 'dictionary',
+      group: '班別設定',
+      required: false,
+      description: '是否允許彈性前後時間'
+    },
+    {
+      label: '彈性區間分鐘數 (C11)',
+      fieldKey: 'C11_flexWindow',
+      type: 'number',
+      category: 'dictionary',
+      group: '班別設定',
+      required: false,
+      description: '可彈性調整的分鐘數'
+    },
+    {
+      label: '假別類別 (C12)',
+      fieldKey: 'C12',
+      type: 'select',
+      category: 'dictionary',
+      group: '假別設定',
+      required: true,
+      description: '維護假別類別與對應設定'
+    },
+    {
+      label: '加班原因 (C13)',
+      fieldKey: 'C13',
+      type: 'select',
+      category: 'dictionary',
+      group: '加班設定',
+      required: false,
+      description: '設定常用的加班原因'
+    },
+    {
+      label: '津貼項目 (C14)',
+      fieldKey: 'C14',
+      type: 'select',
+      category: 'dictionary',
+      group: '薪資設定',
+      required: false,
+      description: '維護津貼或補貼項目'
+    }
+  ],
+  integration: {
+    vendor: 'none',
+    syncSchedule: true,
+    syncPayroll: false,
+    webhookUrl: '',
+    autoRetry: true,
+    lastSync: '尚未同步',
+    statusMessage: '等待測試'
+  },
+  automationRules: [
+    {
+      name: '新員工自動啟用',
+      trigger: '建立員工主檔後',
+      status: 'enabled',
+      actions: ['assignDefaultRole', 'sendMail'],
+      notifyTargets: ['hr'],
+      description: '自動寄送歡迎信並指派 HR 夥伴'
+    },
+    {
+      name: '異常登入鎖定',
+      trigger: '帳號連續 5 次登入失敗',
+      status: 'disabled',
+      actions: ['lockAccount', 'sendMail'],
+      notifyTargets: ['admin', 'security'],
+      description: '通知系統管理員並暫停帳號'
+    }
+  ]
+}
+
+function cloneSettings() {
+  return JSON.parse(JSON.stringify(defaultSettings))
+}
+
+let otherControlSettings = cloneSettings()
+
+export function getOtherControlSettings(req, res) {
+  res.json(otherControlSettings)
+}
+
+export function updateNotificationSettings(req, res) {
+  otherControlSettings.notification = {
+    ...otherControlSettings.notification,
+    ...(req.body || {})
+  }
+  res.json(otherControlSettings.notification)
+}
+
+export function updateSecuritySettings(req, res) {
+  const payload = req.body || {}
+  const ipWhitelist = Array.isArray(payload.ipWhitelist)
+    ? payload.ipWhitelist
+    : otherControlSettings.security.ipWhitelist
+
+  otherControlSettings.security = {
+    ...otherControlSettings.security,
+    ...payload,
+    ipWhitelist
+  }
+
+  res.json(otherControlSettings.security)
+}
+
+export function updateIntegrationSettings(req, res) {
+  otherControlSettings.integration = {
+    ...otherControlSettings.integration,
+    ...(req.body || {})
+  }
+  res.json(otherControlSettings.integration)
+}
+
+export function replaceCustomFields(req, res) {
+  const { customFields } = req.body || {}
+  if (!Array.isArray(customFields)) {
+    return res.status(400).json({ error: 'customFields 必須為陣列' })
+  }
+  otherControlSettings.customFields = customFields
+  res.json(otherControlSettings.customFields)
+}
+
+export function resetOtherControlSettings() {
+  otherControlSettings = cloneSettings()
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -21,6 +21,7 @@ import subDepartmentRoutes from './routes/subDepartmentRoutes.js';
 import holidayRoutes from './routes/holidayRoutes.js';
 import deptScheduleRoutes from './routes/deptScheduleRoutes.js';
 import roleRoutes from './routes/roleRoutes.js';
+import otherControlSettingRoutes from './routes/otherControlSettingRoutes.js';
 
 import salarySettingRoutes from './routes/salarySettingRoutes.js';
 import breakSettingRoutes from './routes/breakSettingRoutes.js';
@@ -151,6 +152,12 @@ app.use(
 app.use('/api/insurance', authenticate, authorizeRoles('admin'), insuranceRoutes);
 app.use('/api/approvals', authenticate, approvalRoutes);
 app.use('/api/menu', authenticate, menuRoutes);
+app.use(
+  '/api/other-control-settings',
+  authenticate,
+  authorizeRoles('admin'),
+  otherControlSettingRoutes
+);
 app.use(
   '/api/departments',
   authenticate,

--- a/server/src/routes/otherControlSettingRoutes.js
+++ b/server/src/routes/otherControlSettingRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express'
+import {
+  getOtherControlSettings,
+  updateNotificationSettings,
+  updateSecuritySettings,
+  updateIntegrationSettings,
+  replaceCustomFields
+} from '../controllers/otherControlSettingController.js'
+
+const router = Router()
+
+router.get('/', getOtherControlSettings)
+router.put('/notification', updateNotificationSettings)
+router.put('/security', updateSecuritySettings)
+router.put('/integration', updateIntegrationSettings)
+router.put('/custom-fields', replaceCustomFields)
+
+export default router


### PR DESCRIPTION
## Summary
- 擴增其他控制設定畫面的欄位型別與預設自訂欄位，涵蓋 C03~C14 的字典需求
- 新增其他控制設定的伺服器控制器與路由，提供通知、安全、整合與自訂欄位的儲存接口
- 補上 OtherControlSetting 單元測試，驗證預設欄位與型別選項

## Testing
- `cd client && npm run test -- --run otherControlSetting`


------
https://chatgpt.com/codex/tasks/task_e_68d9916dee60832987e6fa1352e1cf60