### PR TITLE
精簡後台其他控制設定頁面

### DIFF
--- a/client/src/components/backComponents/OtherControlSetting.vue
+++ b/client/src/components/backComponents/OtherControlSetting.vue
@@ -3,118 +3,6 @@
     <h2>其他控制設定</h2>
 
     <el-tabs v-model="activeTab" type="border-card">
-      <el-tab-pane label="通知中心" name="notification">
-        <div class="tab-content">
-          <el-descriptions :column="2" title="目前通知策略" class="descriptions-block">
-            <el-descriptions-item label="Email 通知">{{ notificationForm.enableEmail ? '啟用' : '停用' }}</el-descriptions-item>
-            <el-descriptions-item label="SMS 通知">{{ notificationForm.enableSMS ? '啟用' : '停用' }}</el-descriptions-item>
-            <el-descriptions-item label="每日摘要時間">{{ notificationForm.digestTime || '未設定' }}</el-descriptions-item>
-            <el-descriptions-item label="預設提醒">提前 {{ notificationForm.defaultReminderMinutes }} 分鐘</el-descriptions-item>
-          </el-descriptions>
-
-          <el-divider content-position="left">編輯通知策略</el-divider>
-          <el-form :model="notificationForm" label-width="160px" class="form-layout">
-            <el-form-item label="啟用 Email 通知">
-              <el-switch v-model="notificationForm.enableEmail" active-text="啟用" inactive-text="停用" />
-            </el-form-item>
-            <el-form-item label="啟用 SMS 通知">
-              <el-switch v-model="notificationForm.enableSMS" active-text="啟用" inactive-text="停用" />
-            </el-form-item>
-            <el-form-item label="預設提醒(分鐘)">
-              <el-input-number v-model="notificationForm.defaultReminderMinutes" :min="0" :step="5" />
-            </el-form-item>
-            <el-form-item label="每日摘要時間">
-              <el-time-picker
-                v-model="notificationForm.digestTime"
-                placeholder="選擇時間"
-                format="HH:mm"
-                value-format="HH:mm"
-                :disabled="!notificationForm.enableEmail"
-              />
-            </el-form-item>
-            <el-form-item label="升級通知對象">
-              <el-select v-model="notificationForm.escalationTargets" multiple placeholder="選擇對象">
-                <el-option v-for="item in escalationOptions" :key="item.value" :label="item.label" :value="item.value" />
-              </el-select>
-            </el-form-item>
-            <el-form-item label="通知頻率">
-              <el-radio-group v-model="notificationForm.frequency">
-                <el-radio-button label="immediate">即時</el-radio-button>
-                <el-radio-button label="hourly">每小時彙整</el-radio-button>
-                <el-radio-button label="daily">每日彙整</el-radio-button>
-              </el-radio-group>
-            </el-form-item>
-            <el-form-item>
-              <el-button type="primary" @click="saveNotificationSetting">儲存通知設定</el-button>
-            </el-form-item>
-          </el-form>
-        </div>
-      </el-tab-pane>
-
-      <el-tab-pane label="安全控制" name="security">
-        <div class="tab-content">
-          <el-descriptions :column="2" title="目前安全概要" class="descriptions-block">
-            <el-descriptions-item label="雙因素驗證">{{ securityForm.enforce2FA ? '強制' : '選用' }}</el-descriptions-item>
-            <el-descriptions-item label="密碼有效天數">
-              {{ securityForm.passwordExpiration ? securityForm.passwordExpireDays + ' 天' : '不限制' }}
-            </el-descriptions-item>
-            <el-descriptions-item label="閒置登出">
-              {{ securityForm.sessionTimeout }} 分鐘
-            </el-descriptions-item>
-            <el-descriptions-item label="異常登入通知">{{ securityForm.loginAlert ? '啟用' : '停用' }}</el-descriptions-item>
-          </el-descriptions>
-
-          <el-divider content-position="left">編輯安全控制</el-divider>
-          <el-form :model="securityForm" label-width="180px" class="form-layout">
-            <el-form-item label="強制雙因素驗證">
-              <el-switch v-model="securityForm.enforce2FA" active-text="強制" inactive-text="選用" />
-            </el-form-item>
-            <el-form-item label="密碼期限">
-              <el-switch v-model="securityForm.passwordExpiration" active-text="啟用" inactive-text="停用" />
-            </el-form-item>
-            <el-form-item label="密碼有效天數">
-              <el-input-number v-model="securityForm.passwordExpireDays" :min="0" :disabled="!securityForm.passwordExpiration" />
-            </el-form-item>
-            <el-form-item label="閒置自動登出">
-              <el-slider
-                v-model="securityForm.sessionTimeout"
-                :min="5"
-                :max="120"
-                :step="5"
-                show-input
-              />
-            </el-form-item>
-            <el-form-item label="異常登入通知">
-              <el-switch v-model="securityForm.loginAlert" active-text="啟用" inactive-text="停用" />
-            </el-form-item>
-            <el-form-item label="維運通知人">
-              <el-select v-model="securityForm.maintenanceContacts" multiple placeholder="選擇人員">
-                <el-option v-for="item in securityContactOptions" :key="item.value" :label="item.label" :value="item.value" />
-              </el-select>
-            </el-form-item>
-            <el-form-item>
-              <el-button type="primary" @click="saveSecuritySetting">儲存安全設定</el-button>
-            </el-form-item>
-          </el-form>
-
-          <el-divider content-position="left">IP 限制</el-divider>
-          <div class="list-action-row">
-            <span class="hint">僅允許表列來源連線後台</span>
-            <el-button type="primary" @click="openIpDialog()">新增 IP</el-button>
-          </div>
-          <el-table :data="ipWhitelist" border>
-            <el-table-column prop="label" label="辨識名稱" width="180" />
-            <el-table-column prop="address" label="IP / 網段" />
-            <el-table-column label="操作" width="180">
-              <template #default="{ $index }">
-                <el-button size="small" @click="openIpDialog($index)">編輯</el-button>
-                <el-button size="small" type="danger" @click="removeIp($index)">刪除</el-button>
-              </template>
-            </el-table-column>
-          </el-table>
-        </div>
-      </el-tab-pane>
-
       <el-tab-pane label="字典項目" name="item-setting">
         <div class="tab-content">
           <el-alert
