### PR TITLE
feat: 支援員工批量匯入流程

### DIFF
--- a/server/src/controllers/employeeBulkImportController.js
+++ b/server/src/controllers/employeeBulkImportController.js
@@ -1,0 +1,400 @@
+import ExcelJS from 'exceljs'
+import crypto from 'crypto'
+import Employee from '../models/Employee.js'
+import { buildEmployeeDoc } from './employeeController.js'
+
+const REQUIRED_MAPPING_KEYS = ['employeeNo', 'name', 'email']
+const VALID_ROLES = ['employee', 'supervisor', 'admin']
+
+const BOOLEAN_FIELDS = new Set(['isPartTime', 'partTime', 'isClocking', 'needClockIn'])
+const DATE_FIELDS = new Set([
+  'birthday',
+  'hireDate',
+  'appointDate',
+  'resignDate',
+  'dismissDate',
+  'reAppointDate',
+  'reDismissDate'
+])
+const NUMBER_FIELDS = new Set([
+  'probationDays',
+  'dependents',
+  'salaryAmount',
+  'laborPensionSelf',
+  'employeeAdvance',
+  'graduationYear'
+])
+
+const EMAIL_REGEX = /^\S+@\S+\.\S+$/
+
+function toPlainCellValue(cell) {
+  if (!cell) return ''
+  if (cell.text !== undefined) return String(cell.text).trim()
+  if (cell.value === null || cell.value === undefined) return ''
+  if (cell.value instanceof Date) return cell.value
+  if (typeof cell.value === 'object' && cell.value.result !== undefined) {
+    return typeof cell.value.result === 'string' ? cell.value.result.trim() : cell.value.result
+  }
+  if (typeof cell.value === 'string') return cell.value.trim()
+  return cell.value
+}
+
+function toBoolean(value) {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) return undefined
+    if (['true', '1', 'yes', 'y', '是', 'on'].includes(normalized)) return true
+    if (['false', '0', 'no', 'n', '否', 'off'].includes(normalized)) return false
+  }
+  return undefined
+}
+
+function excelSerialToDate(serial) {
+  if (typeof serial !== 'number') return null
+  const excelEpoch = new Date(Date.UTC(1899, 11, 30))
+  const millis = Math.round(serial * 24 * 60 * 60 * 1000)
+  if (Number.isNaN(millis)) return null
+  return new Date(excelEpoch.getTime() + millis)
+}
+
+function toDateValue(value) {
+  if (!value && value !== 0) return undefined
+  if (value instanceof Date) return value
+  if (typeof value === 'number') {
+    const converted = excelSerialToDate(value)
+    return converted && !Number.isNaN(converted.getTime()) ? converted : undefined
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return undefined
+    const date = new Date(trimmed)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  }
+  return undefined
+}
+
+function toNumberValue(value) {
+  if (value === null || value === undefined || value === '') return undefined
+  if (typeof value === 'number') return value
+  const num = Number(String(value).trim())
+  return Number.isNaN(num) ? undefined : num
+}
+
+function normalizeEmail(value) {
+  if (typeof value !== 'string') return ''
+  return value.trim().toLowerCase()
+}
+
+function formatRowError(rowNumber, messages) {
+  const text = Array.isArray(messages) ? messages.join('、') : messages
+  return `第 ${rowNumber} 列：${text}`
+}
+
+function deriveUsername(row) {
+  if (typeof row.username === 'string' && row.username.trim()) {
+    return row.username.trim()
+  }
+  if (typeof row.email === 'string' && row.email.includes('@')) {
+    return row.email.split('@')[0].trim()
+  }
+  if (typeof row.employeeNo === 'string' && row.employeeNo.trim()) {
+    return row.employeeNo.trim()
+  }
+  return ''
+}
+
+function generatePassword(length = 12) {
+  let password = ''
+  while (!password) {
+    password = crypto.randomBytes(length).toString('base64').replace(/[^a-zA-Z0-9]/g, '')
+    if (password.length > length) {
+      password = password.slice(0, length)
+    }
+  }
+  return password
+}
+
+function createPreview(row) {
+  return {
+    employeeNo: row.employeeNo ?? '',
+    name: row.name ?? '',
+    department: row.department ?? '',
+    role: row.role ?? '',
+    email: row.email ?? ''
+  }
+}
+
+export async function bulkImportEmployees(req, res) {
+  if (!req.file || !req.file.buffer) {
+    res.status(400).json({ message: '缺少上傳檔案' })
+    return
+  }
+
+  let columnMappings
+  try {
+    columnMappings = JSON.parse(req.body?.mappings || '{}')
+  } catch (error) {
+    res.status(400).json({ message: '欄位對應格式錯誤', errors: ['mappings JSON 解析失敗'] })
+    return
+  }
+
+  if (!columnMappings || typeof columnMappings !== 'object') {
+    res.status(400).json({ message: '欄位對應格式錯誤', errors: ['欄位對應缺失'] })
+    return
+  }
+
+  const missingMappings = REQUIRED_MAPPING_KEYS.filter(key => {
+    const value = columnMappings[key]
+    return typeof value !== 'string' || !value.trim()
+  })
+  if (missingMappings.length) {
+    res.status(400).json({
+      message: '欄位對應缺少必要欄位',
+      errors: missingMappings.map(key => `缺少對應欄位：${key}`)
+    })
+    return
+  }
+
+  let options = {}
+  try {
+    options = req.body?.options ? JSON.parse(req.body.options) : {}
+  } catch (error) {
+    res.status(400).json({ message: '匯入選項格式錯誤', errors: ['options JSON 解析失敗'] })
+    return
+  }
+
+  let defaultRole = typeof options?.defaultRole === 'string' && options.defaultRole.trim()
+    ? options.defaultRole.trim().toLowerCase()
+    : 'employee'
+  if (!VALID_ROLES.includes(defaultRole)) {
+    defaultRole = 'employee'
+  }
+  const resetPassword = typeof options?.resetPassword === 'string' && options.resetPassword.trim()
+    ? options.resetPassword.trim()
+    : null
+
+  const workbook = new ExcelJS.Workbook()
+  let worksheet
+  try {
+    if (req.file.mimetype === 'text/csv' || req.file.originalname?.endsWith('.csv')) {
+      await workbook.csv.read(req.file.buffer)
+    } else {
+      await workbook.xlsx.load(req.file.buffer)
+    }
+    worksheet = workbook.worksheets[0]
+  } catch (error) {
+    res.status(400).json({ message: '無法讀取 Excel 檔案', errors: [error.message] })
+    return
+  }
+
+  if (!worksheet) {
+    res.status(400).json({ message: '找不到可用的工作表', errors: [] })
+    return
+  }
+
+  const headerRow = worksheet.getRow(1)
+  const headerMap = new Map()
+  headerRow.eachCell((cell, colNumber) => {
+    const value = toPlainCellValue(cell)
+    if (typeof value === 'string' && value.trim()) {
+      headerMap.set(value.trim(), colNumber)
+    }
+  })
+
+  const missingColumns = Object.entries(columnMappings)
+    .filter(([, header]) => typeof header === 'string' && header.trim())
+    .filter(([, header]) => !headerMap.has(header.trim()))
+    .map(([key, header]) => `${key} (${header})`)
+
+  if (missingColumns.length) {
+    res.status(400).json({
+      message: '匯入檔案缺少必要欄位',
+      errors: missingColumns.map(col => `找不到對應欄位：${col}`)
+    })
+    return
+  }
+
+  const parsedRows = []
+  const maxRow = worksheet.actualRowCount || worksheet.rowCount
+  for (let index = 2; index <= maxRow; index += 1) {
+    const row = worksheet.getRow(index)
+    if (!row || row.cellCount === 0) continue
+
+    const original = {}
+    const normalized = {}
+    let hasData = false
+
+    Object.entries(columnMappings).forEach(([key, header]) => {
+      if (typeof header !== 'string' || !header.trim()) return
+      const col = headerMap.get(header.trim())
+      if (!col) return
+      const cellValue = toPlainCellValue(row.getCell(col))
+      if (cellValue !== '' && cellValue !== null && cellValue !== undefined) {
+        hasData = true
+      }
+      original[key] = cellValue
+
+      if (BOOLEAN_FIELDS.has(key)) {
+        const boolValue = toBoolean(cellValue)
+        if (typeof boolValue === 'boolean') {
+          normalized[key] = boolValue
+        }
+        return
+      }
+
+      if (DATE_FIELDS.has(key)) {
+        const dateValue = toDateValue(cellValue)
+        if (dateValue) {
+          normalized[key] = dateValue
+        } else if (typeof cellValue === 'string' && cellValue.trim()) {
+          normalized[key] = cellValue.trim()
+        }
+        return
+      }
+
+      if (NUMBER_FIELDS.has(key)) {
+        const numberValue = toNumberValue(cellValue)
+        if (numberValue !== undefined) {
+          normalized[key] = numberValue
+        }
+        return
+      }
+
+      if (typeof cellValue === 'string') {
+        normalized[key] = cellValue.trim()
+      } else {
+        normalized[key] = cellValue
+      }
+
+      if (key === 'employeeNo' && normalized[key] !== undefined && normalized[key] !== null) {
+        normalized[key] = String(normalized[key]).trim()
+      }
+      if (key === 'role' && typeof normalized[key] === 'string') {
+        normalized[key] = normalized[key].trim().toLowerCase()
+      }
+    })
+
+    if (!hasData) continue
+
+    parsedRows.push({
+      rowNumber: index,
+      original,
+      normalized,
+      errors: []
+    })
+  }
+
+  if (!parsedRows.length) {
+    res.status(400).json({ message: '匯入檔案沒有資料', errors: [] })
+    return
+  }
+
+  const seenEmails = new Set()
+  const emailCandidates = new Set()
+
+  parsedRows.forEach(row => {
+    if (!row.normalized.role) {
+      row.normalized.role = defaultRole
+    }
+
+    const email = row.normalized.email ?? row.original.email
+    const normalizedEmail = normalizeEmail(email)
+    if (!normalizedEmail) {
+      row.errors.push('缺少 Email')
+    } else if (!EMAIL_REGEX.test(normalizedEmail)) {
+      row.errors.push('Email 格式不正確')
+    } else if (seenEmails.has(normalizedEmail)) {
+      row.errors.push('Email 重複')
+    } else {
+      seenEmails.add(normalizedEmail)
+      emailCandidates.add(normalizedEmail)
+      row.normalized.email = normalizedEmail
+    }
+
+    if (!row.normalized.employeeNo || String(row.normalized.employeeNo).trim() === '') {
+      row.errors.push('缺少員工編號')
+    }
+
+    if (!row.normalized.name || String(row.normalized.name).trim() === '') {
+      row.errors.push('缺少姓名')
+    }
+
+    if (!VALID_ROLES.includes(row.normalized.role)) {
+      row.errors.push('權限設定不正確')
+    }
+  })
+
+  let existingEmails = []
+  if (emailCandidates.size) {
+    try {
+      const emailList = Array.from(emailCandidates)
+      existingEmails = await Employee.find({ email: { $in: emailList } }, 'email')
+    } catch (error) {
+      res.status(500).json({ message: '檢查既有 Email 失敗', error: error.message })
+      return
+    }
+  }
+
+  const existingEmailSet = new Set(existingEmails.map(doc => normalizeEmail(doc.email)))
+  parsedRows.forEach(row => {
+    const email = normalizeEmail(row.normalized.email ?? row.original.email)
+    if (email && existingEmailSet.has(email)) {
+      row.errors.push('Email 已存在')
+    }
+  })
+
+  const preview = []
+  const errorMessages = []
+  let successCount = 0
+
+  for (const row of parsedRows) {
+    if (row.errors.length) {
+      errorMessages.push(formatRowError(row.rowNumber, row.errors))
+      continue
+    }
+
+    const username = deriveUsername(row.normalized)
+    if (!username) {
+      errorMessages.push(formatRowError(row.rowNumber, '缺少帳號或 Email'))
+      continue
+    }
+
+    const password = resetPassword || generatePassword()
+    const body = {
+      ...row.normalized,
+      email: row.normalized.email,
+      username
+    }
+
+    const employeeDoc = buildEmployeeDoc(body)
+    employeeDoc.password = password
+
+    try {
+      const created = await Employee.create(employeeDoc)
+      successCount += 1
+      preview.push(createPreview({
+        employeeNo: created.employeeId || created.employeeNo || body.employeeNo,
+        name: created.name,
+        department: created.department || body.department,
+        role: created.role || body.role,
+        email: created.email
+      }))
+    } catch (error) {
+      errorMessages.push(formatRowError(row.rowNumber, error.message))
+    }
+  }
+
+  const failureCount = parsedRows.length - successCount
+
+  const statusCode = successCount > 0 ? 200 : 400
+  res.status(statusCode).json({
+    successCount,
+    failureCount,
+    preview,
+    errors: errorMessages
+  })
+}
+
+export default bulkImportEmployees

