### PR TITLE
feat: 串接個人檔案資訊至前台介面

### DIFF
--- a/client/src/stores/profile.js
+++ b/client/src/stores/profile.js
@@ -1,0 +1,58 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { apiFetch } from '../api'
+
+function getStoredEmployeeId() {
+  if (typeof window === 'undefined') return null
+  return (
+    window.sessionStorage?.getItem('employeeId') ||
+    window.localStorage?.getItem('employeeId') ||
+    null
+  )
+}
+
+export const useProfileStore = defineStore('profile', () => {
+  const profile = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function fetchProfile({ force = false } = {}) {
+    if (profile.value && !force) {
+      return profile.value
+    }
+    const employeeId = getStoredEmployeeId()
+    if (!employeeId) {
+      profile.value = null
+      error.value = new Error('缺少員工識別碼')
+      throw error.value
+    }
+    loading.value = true
+    error.value = null
+    try {
+      const res = await apiFetch(`/api/profile?employeeId=${encodeURIComponent(employeeId)}`)
+      if (!res.ok) {
+        throw new Error('讀取個人資料失敗')
+      }
+      const data = await res.json()
+      profile.value = data
+      return data
+    } catch (err) {
+      error.value = err
+      profile.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function setProfile(data) {
+    profile.value = data
+  }
+
+  function clearProfile() {
+    profile.value = null
+    error.value = null
+  }
+
+  return { profile, loading, error, fetchProfile, setProfile, clearProfile }
+})

--- a/client/tests/frontLayout.spec.js
+++ b/client/tests/frontLayout.spec.js
@@ -1,70 +1,190 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
-import { mount } from '@vue/test-utils'
-import FrontLayout from '../src/views/front/FrontLayout.vue'
-import { ref } from 'vue'
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMenuStore } from '../src/stores/menu'
+import { useProfileStore } from '../src/stores/profile'
 
-const push = vi.fn()
+defineElStubs()
 
-vi.mock('vue-router', () => ({
-  useRouter: () => ({ push }),
-  useRoute: () => ({ name: 'attendance' })
-}))
+function defineElStubs() {
+  globalThis.__EL_STUBS__ = {
+    'el-menu': {
+      template: '<nav class="el-menu"><slot /></nav>',
+    },
+    'el-menu-item': {
+      props: {
+        index: {
+          type: String,
+          required: false,
+        },
+      },
+      emits: ['click'],
+      template:
+        '<div class="el-menu-item" :data-index="index" @click="$emit(\'click\')"><slot /></div>',
+    },
+    'el-button': {
+      emits: ['click'],
+      template:
+        '<button type="button" class="el-button" @click="$emit(\'click\')"><slot /></button>',
+    },
+    'el-avatar': {
+      template: '<div class="el-avatar"><slot /></div>',
+    },
+    'el-icon': {
+      template: '<i class="el-icon"><slot /></i>',
+    },
+    'el-tooltip': {
+      props: {
+        content: {
+          type: String,
+          default: '',
+        },
+      },
+      template:
+        '<span class="el-tooltip" :data-content="content"><slot /></span>',
+    },
+    'el-descriptions': {
+      template: '<div class="el-descriptions"><slot /></div>',
+    },
+    'el-descriptions-item': {
+      props: {
+        label: {
+          type: String,
+          default: '',
+        },
+      },
+      template:
+        '<div class="el-descriptions-item"><span class="el-descriptions-item__label">{{ label }}</span><div class="el-descriptions-item__content"><slot /></div></div>',
+    },
+    'router-view': {
+      template: '<div class="router-view-stub"></div>',
+    },
+  }
+}
 
-vi.mock('../src/stores/menu', () => ({
-  useMenuStore: () => ({
-    items: ref([{ name: 'MySchedule', label: '我的排班' }]),
-    fetchMenu: vi.fn(),
-    setMenu: vi.fn(),
-  })
-}))
+const createProfile = () => ({
+  id: '1',
+  employeeId: '1',
+  name: '測試員工',
+  organizationName: '測試機構',
+  departmentName: '測試部門',
+  subDepartmentName: '測試小單位',
+  employeeNumber: '',
+  role: 'employee',
+  username: 'tester',
+})
+
+let FrontLayout
+let fetchProfileMock
+let clearProfileMock
+let profileData
+
+beforeAll(async () => {
+  FrontLayout = (await import('../src/views/front/FrontLayout.vue')).default
+})
 
 describe('FrontLayout manager button', () => {
   beforeEach(() => {
     localStorage.clear()
-    push.mockClear()
+    sessionStorage.clear()
+    fetchProfileMock = undefined
+    clearProfileMock = undefined
+    profileData = createProfile()
+    localStorage.setItem('employeeId', profileData.employeeId)
+
+    setActivePinia(createPinia())
+    const menuStore = useMenuStore()
+    menuStore.setMenu([
+      { name: 'MySchedule', label: '我的排班', icon: 'el-icon-calendar' },
+    ])
+    vi.spyOn(menuStore, 'fetchMenu').mockResolvedValue()
+
+    const profileStore = useProfileStore()
+    profileStore.setProfile(profileData)
+    fetchProfileMock = vi
+      .spyOn(profileStore, 'fetchProfile')
+      .mockImplementation(async () => {
+        profileStore.setProfile(profileData)
+        return profileData
+      })
+    clearProfileMock = vi
+      .spyOn(profileStore, 'clearProfile')
+      .mockImplementation(() => {
+        profileStore.setProfile(null)
+      })
   })
 
   afterAll(() => {
     vi.resetModules()
-    vi.unmock('vue-router')
-    vi.unmock('../src/stores/menu')
   })
 
-  function mountLayout() {
-    return mount(FrontLayout, {
-      global: { stubs: ['el-menu', 'el-menu-item', 'el-button', 'el-avatar', 'el-icon', 'router-view'] }
+  async function mountLayout() {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/attendance', name: 'attendance', component: { template: '<div />' } },
+        { path: '/myschedule', name: 'MySchedule', component: { template: '<div />' } },
+      ],
     })
+    await router.push({ name: 'attendance' })
+    await router.isReady()
+    const wrapper = mount(FrontLayout, {
+      global: {
+        plugins: [router],
+        stubs: globalThis.__EL_STUBS__,
+      },
+    })
+    await flushPromises()
+    return { wrapper, router }
   }
 
   it('管理員不顯示按鈕並可登出', async () => {
     localStorage.setItem('role', 'admin')
     localStorage.setItem('username', 'boss')
-    const wrapper = mountLayout()
-    await wrapper.vm.$nextTick()
+    const { wrapper, router } = await mountLayout()
+    const pushSpy = vi.spyOn(router, 'push')
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
     await wrapper.find('.logout-btn').trigger('click')
-    expect(push).toHaveBeenCalledWith('/')
+    expect(pushSpy).toHaveBeenCalledWith('/')
     expect(localStorage.getItem('role')).toBeNull()
     expect(localStorage.getItem('username')).toBeNull()
+    expect(localStorage.getItem('employeeId')).toBeNull()
+    expect(fetchProfileMock).toHaveBeenCalled()
+    expect(clearProfileMock).toHaveBeenCalled()
   })
 
   it('主管不顯示按鈕', async () => {
     localStorage.setItem('role', 'supervisor')
-    const wrapper = mountLayout()
-    await wrapper.vm.$nextTick()
+    const { wrapper } = await mountLayout()
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
   })
 
-  it('員工不顯示按鈕', () => {
+  it('員工不顯示按鈕', async () => {
     localStorage.setItem('role', 'employee')
-    const wrapper = mountLayout()
+    const { wrapper } = await mountLayout()
     expect(wrapper.find('[data-test="manager-btn"]').exists()).toBe(false)
   })
 
   it('點選我的排班導向 MySchedule', async () => {
-    const wrapper = mountLayout()
-    await wrapper.vm.$nextTick()
-    await wrapper.find('el-menu-item-stub[index="MySchedule"]').trigger('click')
-    expect(push).toHaveBeenCalledWith({ name: 'MySchedule' })
+    const { wrapper, router } = await mountLayout()
+    const pushSpy = vi.spyOn(router, 'push')
+    await wrapper.find('[data-index="MySchedule"]').trigger('click')
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'MySchedule' })
+  })
+
+  it('載入後顯示個人資訊欄位', async () => {
+    const { wrapper } = await mountLayout()
+    expect(fetchProfileMock).toHaveBeenCalled()
+    const text = wrapper.text()
+    expect(text).toContain('機構')
+    expect(text).toContain('部門')
+    expect(text).toContain('小單位')
+    expect(text).toContain('姓名')
+    expect(text).toContain('測試機構')
+    expect(text).toContain('測試部門')
+    expect(text).toContain('測試小單位')
+    expect(text).toContain('測試員工')
   })
 })

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -2,8 +2,50 @@ import { Router } from 'express'
 import jwt from 'jsonwebtoken'
 import Employee from '../models/Employee.js'
 import { blacklistToken } from '../utils/tokenBlacklist.js'
+import { authenticate } from '../middleware/auth.js'
 
 const router = Router();
+
+function buildUserProfile(employee) {
+  if (!employee) return null
+
+  const getName = (entity) => {
+    if (!entity || typeof entity !== 'object') return ''
+    if ('name' in entity && entity.name) return entity.name
+    if ('unitName' in entity && entity.unitName) return entity.unitName
+    return ''
+  }
+
+  const department = employee.department
+  const subDepartment = employee.subDepartment
+
+  const organizationDoc =
+    department && typeof department === 'object' && 'organization' in department
+      ? department.organization
+      : null
+
+  const organizationName =
+    (organizationDoc &&
+    typeof organizationDoc === 'object' &&
+    'name' in organizationDoc
+      ? organizationDoc.name ?? ''
+      : '') || department?.unitName || employee.organization || ''
+
+  const idString = employee._id?.toString?.() ?? employee.id ?? ''
+  const employeeNumber = employee.employeeId ? String(employee.employeeId) : ''
+
+  return {
+    id: idString,
+    employeeId: idString,
+    employeeNumber,
+    role: employee.role,
+    username: employee.username,
+    name: employee.name ?? '',
+    organizationName,
+    departmentName: getName(department),
+    subDepartmentName: getName(subDepartment),
+  }
+}
 
 router.post('/login', async (req, res) => {
   const { username, password, role } = req.body
@@ -17,6 +59,19 @@ router.post('/login', async (req, res) => {
     return res.status(403).json({ error: 'Forbidden' })
   }
 
+  if (typeof employee.populate === 'function') {
+    try {
+      await employee.populate([
+        { path: 'department', populate: { path: 'organization' } },
+        { path: 'subDepartment' },
+      ])
+    } catch (err) {
+      // population 失敗時採用原始資料，避免登入流程中斷
+    }
+  }
+
+  const profile = buildUserProfile(employee)
+
   const token = jwt.sign(
     { id: employee._id, role: employee.role },
     process.env.JWT_SECRET || 'secret',
@@ -24,12 +79,7 @@ router.post('/login', async (req, res) => {
   )
   res.json({
     token,
-    user: {
-      id: employee._id,
-      employeeId: employee._id,
-      role: employee.role,
-      username: employee.username
-    }
+    user: profile
   })
 })
 
@@ -40,6 +90,45 @@ router.post('/logout', async (req, res) => {
     await blacklistToken(token)
   }
   res.status(204).end()
+})
+
+router.get('/profile', authenticate, async (req, res) => {
+  try {
+    const { employeeId } = req.query
+    const normalizedUserId = req.user?.id ? String(req.user.id) : null
+    if (employeeId && employeeId !== normalizedUserId) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+
+    const targetId = employeeId || normalizedUserId
+    if (!targetId) {
+      return res.status(400).json({ error: 'Missing employee id' })
+    }
+
+    let employee = await Employee.findById(targetId)
+    if (!employee) {
+      return res.status(404).json({ error: 'Employee not found' })
+    }
+
+    if (typeof employee.populate === 'function') {
+      try {
+        employee = await employee.populate([
+          { path: 'department', populate: { path: 'organization' } },
+          { path: 'subDepartment' },
+        ])
+      } catch (err) {
+        // 忽略 population 失敗的情況，改用原始欄位
+      }
+    }
+
+    const profile = buildUserProfile(employee)
+    res.json(profile)
+  } catch (error) {
+    if (error?.name === 'CastError') {
+      return res.status(400).json({ error: 'Invalid employee id' })
+    }
+    res.status(500).json({ error: 'Failed to fetch profile' })
+  }
 })
 
 export default router;

--- a/server/tests/auth.integration.test.js
+++ b/server/tests/auth.integration.test.js
@@ -42,8 +42,17 @@ describe('Auth Integration', () => {
     expect(mockEmployee.findOne).toHaveBeenCalledWith({ username: 'tester' })
     expect(selectMock).toHaveBeenCalledWith('+passwordHash')
     expect(res.status).toBe(200)
-    expect(res.body.user).toMatchObject({ username: 'tester' })
+    expect(res.body.user).toMatchObject({
+      username: 'tester',
+      name: 'Tester',
+      role: 'employee',
+      organizationName: '',
+      departmentName: '',
+      subDepartmentName: '',
+      employeeNumber: '',
+    })
     expect(res.body.user.employeeId).toBe(String(employee._id))
+    expect(res.body.user.id).toBe(String(employee._id))
     expect(res.body.token).toBeDefined()
   })
 })

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -45,6 +45,7 @@ describe('Auth API', () => {
           _id: '1',
           role: 'employee',
           username: 'john',
+          name: 'John Doe',
           verifyPassword: (pwd) => pwd === 'pass'
         })
     });