@@ -190,99 +78,7 @@
           </el-table>
         </div>
       </el-tab-pane>
-
-      <el-tab-pane label="整合與同步" name="integration">
-        <div class="tab-content">
-          <el-form :model="integrationForm" label-width="200px" class="form-layout">
-            <el-form-item label="預設整合廠商">
-              <el-select v-model="integrationForm.vendor" placeholder="選擇廠商">
-                <el-option v-for="vendor in vendorOptions" :key="vendor.value" :label="vendor.label" :value="vendor.value" />
-              </el-select>
-            </el-form-item>
-            <el-form-item label="啟用排班同步">
-              <el-switch v-model="integrationForm.syncSchedule" />
-            </el-form-item>
-            <el-form-item label="啟用薪資系統同步">
-              <el-switch v-model="integrationForm.syncPayroll" />
-            </el-form-item>
-            <el-form-item label="Webhook URL">
-              <el-input v-model="integrationForm.webhookUrl" placeholder="https://example.com/webhook" />
-            </el-form-item>
-            <el-form-item label="發生錯誤自動重試">
-              <el-switch v-model="integrationForm.autoRetry" />
-            </el-form-item>
-            <el-form-item label="最後一次同步">
-              <el-tag type="info">{{ integrationStatus.lastSync }}</el-tag>
-            </el-form-item>
-            <el-form-item>
-              <el-button type="primary" @click="saveIntegrationSetting">儲存整合設定</el-button>
-              <el-button @click="testIntegration">測試連線</el-button>
-            </el-form-item>
-          </el-form>
-          <el-alert
-            :title="`最近同步狀態：${integrationStatus.statusMessage}`"
-            type="success"
-            show-icon
-            class="status-alert"
-          />
-        </div>
-      </el-tab-pane>
-
-      <el-tab-pane label="自動化規則" name="automation">
-        <div class="tab-content">
-          <div class="list-action-row">
-            <el-button type="primary" @click="openRuleDialog()">新增規則</el-button>
-          </div>
-          <el-table :data="automationRules" border>
-            <el-table-column prop="name" label="規則名稱" width="220" />
-            <el-table-column prop="trigger" label="觸發條件" />
-            <el-table-column prop="status" label="狀態" width="120">
-              <template #default="{ row }">
-                <el-tag :type="row.status === 'enabled' ? 'success' : 'info'">
-                  {{ row.status === 'enabled' ? '啟用' : '停用' }}
-                </el-tag>
-              </template>
-            </el-table-column>
-            <el-table-column label="執行動作" width="220">
-              <template #default="{ row }">
-                {{ row.actions.map(action => actionLabelMap[action] || action).join('、') }}
-              </template>
-            </el-table-column>
-            <el-table-column label="通知對象" width="180">
-              <template #default="{ row }">
-                {{ row.notifyTargets.map(target => notifyTargetMap[target] || target).join('、') }}
-              </template>
-            </el-table-column>
-            <el-table-column label="操作" width="220">
-              <template #default="{ row, $index }">
-                <el-button size="small" @click="toggleRuleStatus($index)">
-                  {{ row.status === 'enabled' ? '停用' : '啟用' }}
-                </el-button>
-                <el-button size="small" @click="openRuleDialog($index)">編輯</el-button>
-                <el-button size="small" type="danger" @click="removeRule($index)">刪除</el-button>
-              </template>
-            </el-table-column>
-          </el-table>
-        </div>
-      </el-tab-pane>
     </el-tabs>
