### PR TITLE
feat: 支援其他控制設定的項目字典 API

### DIFF
--- a/server/src/controllers/otherControlSettingController.js
+++ b/server/src/controllers/otherControlSettingController.js
@@ -192,6 +192,23 @@ const defaultSettings = {
       description: '維護津貼或補貼項目'
     }
   ],
+  itemSettings: {
+    C03: ['助理', '專員', '經理'],
+    C04: ['護理師', '藥師', '工程師'],
+    C05: [
+      { label: '英文', levels: ['A1', 'B2', 'C1'] },
+      { label: '日文', levels: ['N3', 'N2', 'N1'] }
+    ],
+    C06: ['第一類', '第二類', '第三類'],
+    C07: ['一般員工', '派遣', '實習'],
+    C08: ['高中', '大學', '碩士', '博士'],
+    C09: ['父親', '母親', '配偶', '其他'],
+    C10: ['新進訓練', '專業課程', '領導力'],
+    C11: ['日班', '晚班', '大夜班'],
+    C12: ['特休假', '病假', '事假'],
+    C13: ['專案趕工', '系統維護', '例行支援'],
+    C14: ['交通補助', '餐費補助', '職務津貼']
+  },
   integration: {
     vendor: 'none',
     syncSchedule: true,
@@ -260,6 +277,32 @@ export function updateIntegrationSettings(req, res) {
     ...(req.body || {})
   }
   res.json(otherControlSettings.integration)
+}
+
+export function getItemSettings(req, res) {
+  res.json(otherControlSettings.itemSettings)
+}
+
+export function updateItemSettings(req, res) {
+  const payload = req.body
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return res.status(400).json({ error: 'itemSettings 必須為物件' })
+  }
+
+  const invalidEntry = Object.entries(payload).find(([, value]) => !Array.isArray(value))
+
+  if (invalidEntry) {
+    const [key] = invalidEntry
+    return res.status(400).json({ error: `itemSettings.${key} 必須為陣列` })
+  }
+
+  otherControlSettings.itemSettings = {
+    ...otherControlSettings.itemSettings,
+    ...payload
+  }
+
+  res.json(otherControlSettings.itemSettings)
 }
 
 export function replaceCustomFields(req, res) {

--- a/server/src/routes/otherControlSettingRoutes.js
+++ b/server/src/routes/otherControlSettingRoutes.js
@@ -4,7 +4,9 @@ import {
   updateNotificationSettings,
   updateSecuritySettings,
   updateIntegrationSettings,
-  replaceCustomFields
+  replaceCustomFields,
+  getItemSettings,
+  updateItemSettings
 } from '../controllers/otherControlSettingController.js'
 
 const router = Router()
@@ -14,5 +16,7 @@ router.put('/notification', updateNotificationSettings)
 router.put('/security', updateSecuritySettings)
 router.put('/integration', updateIntegrationSettings)
 router.put('/custom-fields', replaceCustomFields)
+router.get('/item-settings', getItemSettings)
+router.put('/item-settings', updateItemSettings)
 
 export default router

--- a/server/tests/otherControlSetting.test.js
+++ b/server/tests/otherControlSetting.test.js
@@ -1,0 +1,79 @@
+import express from 'express'
+import request from 'supertest'
+
+import routes from '../src/routes/otherControlSettingRoutes.js'
+import { resetOtherControlSettings } from '../src/controllers/otherControlSettingController.js'
+
+const DEFAULT_ITEM_SETTINGS = {
+  C03: ['助理', '專員', '經理'],
+  C04: ['護理師', '藥師', '工程師'],
+  C05: [
+    { label: '英文', levels: ['A1', 'B2', 'C1'] },
+    { label: '日文', levels: ['N3', 'N2', 'N1'] }
+  ],
+  C06: ['第一類', '第二類', '第三類'],
+  C07: ['一般員工', '派遣', '實習'],
+  C08: ['高中', '大學', '碩士', '博士'],
+  C09: ['父親', '母親', '配偶', '其他'],
+  C10: ['新進訓練', '專業課程', '領導力'],
+  C11: ['日班', '晚班', '大夜班'],
+  C12: ['特休假', '病假', '事假'],
+  C13: ['專案趕工', '系統維護', '例行支援'],
+  C14: ['交通補助', '餐費補助', '職務津貼']
+}
+
+const app = express()
+app.use(express.json())
+app.use('/api/other-control-settings', routes)
+
+describe('Other Control Settings - Item Settings', () => {
+  beforeEach(() => {
+    resetOtherControlSettings()
+  })
+
+  it('回傳整體設定時包含 itemSettings 預設值', async () => {
+    const res = await request(app).get('/api/other-control-settings')
+
+    expect(res.status).toBe(200)
+    expect(res.body.itemSettings).toEqual(DEFAULT_ITEM_SETTINGS)
+  })
+
+  it('可單獨取得 itemSettings 字典資料', async () => {
+    const res = await request(app).get('/api/other-control-settings/item-settings')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(DEFAULT_ITEM_SETTINGS)
+  })
+
+  it('拒絕非陣列的字典項目', async () => {
+    const res = await request(app)
+      .put('/api/other-control-settings/item-settings')
+      .send({ C03: 'not-array' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('C03')
+  })
+
+  it('更新後回傳覆寫後的 itemSettings', async () => {
+    const payload = {
+      C03: ['實習生', '正職'],
+      C05: [
+        { label: '英文', levels: ['A2', 'B1'] },
+        { label: '西班牙文', levels: ['初階', '進階'] }
+      ]
+    }
+
+    const updateRes = await request(app)
+      .put('/api/other-control-settings/item-settings')
+      .send(payload)
+
+    expect(updateRes.status).toBe(200)
+    expect(updateRes.body).toMatchObject(payload)
+
+    const fetchRes = await request(app).get('/api/other-control-settings/item-settings')
+
+    expect(fetchRes.status).toBe(200)
+    expect(fetchRes.body).toMatchObject(payload)
+    expect(Object.keys(fetchRes.body)).toEqual(expect.arrayContaining(Object.keys(DEFAULT_ITEM_SETTINGS)))
+  })
+})


### PR DESCRIPTION
## Summary
- 新增其他控制設定的 itemSettings 預設資料並一併複製
- 提供 itemSettings 的 GET/PUT API 與輸入驗證
- 補上整合測試涵蓋 itemSettings 取得與更新流程

## Testing
- npm test -- --runTestsByPath tests/otherControlSetting.test.js

------
https://chatgpt.com/codex/tasks/task_e_68daa3da481483299c04c5f2485466b2