### PR TITLE
擴充其他控制設定字典定義至 C14 並補測試

### DIFF
--- a/client/src/components/backComponents/OtherControlSetting.vue
+++ b/client/src/components/backComponents/OtherControlSetting.vue
@@ -149,7 +149,14 @@ const dictionaryDefinitions = ref([
   { key: 'C04', label: '執業職稱' },
   { key: 'C05', label: '語言能力' },
   { key: 'C06', label: '身障等級' },
-  { key: 'C07', label: '身分類別' }
+  { key: 'C07', label: '身分類別' },
+  { key: 'C08', label: '教育程度' },
+  { key: 'C09', label: '緊急聯絡人稱謂' },
+  { key: 'C10', label: '教育訓練積分類別' },
+  { key: 'C11', label: '班別設定' },
+  { key: 'C12', label: '假別類別' },
+  { key: 'C13', label: '加班原因' },
+  { key: 'C14', label: '津貼項目' }
 ])
 
 function pickFirstString(...values) {
@@ -184,33 +191,62 @@ function normalizeDictionaryOption(option) {
   return { name: '', code: '' }
 }
 
+const defaultDictionaryOptions = {
+  C03: [
+    { name: '人資專員', code: 'HR-S' },
+    { name: '工程師', code: 'ENG' }
+  ],
+  C04: [
+    { name: '護理師', code: 'NURSE' },
+    { name: '會計師', code: 'CPA' }
+  ],
+  C05: [
+    { name: '英文 — 流利', code: 'EN_FL' },
+    { name: '日文 — 進階', code: 'JP_ADV' }
+  ],
+  C06: [
+    { name: '第一類中度', code: 'DISA_MID' },
+    { name: '第二類輕度', code: 'DISA_LIGHT' }
+  ],
+  C07: [
+    { name: '正式員工', code: 'FULLTIME' },
+    { name: '約聘人員', code: 'CONTRACT' }
+  ],
+  C08: [
+    { name: '博士', code: 'PHD' },
+    { name: '大學', code: 'BACHELOR' }
+  ],
+  C09: [
+    { name: '先生', code: 'MR' },
+    { name: '女士', code: 'MS' }
+  ],
+  C10: [
+    { name: '專業課程', code: 'PROFESSIONAL' },
+    { name: '基礎課程', code: 'BASIC' }
+  ],
+  C11: [
+    { name: '日班', code: 'DAY' },
+    { name: '晚班', code: 'NIGHT' }
+  ],
+  C12: [
+    { name: '特休假', code: 'ANNUAL' },
+    { name: '病假', code: 'SICK' }
+  ],
+  C13: [
+    { name: '專案需求', code: 'PROJECT' },
+    { name: '排班調整', code: 'SCHEDULE' }
+  ],
+  C14: [
+    { name: '交通津貼', code: 'TRAFFIC' },
+    { name: '餐費補助', code: 'MEAL' }
+  ]
+}
+
 function createDefaultItemSettings() {
-  const defaults = {
-    C03: [
-      { name: '人資專員', code: 'HR-S' },
-      { name: '工程師', code: 'ENG' }
-    ],
-    C04: [
-      { name: '護理師', code: 'NURSE' },
-      { name: '會計師', code: 'CPA' }
-    ],
-    C05: [
-      { name: '英文 — 流利', code: 'EN_FL' },
-      { name: '日文 — 進階', code: 'JP_ADV' }
-    ],
-    C06: [
-      { name: '第一類中度', code: 'DISA_MID' },
-      { name: '第二類輕度', code: 'DISA_LIGHT' }
-    ],
-    C07: [
-      { name: '正式員工', code: 'FULLTIME' },
-      { name: '約聘人員', code: 'CONTRACT' }
-    ]
-  }
+  const defaults = {}
   dictionaryDefinitions.value.forEach(dict => {
-    if (!defaults[dict.key]) {
-      defaults[dict.key] = []
-    }
+    const baseOptions = defaultDictionaryOptions[dict.key] || []
+    defaults[dict.key] = baseOptions.map(option => normalizeDictionaryOption(option))
   })
   return defaults
 }

--- a/client/tests/otherControlSetting.spec.js
+++ b/client/tests/otherControlSetting.spec.js
@@ -48,6 +48,53 @@ describe('OtherControlSetting custom field defaults', () => {
     expect(keyTypeMap.C14).toBe('select')
   })
 
+  it('dictionaryDefinitions covers C03~C14 with correct labels', async () => {
+    const wrapper = mount(OtherControlSetting, { global: { plugins: [ElementPlus] } })
+    await flushPromises()
+
+    const expectedPairs = [
+      { key: 'C03', label: '職稱' },
+      { key: 'C04', label: '執業職稱' },
+      { key: 'C05', label: '語言能力' },
+      { key: 'C06', label: '身障等級' },
+      { key: 'C07', label: '身分類別' },
+      { key: 'C08', label: '教育程度' },
+      { key: 'C09', label: '緊急聯絡人稱謂' },
+      { key: 'C10', label: '教育訓練積分類別' },
+      { key: 'C11', label: '班別設定' },
+      { key: 'C12', label: '假別類別' },
+      { key: 'C13', label: '加班原因' },
+      { key: 'C14', label: '津貼項目' }
+    ]
+
+    expect(wrapper.vm.dictionaryDefinitions).toEqual(expect.arrayContaining(expectedPairs))
+  })
+
+  it('renders dictionary select options with proper labels for C08 以後', async () => {
+    const wrapper = mount(OtherControlSetting, { attachTo: document.body, global: { plugins: [ElementPlus] } })
+    await flushPromises()
+
+    const trigger = wrapper.find('.dictionary-select .el-select__wrapper')
+    await trigger.trigger('click')
+    await flushPromises()
+
+    const dropdownItems = Array.from(document.querySelectorAll('.el-select-dropdown__item'))
+    const optionTexts = dropdownItems.map(item => item.textContent?.trim())
+    const expectedLabels = [
+      'C08 教育程度',
+      'C09 緊急聯絡人稱謂',
+      'C10 教育訓練積分類別',
+      'C11 班別設定',
+      'C12 假別類別',
+      'C13 加班原因',
+      'C14 津貼項目'
+    ]
+
+    expect(optionTexts).toEqual(expect.arrayContaining(expectedLabels))
+
+    wrapper.unmount()
+  })
+
   it('supports extended field type options when adding a new field', async () => {
     const wrapper = mount(OtherControlSetting, { global: { plugins: [ElementPlus] } })
     await flushPromises()


### PR DESCRIPTION
## Summary
- 擴充其他控制設定的字典定義涵蓋 C03~C14，並同步預設選項生成
- 調整預設項目初始化流程，確保新字典鍵套用並與後端資料整合
- 新增針對字典下拉標籤的前端測試，驗證 C08 以後選項顯示中文標籤

## Testing
- npx vitest run tests/otherControlSetting.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b8b0c8708329a06a6bca7f86448b