-
-    <el-dialog v-model="ipDialogVisible" title="IP 白名單" width="420px">
-      <el-form :model="ipForm" label-width="100px">
-        <el-form-item label="名稱">
-          <el-input v-model="ipForm.label" placeholder="如：總部辦公室" />
-        </el-form-item>
-        <el-form-item label="IP/網段">
-          <el-input v-model="ipForm.address" placeholder="192.168.1.1 或 203.0.113.0/24" />
-        </el-form-item>
-      </el-form>
-      <template #footer>
-        <span class="dialog-footer">
-          <el-button @click="ipDialogVisible = false">取消</el-button>
-          <el-button type="primary" @click="saveIp">儲存</el-button>
-        </span>
-      </template>
-    </el-dialog>
 
     <el-dialog v-model="optionDialogVisible" :title="optionDialogTitle" width="420px">
       <el-form :model="optionForm" label-width="100px">
@@ -338,42 +134,6 @@
         </span>
       </template>
     </el-dialog>
-
-    <el-dialog v-model="ruleDialogVisible" title="自動化規則" width="520px">
-      <el-form :model="ruleForm" label-width="120px">
-        <el-form-item label="規則名稱">
-          <el-input v-model="ruleForm.name" />
-        </el-form-item>
-        <el-form-item label="觸發條件">
-          <el-input v-model="ruleForm.trigger" placeholder="例如：建立新員工資料" />
-        </el-form-item>
-        <el-form-item label="通知對象">
-          <el-select v-model="ruleForm.notifyTargets" multiple>
-            <el-option v-for="option in notifyTargetOptions" :key="option.value" :label="option.label" :value="option.value" />
-          </el-select>
-        </el-form-item>
-        <el-form-item label="執行動作">
-          <el-select v-model="ruleForm.actions" multiple>
-            <el-option v-for="option in actionOptions" :key="option.value" :label="option.label" :value="option.value" />
-          </el-select>
-        </el-form-item>
-        <el-form-item label="狀態">
-          <el-radio-group v-model="ruleForm.status">
-            <el-radio-button label="enabled">啟用</el-radio-button>
-            <el-radio-button label="disabled">停用</el-radio-button>
-          </el-radio-group>
-        </el-form-item>
-        <el-form-item label="備註">
-          <el-input v-model="ruleForm.description" type="textarea" />
-        </el-form-item>
-      </el-form>
-      <template #footer>
-        <span class="dialog-footer">
-          <el-button @click="ruleDialogVisible = false">取消</el-button>
-          <el-button type="primary" @click="saveRule">儲存</el-button>
-        </span>
-      </template>
-    </el-dialog>
   </div>
 </template>
 
