### PR TITLE
擴充報表模板設定與新增測試

### DIFF
--- a/client/src/components/backComponents/ReportManagementSetting.vue
+++ b/client/src/components/backComponents/ReportManagementSetting.vue
@@ -1,78 +1,113 @@
 <!-- src/Components/backComponents/ReportManagementSetting.vue -->
 
 <template>
-    <div class="report-management-setting">
-      <h2>報表管理設定</h2>
-  
-      <el-tabs v-model="activeTab" type="card">
-        <!-- 1) 報表模板管理 -->
-        <el-tab-pane label="報表模板管理" name="template">
-          <div class="tab-content">
-            <el-button type="primary" @click="openTemplateDialog()">新增報表模板</el-button>
-            <el-table :data="reportTemplates" style="margin-top: 20px;">
-              <el-table-column prop="name" label="報表名稱" width="180"></el-table-column>
-              <el-table-column prop="type" label="類型" width="120"></el-table-column>
-              <el-table-column prop="fields" label="欄位數">
-                <template #default="{ row }">
-                  <!-- 顯示欄位陣列長度 -->
-                  {{ row.fields.length }} 項
-                </template>
-              </el-table-column>
-              <el-table-column label="操作" width="180">
-                <template #default="{ row, $index }">
-                  <el-button type="primary" @click="openTemplateDialog($index)">編輯</el-button>
-                  <el-button type="danger" @click="deleteTemplate($index)">刪除</el-button>
-                </template>
-              </el-table-column>
-            </el-table>
-  
-            <!-- 新增/編輯 報表模板 Dialog -->
-            <el-dialog v-model="templateDialogVisible" title="報表模板設定" width="600px">
-              <el-form :model="templateForm" label-width="120px">
-                <el-form-item label="報表名稱">
-                  <el-input v-model="templateForm.name" placeholder="如：出勤統計報表 / 請假統計 / 薪資明細..."></el-input>
-                </el-form-item>
-                <el-form-item label="類型">
-                  <el-select v-model="templateForm.type" placeholder="選擇報表類型">
-                    <el-option label="出勤" value="出勤" />
-                    <el-option label="請假" value="請假" />
-                    <el-option label="加班/補休" value="加班補休" />
-                    <el-option label="薪資" value="薪資" />
-                    <el-option label="其他" value="其他" />
-                  </el-select>
-                </el-form-item>
-                <el-form-item label="欄位列表">
-                  <div class="field-list">
-                    <el-tag
-                      v-for="(field, idx) in templateForm.fields"
-                      :key="idx"
-                      closable
-                      @close="removeField(idx)"
-                      style="margin: 4px;"
-                    >
-                      {{ field }}
-                    </el-tag>
-                    <el-input
-                      v-model="newField"
-                      placeholder="輸入欄位名稱後按 Enter"
-                      @keyup.enter="addField"
-                      style="width: 100%; margin-top: 4px;"
-                    />
-                  </div>
-                </el-form-item>
-              </el-form>
-              <span slot="footer" class="dialog-footer">
+  <div class="report-management-setting">
+    <h2>報表管理設定</h2>
+
+    <el-tabs v-model="activeTab" type="card">
+      <!-- 1) 報表模板管理 -->
+      <el-tab-pane label="報表模板管理" name="template">
+        <div class="tab-content">
+          <el-button type="primary" @click="openTemplateDialog()">新增報表模板</el-button>
+          <el-table
+            :data="reportTemplates"
+            style="margin-top: 20px;"
+            v-loading="isLoading"
+            highlight-current-row
+            row-key="id"
+            :current-row-key="selectedTemplateId"
+            empty-text="尚無報表模板"
+            @current-change="handleTemplateChange"
+          >
+            <el-table-column prop="name" label="報表名稱" width="180" />
+            <el-table-column prop="type" label="類型" width="120" />
+            <el-table-column prop="fields" label="欄位數">
+              <template #default="{ row }">
+                {{ row.fields.length }} 項
+              </template>
+            </el-table-column>
+            <el-table-column label="操作" width="200">
+              <template #default="{ row }">
+                <el-button type="primary" @click="openTemplateDialog(row)">編輯</el-button>
+                <el-button type="danger" @click="deleteTemplate(row)">刪除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+
+          <el-alert
+            v-if="currentTemplate"
+            type="info"
+            :closable="false"
+            style="margin-top: 16px;"
+            :title="`目前選擇模板：${currentTemplate.name}`"
+          />
+          <el-alert
+            v-else
+            type="info"
+            :closable="false"
+            style="margin-top: 16px;"
+            title="請先新增報表模板"
+          />
+
+          <el-dialog v-model="templateDialogVisible" title="報表模板設定" width="600px">
+            <el-form :model="templateForm" label-width="120px">
+              <el-form-item label="報表名稱">
+                <el-input v-model="templateForm.name" placeholder="如：出勤統計報表 / 請假統計 / 薪資明細..."></el-input>
+              </el-form-item>
+              <el-form-item label="類型">
+                <el-select v-model="templateForm.type" placeholder="選擇報表類型">
+                  <el-option label="出勤" value="出勤" />
+                  <el-option label="請假" value="請假" />
+                  <el-option label="加班/補休" value="加班補休" />
+                  <el-option label="薪資" value="薪資" />
+                  <el-option label="其他" value="其他" />
+                </el-select>
+              </el-form-item>
+              <el-form-item label="欄位列表">
+                <div class="field-list">
+                  <el-tag
+                    v-for="(field, idx) in templateForm.fields"
+                    :key="idx"
+                    closable
+                    @close="removeField(idx)"
+                    style="margin: 4px;"
+                  >
+                    {{ field }}
+                  </el-tag>
+                  <el-input
+                    v-model="newField"
+                    placeholder="輸入欄位名稱後按 Enter"
+                    @keyup.enter="addField"
+                    style="width: 100%; margin-top: 4px;"
+                  />
+                </div>
+              </el-form-item>
+            </el-form>
+            <template #footer>
+              <span class="dialog-footer">
                 <el-button @click="templateDialogVisible = false">取消</el-button>