--- a/server/src/middleware/upload.js
+++ b/server/src/middleware/upload.js
@@ -1,0 +1,164 @@
+const MAX_UPLOAD_SIZE = 8 * 1024 * 1024 // 8MB：含檔案與欄位
+
+function trimBufferCRLF(buffer) {
+  let end = buffer.length
+  if (end >= 2 && buffer[end - 2] === 13 && buffer[end - 1] === 10) {
+    end -= 2
+  }
+  return buffer.slice(0, end)
+}
+
+function parseContentDisposition(header = '') {
+  const result = {}
+  header
+    .split(';')
+    .map(part => part.trim())
+    .forEach(part => {
+      const [key, rawValue] = part.split('=')
+      if (!rawValue) return
+      const value = rawValue.replace(/^"|"$/g, '')
+      result[key.toLowerCase()] = value
+    })
+  return result
+}
+
+function parseMultipartBody(buffer, boundaryKey) {
+  const boundary = `--${boundaryKey}`
+  const raw = buffer.toString('binary')
+  const segments = raw.split(boundary).slice(1, -1)
+
+  const fields = {}
+  let file = null
+
+  segments.forEach(segment => {
+    if (!segment) return
+    let partBuffer = Buffer.from(segment, 'binary')
+    if (partBuffer.length >= 2 && partBuffer[0] === 13 && partBuffer[1] === 10) {
+      partBuffer = partBuffer.slice(2)
+    }
+    const headerDelimiter = Buffer.from('\r\n\r\n')
+    const headerEnd = partBuffer.indexOf(headerDelimiter)
+    if (headerEnd === -1) return
+
+    const headerSection = partBuffer.slice(0, headerEnd).toString('utf8')
+    let bodyBuffer = partBuffer.slice(headerEnd + headerDelimiter.length)
+    bodyBuffer = trimBufferCRLF(bodyBuffer)
+
+    const headers = {}
+    headerSection
+      .split('\r\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .forEach(line => {
+        const idx = line.indexOf(':')
+        if (idx === -1) return
+        const key = line.slice(0, idx).trim().toLowerCase()
+        const value = line.slice(idx + 1).trim()
+        headers[key] = value
+      })
+
+    const disposition = parseContentDisposition(headers['content-disposition'])
+    const fieldName = disposition.name
+    if (!fieldName) return
+
+    if (Object.prototype.hasOwnProperty.call(disposition, 'filename') && disposition.filename) {
+      if (!bodyBuffer.length) return
+      file = {
+        fieldname: fieldName,
+        originalname: disposition.filename,
+        encoding: '7bit',
+        mimetype: headers['content-type'] || 'application/octet-stream',
+        size: bodyBuffer.length,
+        buffer: bodyBuffer,
+      }
+    } else {
+      const value = bodyBuffer.toString('utf8')
+      fields[fieldName] = value
+    }
+  })
+
+  return { fields, file }
+}
+
+export default function uploadMiddleware(req, res, next) {
+  if (req.file) {
+    next()
+    return
+  }
+
+  const contentType = req.headers['content-type'] || ''
+  const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i)
+  if (!boundaryMatch) {
+    res.status(400).json({ message: 'Content-Type 必須為 multipart/form-data' })
+    return
+  }
+
+  const boundaryKey = boundaryMatch[1] || boundaryMatch[2]
+  const chunks = []
+  let totalLength = 0
+  let handled = false
+
+  const cleanup = () => {
+    req.removeListener('data', onData)
+    req.removeListener('end', onEnd)
+    req.removeListener('error', onError)
+    req.removeListener('close', onClose)
+  }
+
+  const abortWithError = (status, message) => {
+    if (handled) return
+    handled = true
+    cleanup()
+    if (!res.headersSent) {
+      res.status(status).json({ message })
+    }
+  }
+
+  const onData = (chunk) => {
+    totalLength += chunk.length
+    if (totalLength > MAX_UPLOAD_SIZE) {
+      abortWithError(413, '上傳檔案過大')
+      req.destroy()
+      return
+    }
+    chunks.push(chunk)
+  }
+
+  const onEnd = () => {
+    if (handled) return
+    handled = true
+    cleanup()
+
+    const buffer = Buffer.concat(chunks)
+    try {
+      const { fields, file } = parseMultipartBody(buffer, boundaryKey)
+      if (!file || file.fieldname !== 'file') {
+        res.status(400).json({ message: '缺少上傳檔案' })
+        return
+      }
+      req.file = file
+      req.body = { ...(req.body || {}), ...fields }
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  const onError = (error) => {
+    if (handled) return
+    handled = true
+    cleanup()
+    next(error)
+  }
+
+  const onClose = () => {
+    if (handled) return
+    handled = true
+    cleanup()
+  }
+
+  req.on('data', onData)
+  req.on('end', onEnd)
+  req.on('error', onError)
+  req.on('close', onClose)
+}

--- a/server/src/routes/employeeRoutes.js
+++ b/server/src/routes/employeeRoutes.js
@@ -8,12 +8,16 @@ import {
   deleteEmployee,
   setSupervisors
 } from '../controllers/employeeController.js';
+import { bulkImportEmployees } from '../controllers/employeeBulkImportController.js';
+import uploadMiddleware from '../middleware/upload.js';
 
 const router = Router();
 
 router.get('/', listEmployees);
 router.get('/options', listEmployeeOptions);
 router.post('/', createEmployee);
+router.post('/bulk-import', uploadMiddleware, bulkImportEmployees);
+router.post('/import', uploadMiddleware, bulkImportEmployees);
 router.post('/set-supervisors', setSupervisors);
 router.get('/:id', getEmployee);
 router.put('/:id', updateEmployee);

--- a/server/tests/employeeBulkImport.test.js
+++ b/server/tests/employeeBulkImport.test.js
@@ -1,0 +1,146 @@
+import request from 'supertest'
+import express from 'express'
+import ExcelJS from 'exceljs'
+import { jest } from '@jest/globals'
+
+const mockEmployeeModel = {
+  find: jest.fn(),
+  create: jest.fn()
+}
+
+jest.unstable_mockModule('../src/models/Employee.js', () => ({
+  default: mockEmployeeModel
+}))
+
+let app
+
+async function setupApp() {
+  if (app) return app
+  const employeeRoutes = (await import('../src/routes/employeeRoutes.js')).default
+  const instance = express()
+  instance.use('/api/employees', employeeRoutes)
+  app = instance
+  return app
+}
+
+async function createWorkbookBuffer(rows) {
+  const workbook = new ExcelJS.Workbook()
+  const worksheet = workbook.addWorksheet('員工資料')
+  worksheet.addRow(['員工編號', '姓名', 'Email', '系統權限'])
+  rows.forEach(data => worksheet.addRow(data))
+  const arrayBuffer = await workbook.xlsx.writeBuffer()
+  return Buffer.from(arrayBuffer)
+}
+
+beforeEach(() => {
+  Object.values(mockEmployeeModel).forEach(fn => fn.mockReset())
+})
+
+describe('POST /api/employees/bulk-import', () => {
+  it('成功匯入資料並回傳預覽與統計', async () => {
+    const application = await setupApp()
+    const buffer = await createWorkbookBuffer([
+      ['E0001', '王小明', 'user1@example.com', 'employee'],
+      ['E0002', '陳美麗', 'user2@example.com', 'supervisor']
+    ])
+
+    mockEmployeeModel.find.mockResolvedValue([])
+    mockEmployeeModel.create.mockImplementation(async (doc) => ({
+      _id: `${doc.employeeNo}-id`,
+      employeeId: doc.employeeNo,
+      name: doc.name,
+      department: doc.department,
+      role: doc.role,
+      email: doc.email
+    }))
+
+    const response = await request(application)
+      .post('/api/employees/bulk-import')
+      .attach('file', buffer, { filename: 'import.xlsx' })
+      .field('mappings', JSON.stringify({
+        employeeNo: '員工編號',
+        name: '姓名',
+        email: 'Email',
+        role: '系統權限'
+      }))
+      .field('options', JSON.stringify({ defaultRole: 'employee', resetPassword: 'Temp1234!' }))
+
+    expect(response.status).toBe(200)
+    expect(response.body.successCount).toBe(2)
+    expect(response.body.failureCount).toBe(0)
+    expect(Array.isArray(response.body.preview)).toBe(true)
+    expect(response.body.preview).toHaveLength(2)
+    expect(response.body.errors).toEqual([])
+    expect(mockEmployeeModel.create).toHaveBeenCalledTimes(2)
+    const createdDoc = mockEmployeeModel.create.mock.calls[0][0]
+    expect(createdDoc).toMatchObject({
+      employeeNo: 'E0001',
+      name: '王小明',
+      email: 'user1@example.com',
+      role: 'employee',
+      password: 'Temp1234!'
+    })
+  })
+
+  it('欄位缺漏時回傳錯誤並不建立資料', async () => {
+    const application = await setupApp()
+    const buffer = await createWorkbookBuffer([
+      ['E0003', '', 'user3@example.com', 'employee']
+    ])
+
+    mockEmployeeModel.find.mockResolvedValue([])
+
+    const response = await request(application)
+      .post('/api/employees/bulk-import')
+      .attach('file', buffer, { filename: 'import.xlsx' })
+      .field('mappings', JSON.stringify({
+        employeeNo: '員工編號',
+        name: '姓名',
+        email: 'Email',
+        role: '系統權限'
+      }))
+
+    expect(response.status).toBe(400)
+    expect(response.body.successCount).toBe(0)
+    expect(response.body.failureCount).toBe(1)
+    expect(response.body.errors[0]).toMatch(/缺少姓名/)
+    expect(mockEmployeeModel.create).not.toHaveBeenCalled()
+  })
+
+  it('偵測檔案內重複 Email 與既有 Email', async () => {
+    const application = await setupApp()
+    const buffer = await createWorkbookBuffer([
+      ['E0004', '張一', 'dup@example.com', 'employee'],
+      ['E0005', '張二', 'dup@example.com', 'employee'],
+      ['E0006', '張三', 'taken@example.com', 'employee']
+    ])
+
+    mockEmployeeModel.find.mockResolvedValue([{ email: 'taken@example.com' }])
+    mockEmployeeModel.create.mockImplementation(async (doc) => ({
+      _id: `${doc.employeeNo}-id`,
+      employeeId: doc.employeeNo,
+      name: doc.name,
+      department: doc.department,
+      role: doc.role,
+      email: doc.email
+    }))
+
+    const response = await request(application)
+      .post('/api/employees/bulk-import')
+      .attach('file', buffer, { filename: 'import.xlsx' })
+      .field('mappings', JSON.stringify({
+        employeeNo: '員工編號',
+        name: '姓名',
+        email: 'Email',
+        role: '系統權限'
+      }))
+
+    expect(response.status).toBe(200)
+    expect(response.body.successCount).toBe(1)
+    expect(response.body.failureCount).toBe(2)
+    expect(response.body.errors).toHaveLength(2)
+    expect(response.body.errors[0]).toMatch(/Email 重複/)
+    expect(response.body.errors[1]).toMatch(/Email 已存在/)
+    expect(mockEmployeeModel.create).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- 新增記憶體型 multipart 上傳解析中介層並掛載至員工路由
- 實作員工批量匯入控制器，處理 Excel 欄位對應、驗證、局部成功與錯誤回報
- 補上批量匯入整合測試，涵蓋成功、欄位缺漏與 Email 重複情境

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2eecac03c83299ff4496ab41604d0