@@ -52,7 +53,17 @@ describe('Auth API', () => {
     const res = await request(app).post('/api/login').send({ username: 'john', password: 'pass', role: 'employee' });
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    expect(res.body.user).toEqual({ id: '1', employeeId: '1', role: 'employee', username: 'john' });
+    expect(res.body.user).toEqual({
+      id: '1',
+      employeeId: '1',
+      employeeNumber: '',
+      role: 'employee',
+      username: 'john',
+      name: 'John Doe',
+      organizationName: '',
+      departmentName: '',
+      subDepartmentName: '',
+    });
     expect(signSpy).toHaveBeenCalledWith({ id: '1', role: 'employee' }, 'secret', { expiresIn: '1h' });
     signSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- 新增後端登入回應與 /api/profile 介面，統一整理員工的機構與部門資訊
- 建立前端 profile store 並在 FrontLayout 於掛載時載入個人資料，左側面板加入姓名與組織欄位顯示
- 重構 FrontLayout 測試，使用自訂 Element Plus stub 驗證菜單導向與個人資訊文字

## Testing
- `npm --prefix client test -- frontLayout.spec.js`
- `npm test` *(client 端既有測試出現 esbuild TextEncoder 例外與多項版面測試失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68d98f9f5cc88329b5d5b86d0c7590f8