-                <el-button type="primary" @click="saveTemplate">儲存</el-button>
+                <el-button type="primary" :loading="savingTemplate" @click="saveTemplate">儲存</el-button>
               </span>
-            </el-dialog>
-          </div>
-        </el-tab-pane>
-  
-        <!-- 2) 匯出格式與樣式 -->
-        <el-tab-pane label="匯出格式與樣式" name="export">
-          <div class="tab-content">
+            </template>
+          </el-dialog>
+        </div>
+      </el-tab-pane>
+
+      <!-- 2) 匯出格式與樣式 -->
+      <el-tab-pane label="匯出格式與樣式" name="export">
+        <div class="tab-content">
+          <template v-if="reportTemplates.length">
             <el-form :model="exportForm" label-width="160px">
+              <el-form-item label="選擇模板">
+                <el-select v-model="selectedTemplateId" placeholder="選擇報表模板">
+                  <el-option
+                    v-for="template in reportTemplates"
+                    :key="template.id"
+                    :label="template.name"
+                    :value="template.id"
+                  />
+                </el-select>
+              </el-form-item>
               <el-form-item label="支援匯出格式">
                 <el-checkbox-group v-model="exportForm.formats">
                   <el-checkbox label="PDF" />
@@ -87,16 +122,39 @@
                 <el-input v-model="exportForm.footerNote" placeholder="如：機密文件/僅供內部參考"></el-input>
               </el-form-item>
               <el-form-item>
-                <el-button type="primary" @click="saveExportSetting">儲存匯出設定</el-button>
+                <el-button
+                  type="primary"
+                  :disabled="!currentTemplate"
+                  :loading="exportSaving"
+                  @click="saveExportSetting"
+                >儲存匯出設定</el-button>
               </el-form-item>
             </el-form>
-          </div>
-        </el-tab-pane>
-  
-        <!-- 3) 權限與範圍設定 -->
-        <el-tab-pane label="權限與範圍" name="permission">
-          <div class="tab-content">
+          </template>
+          <el-alert
+            v-else
+            type="info"
+            :closable="false"
+            title="請先新增報表模板"
+          />
+        </div>
+      </el-tab-pane>
+
+      <!-- 3) 權限與範圍設定 -->
+      <el-tab-pane label="權限與範圍" name="permission">
+        <div class="tab-content">
+          <template v-if="reportTemplates.length">
             <el-form :model="permissionForm" label-width="180px">
+              <el-form-item label="選擇模板">
+                <el-select v-model="selectedTemplateId" placeholder="選擇報表模板">
+                  <el-option
+                    v-for="template in reportTemplates"
+                    :key="template.id"
+                    :label="template.name"
+                    :value="template.id"
+                  />
+                </el-select>
+              </el-form-item>
               <el-form-item label="主管可查部門彙總報表">
                 <el-switch v-model="permissionForm.supervisorDept" />
               </el-form-item>
@@ -107,20 +165,43 @@
                 <el-switch v-model="permissionForm.employeeDownload" />
               </el-form-item>
               <el-form-item label="報表歷史可查詢 (月)">
-                <el-input-number v-model="permissionForm.historyMonths" :min="1" />
+                <el-input-number v-model="permissionForm.historyMonths" :min="0" />
                 <small>可查詢往前幾個月報表？</small>
               </el-form-item>
               <el-form-item>
-                <el-button type="primary" @click="savePermission">儲存權限設定</el-button>
+                <el-button
+                  type="primary"
+                  :disabled="!currentTemplate"
+                  :loading="permissionSaving"
+                  @click="savePermission"
+                >儲存權限設定</el-button>
               </el-form-item>
             </el-form>
-          </div>
-        </el-tab-pane>
-  
-        <!-- 4) 報表通知與寄送 (選擇性) -->
-        <el-tab-pane label="通知與寄送" name="notification">
-          <div class="tab-content">
+          </template>
+          <el-alert
+            v-else
+            type="info"
+            :closable="false"
+            title="請先新增報表模板"
+          />
+        </div>
+      </el-tab-pane>
+
+      <!-- 4) 報表通知與寄送 (選擇性) -->
+      <el-tab-pane label="通知與寄送" name="notification">
+        <div class="tab-content">
+          <template v-if="reportTemplates.length">
             <el-form :model="notifyForm" label-width="160px">
+              <el-form-item label="選擇模板">
+                <el-select v-model="selectedTemplateId" placeholder="選擇報表模板">
+                  <el-option
+                    v-for="template in reportTemplates"
+                    :key="template.id"
+                    :label="template.name"
+                    :value="template.id"
+                  />
+                </el-select>
+              </el-form-item>
               <el-form-item label="自動寄送報表">
                 <el-switch v-model="notifyForm.autoSend" />
                 <small>若啟用，可設定排程定期寄送</small>
@@ -141,133 +222,406 @@
                 </el-checkbox-group>
               </el-form-item>
               <el-form-item>
-                <el-button type="primary" @click="saveNotifySetting">儲存通知設定</el-button>
+                <el-button
+                  type="primary"
+                  :disabled="!currentTemplate"
+                  :loading="notifySaving"
+                  @click="saveNotifySetting"
+                >儲存通知設定</el-button>
               </el-form-item>
             </el-form>