@@ -382,7 +142,7 @@ import { computed, onMounted, ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { apiFetch } from '../../api'
 
-const activeTab = ref('notification')
+const activeTab = ref('item-setting')
 
 const dictionaryDefinitions = ref([
   { key: 'C03', label: '職稱' },
@@ -436,44 +196,6 @@ const activeDictionaryLabel = computed(() => {
 const optionDialogTitle = computed(() =>
   editingOptionIndex.value > -1 ? '編輯字典選項' : '新增字典選項'
 )
-
-const notificationForm = ref({
-  enableEmail: true,
-  enableSMS: false,
-  defaultReminderMinutes: 30,
-  digestTime: '08:30',
-  escalationTargets: ['manager'],
-  frequency: 'immediate'
-})
-
-const escalationOptions = [
-  { label: '部門主管', value: 'manager' },
-  { label: 'HR 夥伴', value: 'hr' },
-  { label: '系統管理員', value: 'admin' }
-]
-
-const securityForm = ref({
-  enforce2FA: true,
-  passwordExpiration: true,
-  passwordExpireDays: 90,
-  sessionTimeout: 30,
-  loginAlert: true,
-  maintenanceContacts: ['security']
-})
-
-const securityContactOptions = [
-  { label: '資訊安全', value: 'security' },
-  { label: '系統管理員', value: 'admin' },
-  { label: 'HR 主管', value: 'hr' }
-]
-
-const ipWhitelist = ref([
-  { label: '台北總部', address: '203.0.113.0/24' },
-  { label: '備援機房', address: '198.51.100.25' }
-])
-const ipDialogVisible = ref(false)
-const editingIpIndex = ref(-1)
-const ipForm = ref({ label: '', address: '' })
 
 const fieldTypeOptions = [
   { label: '文字輸入', value: 'text' },
@@ -675,70 +397,6 @@ const fieldForm = ref({
   description: ''
 })
 
-const vendorOptions = [
-  { label: '無', value: 'none' },
-  { label: 'Workday', value: 'workday' },
-  { label: 'SAP SuccessFactors', value: 'sap' },
-  { label: 'Local ERP', value: 'local' }
-]
-const integrationForm = ref({
-  vendor: 'none',
-  syncSchedule: true,
-  syncPayroll: false,
-  webhookUrl: '',
-  autoRetry: true
-})
-
-const integrationStatus = ref({
-  lastSync: '尚未同步',
-  statusMessage: '等待測試'
-})
-
-const actionOptions = [
-  { label: '指派預設角色', value: 'assignDefaultRole' },
-  { label: '寄送通知郵件', value: 'sendMail' },
-  { label: '建立審核待辦', value: 'createApprovalTask' },
-  { label: '鎖定帳號', value: 'lockAccount' }
-]
-const actionLabelMap = actionOptions.reduce((map, option) => ({ ...map, [option.value]: option.label }), {})
-
-const notifyTargetOptions = [
-  { label: '部門主管', value: 'manager' },
-  { label: 'HR 夥伴', value: 'hr' },
-  { label: '系統管理員', value: 'admin' },
-  { label: '資安人員', value: 'security' }
-]
-const notifyTargetMap = notifyTargetOptions.reduce((map, option) => ({ ...map, [option.value]: option.label }), {})
-
-const automationRules = ref([
-  {
-    name: '新員工自動啟用',
-    trigger: '建立員工主檔後',
-    status: 'enabled',
-    actions: ['assignDefaultRole', 'sendMail'],
-    notifyTargets: ['hr'],
-    description: '自動寄送歡迎信並指派 HR 夥伴'
-  },
-  {
-    name: '異常登入鎖定',
-    trigger: '帳號連續 5 次登入失敗',
-    status: 'disabled',
-    actions: ['lockAccount', 'sendMail'],
-    notifyTargets: ['admin', 'security'],
-    description: '通知系統管理員並暫停帳號'
-  }
-])
-const ruleDialogVisible = ref(false)
-const editingRuleIndex = ref(-1)
-const ruleForm = ref({
-  name: '',
-  trigger: '',
-  actions: [],
-  notifyTargets: [],
-  status: 'enabled',
-  description: ''
-})
-
 onMounted(() => {
   loadSettings()
 })
@@ -748,15 +406,6 @@ async function loadSettings() {
     const res = await apiFetch('/api/other-control-settings', { method: 'GET' }, { autoRedirect: false })
     if (res.ok) {
       const data = await res.json()
-      if (data.notification) {
-        notificationForm.value = { ...notificationForm.value, ...data.notification }
-      }
-      if (data.security) {
-        securityForm.value = { ...securityForm.value, ...data.security }
-        if (Array.isArray(data.security.ipWhitelist)) {
-          ipWhitelist.value = data.security.ipWhitelist
-        }
-      }
       if (Array.isArray(data.customFields) && data.customFields.length) {
         customFields.value = data.customFields
       } else {
@@ -784,51 +433,9 @@ async function loadSettings() {
       } else {
         itemSettings.value = createDefaultItemSettings()
       }
-      if (data.integration) {
-        integrationForm.value = { ...integrationForm.value, ...data.integration }
-        integrationStatus.value = {
-          lastSync: data.integration.lastSync || integrationStatus.value.lastSync,
-          statusMessage: data.integration.statusMessage || integrationStatus.value.statusMessage
-        }
-      }
-      if (Array.isArray(data.automationRules)) {
-        automationRules.value = data.automationRules
-      }
     }
   } catch (error) {
     console.warn('載入其他控制設定失敗：', error)
-  }
-}
-
-async function saveNotificationSetting() {
-  try {
-    const res = await apiFetch('/api/other-control-settings/notification', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(notificationForm.value)
-    })
-    if (!res.ok) throw new Error('儲存失敗')
-    ElMessage.success('已儲存通知設定')
-  } catch (error) {
-    ElMessage.error('儲存通知設定時發生問題')
-  }
-}
-
-async function saveSecuritySetting() {
-  const payload = {
-    ...securityForm.value,
-    ipWhitelist: ipWhitelist.value
-  }
-  try {
-    const res = await apiFetch('/api/other-control-settings/security', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    })
-    if (!res.ok) throw new Error('儲存失敗')
-    ElMessage.success('已儲存安全設定')
-  } catch (error) {
-    ElMessage.error('儲存安全設定時發生問題')
   }
 }
 
@@ -921,40 +528,6 @@ async function removeOption(dictionaryKey, index) {
   }
 }
 
-function openIpDialog(index = -1) {
-  editingIpIndex.value = index
-  if (index > -1) {
-    ipForm.value = { ...ipWhitelist.value[index] }
-  } else {
-    ipForm.value = { label: '', address: '' }
-  }
-  ipDialogVisible.value = true
-}
-
-async function saveIp() {
-  if (!ipForm.value.label || !ipForm.value.address) {
-    ElMessage.warning('請填寫完整的 IP 資訊')
-    return
-  }
-  if (editingIpIndex.value > -1) {
-    ipWhitelist.value.splice(editingIpIndex.value, 1, { ...ipForm.value })
-  } else {
-    ipWhitelist.value.push({ ...ipForm.value })
-  }
-  ipDialogVisible.value = false
-  ElMessage.success('已更新 IP 白名單')
-}
-
-async function removeIp(index) {
-  try {
-    await ElMessageBox.confirm('確定要移除該 IP 限制嗎？', '提醒', { type: 'warning' })
-    ipWhitelist.value.splice(index, 1)
-    ElMessage.success('已移除 IP 限制')
-  } catch (error) {
-    // 使用者取消
-  }
-}
-
 function openFieldDialog(index = -1) {
   editingFieldIndex.value = index
   if (index > -1) {
@@ -996,88 +569,6 @@ async function removeField(index) {
     // 取消
   }
 }
-
-async function saveIntegrationSetting() {
-  try {
-    const res = await apiFetch('/api/other-control-settings/integration', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(integrationForm.value)
-    })
-    if (!res.ok) throw new Error('儲存失敗')
-    integrationStatus.value = {
-      lastSync: new Date().toLocaleString(),
-      statusMessage: '設定已更新，等待下一次同步'
-    }
-    ElMessage.success('已儲存整合設定')
-  } catch (error) {
-    ElMessage.error('儲存整合設定時發生問題')
-  }
-}
-
-async function testIntegration() {
-  integrationStatus.value = {
-    lastSync: new Date().toLocaleString(),
-    statusMessage: '測試連線成功'
-  }
-  ElMessage.success('測試連線請求已送出')
-}
-
-function openRuleDialog(index = -1) {
-  editingRuleIndex.value = index
-  if (index > -1) {
-    const target = automationRules.value[index]
-    ruleForm.value = {
-      name: target.name,
-      trigger: target.trigger,
-      actions: [...target.actions],
-      notifyTargets: [...target.notifyTargets],
-      status: target.status,
-      description: target.description || ''
-    }
-  } else {
-    ruleForm.value = {
-      name: '',
-      trigger: '',
-      actions: [],
-      notifyTargets: [],
-      status: 'enabled',
-      description: ''
-    }
-  }
-  ruleDialogVisible.value = true
-}
-
-async function saveRule() {
-  if (!ruleForm.value.name || !ruleForm.value.trigger) {
-    ElMessage.warning('請填寫規則名稱與觸發條件')
-    return
-  }
-  if (editingRuleIndex.value > -1) {
-    automationRules.value.splice(editingRuleIndex.value, 1, { ...ruleForm.value })
-  } else {
-    automationRules.value.push({ ...ruleForm.value })
-  }
-  ruleDialogVisible.value = false
-  ElMessage.success('已更新自動化規則')
-}
-
-async function removeRule(index) {
-  try {
-    await ElMessageBox.confirm('確定要刪除這條規則嗎？', '提醒', { type: 'warning' })
-    automationRules.value.splice(index, 1)
-    ElMessage.success('已刪除自動化規則')
-  } catch (error) {
-    // 取消
-  }
-}
-
-function toggleRuleStatus(index) {
-  const rule = automationRules.value[index]
-  const nextStatus = rule.status === 'enabled' ? 'disabled' : 'enabled'
-  automationRules.value.splice(index, 1, { ...rule, status: nextStatus })
-  ElMessage.success(`規則已${nextStatus === 'enabled' ? '啟用' : '停用'}`)
-}
 </script>
 
 <style scoped>
@@ -1092,14 +583,6 @@ function toggleRuleStatus(index) {
 
 .tab-content {
   padding: 16px 8px;
-}
-
-.form-layout {
-  max-width: 720px;
-}
-
-.descriptions-block {
-  margin-bottom: 16px;
 }
 
 .list-action-row {
@@ -1145,10 +628,6 @@ function toggleRuleStatus(index) {
 
 .dictionary-select {
   width: 200px;
-}
-
-.status-alert {
-  margin-top: 16px;
 }
 
 .dialog-footer {


### PR DESCRIPTION
## Summary
- 移除其他控制設定中的通知中心、安全控制、整合與同步、自動化規則等分頁與對應邏輯，保留核心的字典項目與自訂欄位管理
- 將預設分頁改為字典項目，整理預設字典與自訂欄位資料結構並清除不再使用的樣式

## Testing
- npm --prefix client test -- --run tests/otherControlSetting.spec.js
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68dc2f0caa508329aa9ba926a1c5d704