### PR TITLE
修正批量匯入說明並優化簽核角色樣式

### DIFF
--- a/client/src/components/backComponents/__tests__/EmployeeManagementBulkImport.spec.js
+++ b/client/src/components/backComponents/__tests__/EmployeeManagementBulkImport.spec.js
@@ -167,6 +167,8 @@ describe('EmployeeManagement - 批量匯入流程', () => {
     const [headerRow, descriptionRow] = blobCalls[0].parts[0].split('\n')
     expect(headerRow).toContain('employeeId')
     expect(headerRow).toContain('email')
+    expect(descriptionRow).toContain('員工編號 (必填)')
+    expect(descriptionRow).toContain('姓名 (必填)')
     expect(descriptionRow).toContain('電子郵件 (必填唯一)')
     expect(descriptionRow).toContain('性別 (M=男, F=女, O=其他)')
 


### PR DESCRIPTION
## Summary
- 於員工批量匯入說明加入必填欄位註記與動態描述，避免錯誤解讀導致匯入失敗
- 優化簽核角色選項的排版樣式並新增選取狀態樣式，修正跑位問題
- 更新批量匯入範本下載測試，驗證新的必填欄位說明

## Testing
- npm test *(失敗：client 測試環境既有問題，詳見回報)*
- npm --prefix client test src/components/backComponents/__tests__/EmployeeManagementBulkImport.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e3c990afcc8329b8b2aacb68738c16