-          </div>
-        </el-tab-pane>
-      </el-tabs>
-    </div>
-  </template>
-  
-  <script setup>
-  import { ref } from 'vue'
-  
-  const activeTab = ref('template')
-  
-  // =============== (1) 報表模板管理 ===============
-  const reportTemplates = ref([
-    {
-      name: '出勤統計報表',
-      type: '出勤',
-      fields: ['員工姓名', '部門', '應出勤天數', '實際出勤天數', '遲到次數', '早退次數']
-    },
-    {
-      name: '請假統計報表',
-      type: '請假',
-      fields: ['員工姓名', '部門', '請假天數', '請假類型', '剩餘特休']
-    }
-  ])
-  const templateDialogVisible = ref(false)
-  let templateEditIndex = null
-  
-  const templateForm = ref({
-    name: '',
-    type: '',
-    fields: []
-  })
-  
-  const newField = ref('')
-  
-  function openTemplateDialog(index = null) {
-    if (index !== null) {
-      // 編輯模式
-      templateEditIndex = index
-      templateForm.value = { ...reportTemplates.value[index] }
+          </template>
+          <el-alert
+            v-else
+            type="info"
+            :closable="false"
+            title="請先新增報表模板"
+          />
+        </div>
+      </el-tab-pane>
+    </el-tabs>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { apiFetch } from '../../api.js'
+
+const activeTab = ref('template')
+const isLoading = ref(false)
+const savingTemplate = ref(false)
+const exportSaving = ref(false)
+const permissionSaving = ref(false)
+const notifySaving = ref(false)
+
+const reportTemplates = ref([])
+const selectedTemplateId = ref(null)
+
+const templateDialogVisible = ref(false)
+let templateEditId = null
+
+const templateForm = ref(createTemplateForm())
+const newField = ref('')
+
+const exportForm = ref(createDefaultExportSettings())
+const permissionForm = ref(createDefaultPermissionSettings())
+const notifyForm = ref(createDefaultNotificationSettings())
+
+const currentTemplate = computed(() =>
+  reportTemplates.value.find((template) => template.id === selectedTemplateId.value) ?? null
+)
+
+watch(
+  currentTemplate,
+  (template) => {
+    if (template) {
+      exportForm.value = cloneWithDefaults(template.exportSettings, createDefaultExportSettings)
+      permissionForm.value = cloneWithDefaults(
+        template.permissionSettings,
+        createDefaultPermissionSettings
+      )
+      notifyForm.value = cloneWithDefaults(
+        template.notificationSettings,
+        createDefaultNotificationSettings
+      )
     } else {
-      // 新增模式
-      templateEditIndex = null
-      templateForm.value = { name: '', type: '', fields: [] }
+      exportForm.value = createDefaultExportSettings()
+      permissionForm.value = createDefaultPermissionSettings()
+      notifyForm.value = createDefaultNotificationSettings()
     }
+  },
+  { immediate: true }
+)
+
+watch(
+  () => notifyForm.value.autoSend,
+  (autoSend) => {
+    if (!autoSend) {
+      notifyForm.value.sendFrequency = ''
+      notifyForm.value.recipients = []
+    }
+  }
+)
+
+function createDefaultExportSettings() {
+  return { formats: [], includeLogo: false, footerNote: '' }
+}
+
+function createDefaultPermissionSettings() {
+  return { supervisorDept: false, hrAllDept: false, employeeDownload: false, historyMonths: 6 }
+}
+
+function createDefaultNotificationSettings() {
+  return { autoSend: false, sendFrequency: '', recipients: [] }
+}
+
+function cloneWithDefaults(value, defaultsFactory) {
+  const merged = { ...defaultsFactory(), ...(value || {}) }
+  return JSON.parse(JSON.stringify(merged))
+}
+
+function normalizeFieldsList(list) {
+  if (!Array.isArray(list)) return []
+  return list
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean)
+}
+
+function createTemplateForm(template) {
+  return {
+    name: template?.name ?? '',
+    type: template?.type ?? '',
+    fields: Array.isArray(template?.fields) ? [...template.fields] : [],
+    exportSettings: cloneWithDefaults(template?.exportSettings, createDefaultExportSettings),
+    permissionSettings: cloneWithDefaults(
+      template?.permissionSettings,
+      createDefaultPermissionSettings
+    ),
+    notificationSettings: cloneWithDefaults(
+      template?.notificationSettings,
+      createDefaultNotificationSettings
+    ),
+  }
+}
+
+function normalizeTemplateFromApi(template) {
+  if (!template) return null
+  const { id, _id, exportSettings, permissionSettings, notificationSettings, fields, ...rest } = template
+  return {
+    ...rest,
+    id: id ?? _id ?? '',
+    fields: normalizeFieldsList(fields),
+    exportSettings: cloneWithDefaults(exportSettings, createDefaultExportSettings),
+    permissionSettings: cloneWithDefaults(permissionSettings, createDefaultPermissionSettings),
+    notificationSettings: cloneWithDefaults(
+      notificationSettings,
+      createDefaultNotificationSettings
+    ),
+  }
+}
+
+function buildTemplatePayload(formValue) {
+  return {
+    name: formValue.name ?? '',
+    type: formValue.type ?? '',
+    fields: normalizeFieldsList(formValue.fields),
+    exportSettings: cloneWithDefaults(formValue.exportSettings, createDefaultExportSettings),
+    permissionSettings: cloneWithDefaults(
+      formValue.permissionSettings,
+      createDefaultPermissionSettings
+    ),
+    notificationSettings: cloneWithDefaults(
+      formValue.notificationSettings,
+      createDefaultNotificationSettings
+    ),
+  }
+}
+
+function syncSelectedTemplate(preferredId) {
+  const targetId = preferredId ?? selectedTemplateId.value
+  const match = targetId ? reportTemplates.value.find((template) => template.id === targetId) : null
+  if (match) {
+    selectedTemplateId.value = match.id
+  } else {
+    selectedTemplateId.value = reportTemplates.value[0]?.id ?? null
+  }
+}
+
+async function parseJson(response, fallbackMessage) {
+  let payload = null
+  try {
+    payload = await response.json()
+  } catch (error) {
+    if (response.ok) {
+      return null
+    }
+  }
+  if (!response.ok) {
+    const message = payload?.error || fallbackMessage
+    throw new Error(message)
+  }
+  return payload
+}
+
+async function loadReports() {
+  isLoading.value = true
+  const previousId = selectedTemplateId.value
+  try {
+    const res = await apiFetch('/api/reports')
+    const data = await parseJson(res, '載入報表模板失敗')
+    if (Array.isArray(data)) {
+      reportTemplates.value = data
+        .map((item) => normalizeTemplateFromApi(item))
+        .filter((item) => item)
+      syncSelectedTemplate(previousId)
+    } else {
+      reportTemplates.value = []
+      selectedTemplateId.value = null
+    }
+  } catch (error) {
+    ElMessage.error(error.message || '載入報表模板失敗')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function handleTemplateChange(row) {
+  if (row && row.id) {
+    selectedTemplateId.value = row.id
+  }
+}
+
+function openTemplateDialog(template) {
+  if (template && template.id) {
+    templateEditId = template.id
+    templateForm.value = createTemplateForm(template)
+    selectedTemplateId.value = template.id
+  } else {
+    templateEditId = null
+    templateForm.value = createTemplateForm()
+  }
+  newField.value = ''
+  templateDialogVisible.value = true
+}
+
+function addField() {
+  const value = newField.value.trim()
+  if (value) {
+    templateForm.value.fields.push(value)
     newField.value = ''
-    templateDialogVisible.value = true
   }
-  
-  function addField() {
-    if (newField.value.trim()) {
-      templateForm.value.fields.push(newField.value.trim())
-      newField.value = ''
+}
+
+function removeField(idx) {
+  templateForm.value.fields.splice(idx, 1)
+}
+
+function upsertTemplate(updated) {
+  const normalized = normalizeTemplateFromApi(updated)
+  if (!normalized || !normalized.id) return
+  const index = reportTemplates.value.findIndex((template) => template.id === normalized.id)
+  if (index === -1) {
+    reportTemplates.value.push(normalized)
+  } else {
+    reportTemplates.value.splice(index, 1, normalized)
+  }
+  syncSelectedTemplate(normalized.id)
+}
+
+async function saveTemplate() {
+  if (!templateForm.value.name.trim()) {
+    ElMessage.error('請輸入報表名稱')
+    return
+  }
+
+  savingTemplate.value = true
+  try {
+    const payload = buildTemplatePayload(templateForm.value)
+    const url = templateEditId ? `/api/reports/${templateEditId}` : '/api/reports'
+    const method = templateEditId ? 'PUT' : 'POST'
+    const res = await apiFetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    const data = await parseJson(
+      res,
+      templateEditId ? '更新報表模板失敗' : '新增報表模板失敗'
+    )
+    if (data) {
+      upsertTemplate(data)
     }
-  }
-  
-  function removeField(idx) {
-    templateForm.value.fields.splice(idx, 1)
-  }
-  
-  function saveTemplate() {
-    if (templateEditIndex === null) {
-      reportTemplates.value.push({ ...templateForm.value })
-    } else {
-      reportTemplates.value[templateEditIndex] = { ...templateForm.value }
-    }
+    ElMessage.success(templateEditId ? '報表模板已更新' : '報表模板已新增')
     templateDialogVisible.value = false
+  } catch (error) {
+    ElMessage.error(error.message || '儲存報表模板失敗')
+  } finally {
+    savingTemplate.value = false
   }
-  
-  function deleteTemplate(index) {
-    reportTemplates.value.splice(index, 1)
+}
+
+async function deleteTemplate(template) {
+  if (!template || !template.id) return
+  try {
+    await ElMessageBox.confirm(`確定要刪除「${template.name}」？`, '刪除確認', {
+      type: 'warning'
+    })
+  } catch (error) {
+    return
   }
-  
-  // =============== (2) 匯出格式與樣式 ===============
-  const exportForm = ref({
-    formats: ['PDF', 'Excel'], // 預設勾選
-    includeLogo: true,
-    footerNote: '機密文件，請勿外流'
-  })
-  
-  function saveExportSetting() {
-    console.log('儲存匯出設定', exportForm.value)
-    alert('已儲存「匯出格式與樣式」設定')
+
+  try {
+    const res = await apiFetch(`/api/reports/${template.id}`, { method: 'DELETE' })
+    await parseJson(res, '刪除報表模板失敗')
+    const index = reportTemplates.value.findIndex((item) => item.id === template.id)
+    if (index !== -1) {
+      reportTemplates.value.splice(index, 1)
+    }
+    syncSelectedTemplate()
+    ElMessage.success('報表模板已刪除')
+  } catch (error) {
+    ElMessage.error(error.message || '刪除報表模板失敗')
   }
-  
-  // =============== (3) 權限與範圍 ===============
-  const permissionForm = ref({
-    supervisorDept: true,
-    hrAllDept: true,
-    employeeDownload: true,
-    historyMonths: 6
-  })
-  
-  function savePermission() {
-    console.log('儲存權限與範圍設定', permissionForm.value)
-    alert('已儲存「權限與範圍」設定')
+}
+
+async function saveExportSetting() {
+  if (!currentTemplate.value) {
+    ElMessage.warning('請先選擇報表模板')
+    return
   }
-  
-  // =============== (4) 通知與寄送 ===============
-  const notifyForm = ref({
-    autoSend: false,
-    sendFrequency: '',
-    recipients: []
-  })
-  
-  function saveNotifySetting() {
-    console.log('儲存報表通知設定', notifyForm.value)
-    alert('已儲存「通知與寄送」設定')
+  exportSaving.value = true
+  try {
+    const res = await apiFetch(`/api/reports/${currentTemplate.value.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ exportSettings: cloneWithDefaults(exportForm.value, createDefaultExportSettings) })
+    })
+    const data = await parseJson(res, '儲存匯出設定失敗')
+    if (data) {
+      upsertTemplate(data)
+    }
+    ElMessage.success('匯出設定已更新')
+  } catch (error) {
+    ElMessage.error(error.message || '儲存匯出設定失敗')
+  } finally {
+    exportSaving.value = false
   }
-  </script>
-  
-  <style scoped>
-  .report-management-setting {
-    padding: 20px;
+}
+
+async function savePermission() {
+  if (!currentTemplate.value) {
+    ElMessage.warning('請先選擇報表模板')
+    return
   }
-  
-  .tab-content {
-    margin-top: 20px;
+  permissionSaving.value = true
+  try {
+    const res = await apiFetch(`/api/reports/${currentTemplate.value.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        permissionSettings: cloneWithDefaults(permissionForm.value, createDefaultPermissionSettings)
+      })
+    })
+    const data = await parseJson(res, '儲存權限設定失敗')
+    if (data) {
+      upsertTemplate(data)
+    }
+    ElMessage.success('權限設定已更新')
+  } catch (error) {
+    ElMessage.error(error.message || '儲存權限設定失敗')
+  } finally {
+    permissionSaving.value = false
   }
-  
-  .field-list {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 4px;
+}
+
+async function saveNotifySetting() {
+  if (!currentTemplate.value) {
+    ElMessage.warning('請先選擇報表模板')
+    return
   }
-  </style>
+  notifySaving.value = true
+  try {
+    const res = await apiFetch(`/api/reports/${currentTemplate.value.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        notificationSettings: cloneWithDefaults(
+          notifyForm.value,
+          createDefaultNotificationSettings
+        )
+      })
+    })
+    const data = await parseJson(res, '儲存通知設定失敗')
+    if (data) {
+      upsertTemplate(data)
+    }
+    ElMessage.success('通知設定已更新')
+  } catch (error) {
+    ElMessage.error(error.message || '儲存通知設定失敗')
+  } finally {
+    notifySaving.value = false
+  }
+}
+
+onMounted(() => {
+  loadReports()
+})
+</script>
+
+<style scoped>
+.report-management-setting {
+  padding: 20px;
+}
+
+.tab-content {
+  margin-top: 20px;
+}
+
+.field-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+</style>

--- a/client/tests/reportManagementSetting.spec.js
+++ b/client/tests/reportManagementSetting.spec.js
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import ReportManagementSetting from '../src/components/backComponents/ReportManagementSetting.vue'
+
+vi.mock('../src/api.js', () => ({
+  apiFetch: vi.fn()
+}))
+
+vi.mock('element-plus', () => ({
+  __esModule: true,
+  ElMessage: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  },
+  ElMessageBox: {
+    confirm: vi.fn()
+  }
+}))
+
+const { apiFetch } = await import('../src/api.js')
+const { ElMessage, ElMessageBox } = await import('element-plus')
+
+function createWrapper() {
+  return mount(ReportManagementSetting, {
+    global: {
+      stubs: {
+        'el-tabs': { template: '<div><slot /></div>' },
+        'el-tab-pane': { template: '<div><slot /></div>' },
+        'el-table': {
+          props: ['data'],
+          emits: ['current-change'],
+          template:
+            '<div><div v-for="(row, index) in data" :key="row?.id ?? index"><slot :row="row" :$index="index" /></div></div>'
+        },
+        'el-table-column': { template: '<div></div>' },
+        'el-button': {
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>'
+        },
+        'el-dialog': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<div v-if="modelValue"><slot /><slot name="footer" /></div>'
+        },
+        'el-form': { template: '<form><slot /></form>' },
+        'el-form-item': { template: '<div><slot /></div>' },
+        'el-input': {
+          props: ['modelValue'],
+          emits: ['update:modelValue', 'keyup'],
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @keyup="$emit(\'keyup\', $event)" />'
+        },
+        'el-select': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template:
+            '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>'
+        },
+        'el-option': {
+          props: ['label', 'value'],
+          template: '<option :value="value">{{ label }}</option>'
+        },
+        'el-tag': {
+          emits: ['close'],
+          template: '<span><slot /></span>'
+        },
+        'el-switch': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />'
+        },
+        'el-checkbox-group': { template: '<div><slot /></div>' },
+        'el-checkbox': { template: '<label><slot /></label>' },
+        'el-input-number': {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="number" :value="modelValue" @input="$emit(\'update:modelValue\', Number($event.target.value))" />'
+        },
+        'el-alert': { props: ['title'], template: '<div><slot />{{ title }}</div>' }
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiFetch.mockReset()
+  ElMessage.success.mockReset()
+  ElMessage.error.mockReset()
+  ElMessage.warning.mockReset()
+  ElMessageBox.confirm.mockReset()
+  ElMessageBox.confirm.mockResolvedValue()
+})
+
+describe('ReportManagementSetting.vue', () => {
+  it('載入報表模板並預設選擇第一筆', async () => {
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          id: 'r1',
+          name: '出勤報表',
+          type: 'custom',
+          fields: ['員工'],
+          exportSettings: { formats: ['PDF'], includeLogo: false, footerNote: '' },
+          permissionSettings: {
+            supervisorDept: false,
+            hrAllDept: true,
+            employeeDownload: false,
+            historyMonths: 6
+          },
+          notificationSettings: { autoSend: false, sendFrequency: '', recipients: [] }
+        }
+      ]
+    })
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/reports')
+    expect(wrapper.vm.reportTemplates).toHaveLength(1)
+    expect(wrapper.vm.selectedTemplateId).toBe('r1')
+    expect(wrapper.vm.exportForm.formats).toEqual(['PDF'])
+  })
+
+  it('新增報表模板後更新列表', async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    const created = {
+      id: 'r2',
+      name: '請假報表',
+      type: '請假',
+      fields: ['姓名'],
+      exportSettings: { formats: [], includeLogo: false, footerNote: '' },
+      permissionSettings: {
+        supervisorDept: false,
+        hrAllDept: false,
+        employeeDownload: false,
+        historyMonths: 6
+      },
+      notificationSettings: { autoSend: false, sendFrequency: '', recipients: [] }
+    }
+
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => created })
+
+    wrapper.vm.openTemplateDialog()
+    wrapper.vm.templateForm.name = '請假報表'
+    wrapper.vm.templateForm.type = '請假'
+    wrapper.vm.templateForm.fields = ['姓名']
+
+    await wrapper.vm.saveTemplate()
+    await flushPromises()
+
+    const lastCall = apiFetch.mock.calls.at(-1)
+    expect(lastCall[0]).toBe('/api/reports')
+    expect(lastCall[1]).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    })
+    const payload = JSON.parse(lastCall[1].body)
+    expect(payload).toMatchObject({
+      name: '請假報表',
+      type: '請假',
+      fields: ['姓名']
+    })
+    expect(wrapper.vm.reportTemplates).toHaveLength(1)
+    expect(wrapper.vm.reportTemplates[0].name).toBe('請假報表')
+    expect(wrapper.vm.selectedTemplateId).toBe('r2')
+  })
+
+  it('儲存匯出設定會呼叫對應 API', async () => {
+    const baseTemplate = {
+      id: 'r3',
+      name: '薪資報表',
+      type: 'custom',
+      fields: ['姓名'],
+      exportSettings: { formats: ['PDF'], includeLogo: false, footerNote: '' },
+      permissionSettings: {
+        supervisorDept: false,
+        hrAllDept: false,
+        employeeDownload: false,
+        historyMonths: 6
+      },
+      notificationSettings: { autoSend: false, sendFrequency: '', recipients: [] }
+    }
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => [baseTemplate] })
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ...baseTemplate,
+        exportSettings: { formats: ['CSV'], includeLogo: true, footerNote: '備註' }
+      })
+    })
+
+    wrapper.vm.exportForm.formats = ['CSV']
+    wrapper.vm.exportForm.includeLogo = true
+    wrapper.vm.exportForm.footerNote = '備註'
+
+    await wrapper.vm.saveExportSetting()
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenLastCalledWith(
+      '/api/reports/r3',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          exportSettings: { formats: ['CSV'], includeLogo: true, footerNote: '備註' }
+        })
+      })
+    )
+    expect(wrapper.vm.reportTemplates[0].exportSettings.formats).toEqual(['CSV'])
+    expect(ElMessage.success).toHaveBeenCalledWith('匯出設定已更新')
+  })
+
+  it('刪除報表模板後同步更新列表', async () => {
+    const baseTemplate = {
+      id: 'r4',
+      name: '考勤報表',
+      type: 'custom',
+      fields: ['姓名'],
+      exportSettings: { formats: ['PDF'], includeLogo: false, footerNote: '' },
+      permissionSettings: {
+        supervisorDept: false,
+        hrAllDept: false,
+        employeeDownload: false,
+        historyMonths: 6
+      },
+      notificationSettings: { autoSend: false, sendFrequency: '', recipients: [] }
+    }
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => [baseTemplate] })
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    apiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    await wrapper.vm.deleteTemplate(wrapper.vm.reportTemplates[0])
+    await flushPromises()
+
+    expect(ElMessageBox.confirm).toHaveBeenCalled()
+    expect(apiFetch).toHaveBeenLastCalledWith(
+      '/api/reports/r4',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+    expect(wrapper.vm.reportTemplates).toHaveLength(0)
+    expect(wrapper.vm.selectedTemplateId).toBeNull()
+    expect(ElMessage.success).toHaveBeenCalledWith('報表模板已刪除')
+  })
+})

--- a/server/src/models/Report.js
+++ b/server/src/models/Report.js
@@ -1,8 +1,75 @@
 import mongoose from 'mongoose';
 
-const reportSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  data: { type: mongoose.Schema.Types.Mixed, required: true }
-}, { timestamps: true });
+const exportSettingsSchema = new mongoose.Schema(
+  {
+    formats: {
+      type: [String],
+      default: [],
+      set: (values) =>
+        Array.isArray(values)
+          ? values
+              .map((item) => (typeof item === 'string' ? item.trim() : ''))
+              .filter(Boolean)
+          : [],
+    },
+    includeLogo: { type: Boolean, default: false },
+    footerNote: { type: String, default: '', trim: true },
+  },
+  { _id: false }
+);
+
+const permissionSettingsSchema = new mongoose.Schema(
+  {
+    supervisorDept: { type: Boolean, default: false },
+    hrAllDept: { type: Boolean, default: false },
+    employeeDownload: { type: Boolean, default: false },
+    historyMonths: { type: Number, default: 6, min: 0 },
+  },
+  { _id: false }
+);
+
+const notificationSettingsSchema = new mongoose.Schema(
+  {
+    autoSend: { type: Boolean, default: false },
+    sendFrequency: {
+      type: String,
+      enum: ['daily', 'weekly', 'monthly', ''],
+      default: '',
+    },
+    recipients: {
+      type: [String],
+      default: [],
+      set: (values) =>
+        Array.isArray(values)
+          ? values
+              .map((item) => (typeof item === 'string' ? item.trim() : ''))
+              .filter(Boolean)
+          : [],
+    },
+  },
+  { _id: false }
+);
+
+const reportSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    type: { type: String, default: 'custom', trim: true },
+    fields: {
+      type: [String],
+      default: [],
+      set: (values) =>
+        Array.isArray(values)
+          ? values
+              .map((item) => (typeof item === 'string' ? item.trim() : ''))
+              .filter(Boolean)
+          : [],
+    },
+    data: { type: mongoose.Schema.Types.Mixed, default: {} },
+    exportSettings: { type: exportSettingsSchema, default: () => ({}) },
+    permissionSettings: { type: permissionSettingsSchema, default: () => ({}) },
+    notificationSettings: { type: notificationSettingsSchema, default: () => ({}) },
+  },
+  { timestamps: true }
+);
 
 export default mongoose.model('Report', reportSchema);

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -3,8 +3,51 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const saveMock = jest.fn();
-const mockReport = jest.fn().mockImplementation(() => ({ save: saveMock }));
+
+function buildReportDocument(overrides = {}) {
+  return {
+    _id: overrides._id ?? 'report-id',
+    name: overrides.name ?? '月度報表',
+    type: overrides.type ?? 'custom',
+    fields: overrides.fields ?? ['欄位一'],
+    data: overrides.data ?? {},
+    exportSettings:
+      overrides.exportSettings ??
+      {
+        formats: ['PDF'],
+        includeLogo: false,
+        footerNote: '',
+      },
+    permissionSettings:
+      overrides.permissionSettings ??
+      {
+        supervisorDept: false,
+        hrAllDept: true,
+        employeeDownload: false,
+        historyMonths: 6,
+      },
+    notificationSettings:
+      overrides.notificationSettings ??
+      {
+        autoSend: false,
+        sendFrequency: '',
+        recipients: [],
+      },
+    createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2024-01-02T00:00:00Z'),
+    save: saveMock,
+    toObject() {
+      const { save, toObject, ...rest } = this;
+      return { ...rest };
+    },
+  };
+}
+
+const mockReport = jest.fn().mockImplementation((payload = {}) => buildReportDocument(payload));
 mockReport.find = jest.fn();
+mockReport.findById = jest.fn();
+mockReport.findByIdAndUpdate = jest.fn();
+mockReport.findByIdAndDelete = jest.fn();
 
 const mockEmployee = { find: jest.fn(), exists: jest.fn() };
 const mockShiftSchedule = { find: jest.fn() };
@@ -39,13 +82,19 @@ beforeAll(async () => {
 
 beforeEach(() => {
   saveMock.mockReset();
+  mockReport.mockClear();
   mockReport.find.mockReset();
+  mockReport.findById.mockReset();
+  mockReport.findByIdAndUpdate.mockReset();
+  mockReport.findByIdAndDelete.mockReset();
   mockEmployee.find.mockReset();
   mockEmployee.exists.mockReset();
   mockShiftSchedule.find.mockReset();
   mockAttendanceRecord.find.mockReset();
   mockApprovalRequest.find.mockReset();
   mockGetLeaveFieldIds.mockReset();
+
+  saveMock.mockResolvedValue(undefined);
 
   mockEmployee.find.mockResolvedValue([]);
   mockEmployee.exists.mockResolvedValue(null);
@@ -62,11 +111,48 @@ beforeEach(() => {
 
 describe('Report API', () => {
   it('lists reports', async () => {
-    const fakeReports = [{ name: 'Monthly' }];
+    const fakeReports = [
+      buildReportDocument({
+        _id: 'r1',
+        name: '出勤統計',
+        fields: ['員工', '部門', '出勤天數 '],
+        exportSettings: { formats: ['PDF', ' Excel '], includeLogo: true, footerNote: ' 需覆核 ' },
+      }),
+      buildReportDocument({
+        _id: 'r2',
+        name: '請假統計',
+        type: 'leave',
+        fields: ['員工', '請假天數'],
+        notificationSettings: { autoSend: true, sendFrequency: 'weekly', recipients: ['HR', ' 主管 '] },
+      }),
+    ];
     mockReport.find.mockResolvedValue(fakeReports);
     const res = await request(app).get('/api/reports');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(fakeReports);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      id: 'r1',
+      name: '出勤統計',
+      type: 'custom',
+      fields: ['員工', '部門', '出勤天數'],
+      exportSettings: {
+        formats: ['PDF', 'Excel'],
+        includeLogo: true,
+        footerNote: '需覆核',
+      },
+      permissionSettings: expect.objectContaining({ hrAllDept: true }),
+      notificationSettings: { autoSend: false, sendFrequency: '', recipients: [] },
+    });
+    expect(res.body[1]).toMatchObject({
+      id: 'r2',
+      name: '請假統計',
+      type: 'leave',
+      notificationSettings: {
+        autoSend: true,
+        sendFrequency: 'weekly',
+        recipients: ['HR', '主管'],
+      },
+    });
   });
 
   it('returns 500 if listing fails', async () => {
@@ -76,13 +162,156 @@ describe('Report API', () => {
     expect(res.body).toEqual({ error: 'fail' });
   });
 
-  it('creates report', async () => {
-    const payload = { name: 'Monthly' };
-    saveMock.mockResolvedValue();
+  it('creates report with sanitization', async () => {
+    const payload = {
+      name: '  月度報表  ',
+      type: '',
+      fields: [' 員工 ', '', ' 部門 '],
+      exportSettings: { formats: ['PDF', ''], includeLogo: 'true', footerNote: ' 重要 ' },
+      permissionSettings: { historyMonths: 3.6, hrAllDept: false },
+      notificationSettings: {
+        autoSend: true,
+        sendFrequency: 'weekly',
+        recipients: ['HR', ''],
+      },
+    };
+
     const res = await request(app).post('/api/reports').send(payload);
+
     expect(res.status).toBe(201);
-    expect(saveMock).toHaveBeenCalled();
-    expect(res.body).toEqual({});
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(mockReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '月度報表',
+        type: 'custom',
+        fields: ['員工', '部門'],
+      })
+    );
+    expect(res.body).toMatchObject({
+      id: 'report-id',
+      name: '月度報表',
+      type: 'custom',
+      fields: ['員工', '部門'],
+      exportSettings: {
+        formats: ['PDF'],
+        includeLogo: true,
+        footerNote: '重要',
+      },
+      permissionSettings: {
+        supervisorDept: false,
+        hrAllDept: false,
+        employeeDownload: false,
+        historyMonths: 3,
+      },
+      notificationSettings: {
+        autoSend: true,
+        sendFrequency: 'weekly',
+        recipients: ['HR'],
+      },
+    });
+  });
+
+  it('rejects create without name', async () => {
+    const res = await request(app).post('/api/reports').send({ fields: [] });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: '報表名稱為必填' });
+  });
+
+  it('gets report with formatted response', async () => {
+    mockReport.findById.mockResolvedValue(
+      buildReportDocument({ _id: 'r1', name: '人員報表', type: 'people' })
+    );
+    const res = await request(app).get('/api/reports/r1');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: 'r1', name: '人員報表', type: 'people' });
+  });
+
+  it('updates report template', async () => {
+    mockReport.findByIdAndUpdate.mockResolvedValue(
+      buildReportDocument({
+        _id: 'r-update',
+        name: '更新後模板',
+        fields: ['姓名'],
+        exportSettings: { formats: ['CSV'], includeLogo: true, footerNote: '最終版' },
+        permissionSettings: {
+          supervisorDept: true,
+          hrAllDept: false,
+          employeeDownload: true,
+          historyMonths: 12,
+        },
+        notificationSettings: {
+          autoSend: true,
+          sendFrequency: 'monthly',
+          recipients: ['HR'],
+        },
+      })
+    );
+
+    const res = await request(app)
+      .put('/api/reports/r-update')
+      .send({
+        name: ' 更新後模板 ',
+        fields: ['姓名', ''],
+        exportSettings: { formats: ['CSV'], includeLogo: true, footerNote: '最終版 ' },
+        permissionSettings: {
+          supervisorDept: true,
+          hrAllDept: false,
+          employeeDownload: true,
+          historyMonths: 12,
+        },
+        notificationSettings: {
+          autoSend: true,
+          sendFrequency: 'monthly',
+          recipients: ['HR', ''],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockReport.findByIdAndUpdate).toHaveBeenCalledWith(
+      'r-update',
+      expect.objectContaining({
+        name: '更新後模板',
+        fields: ['姓名'],
+        exportSettings: {
+          formats: ['CSV'],
+          includeLogo: true,
+          footerNote: '最終版',
+        },
+        permissionSettings: expect.objectContaining({ historyMonths: 12 }),
+        notificationSettings: {
+          autoSend: true,
+          sendFrequency: 'monthly',
+          recipients: ['HR'],
+        },
+      }),
+      expect.objectContaining({ new: true, runValidators: true })
+    );
+    expect(res.body).toMatchObject({
+      id: 'r-update',
+      name: '更新後模板',
+      fields: ['姓名'],
+      notificationSettings: {
+        autoSend: true,
+        sendFrequency: 'monthly',
+        recipients: ['HR'],
+      },
+    });
+  });
+
+  it('rejects invalid update payload', async () => {
+    const res = await request(app)
+      .put('/api/reports/r-update')
+      .send({ exportSettings: { formats: 'csv' } });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: '匯出格式需為陣列' });
+    expect(mockReport.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('deletes report template', async () => {
+    mockReport.findByIdAndDelete.mockResolvedValue(buildReportDocument({ _id: 'r-delete' }));
+    const res = await request(app).delete('/api/reports/r-delete');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
   });
 
   it('exports department attendance for supervisor', async () => {


### PR DESCRIPTION
## Summary
- 擴充報表模板模型結構，涵蓋匯出、權限與通知設定並提供預設值
- 強化報表 CRUD 控制器的輸入驗證、預設值補齊與回傳欄位整潔
- 將報表管理前端改為與後端 API 互動並新增對應的前後端測試

## Testing
- npm --prefix server test
- npm --prefix client test -- --run tests/reportManagementSetting.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e2d89d56b08329b3782c3a4139c62e