### PR TITLE
優化 Schedule 簽核摘要顯示、快速定位與載入失敗回退

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -221,6 +221,24 @@
             目前部門/單位：{{ fullscreenFilterHint }}
           </p>
         </div>
+        <div class="approval-summary-inline" data-test="approval-summary-inline">
+          <div class="approval-summary-inline-item">
+            <span class="approval-summary-inline-label">待簽核</span>
+            <strong class="approval-summary-inline-value" data-test="approval-summary-pending">{{ pendingApprovalCount }}</strong>
+          </div>
+          <div class="approval-summary-inline-item">
+            <span class="approval-summary-inline-label">異議</span>
+            <strong class="approval-summary-inline-value" data-test="approval-summary-disputed">{{ disputedApprovalCount }}</strong>
+          </div>
+          <el-button
+            class="action-btn secondary approval-jump-btn"
+            :disabled="!relatedApprovalRows.length"
+            data-test="approval-jump-button"
+            @click="jumpToApprovalSection"
+          >
+            前往簽核詳情
+          </el-button>
+        </div>
         <el-button class="action-btn secondary fullscreen-toggle" @click="toggleTableFullscreen"
           data-test="fullscreen-toggle-button">
           {{ isTableFullscreen ? '退出全螢幕' : '進入全螢幕' }}
@@ -454,7 +472,7 @@
     </div>
 
     <!-- Enhanced approval list with modern card design -->
-    <div v-if="relatedApprovalRows.length" class="approval-card">
+    <div ref="approvalCardRef" class="approval-card">
       <div class="approval-header">
         <h3 class="approval-title">相關簽核</h3>
         <div class="approval-count">{{ relatedApprovalRows.length }} 項</div>
@@ -462,11 +480,23 @@
           {{ approvalCollapsed ? '展開列表' : '收合列表' }}
         </el-button>
       </div>
+      <el-alert
+        v-if="approvalFetchError"
+        class="approval-error-alert"
+        type="warning"
+        :closable="false"
+        show-icon
+        data-test="approval-error-alert"
+        :title="approvalFetchError"
+      />
+      <p v-if="!approvalFetchError && !relatedApprovalRows.length" class="approval-empty-hint" data-test="approval-empty-hint">
+        目前沒有相關簽核資料。
+      </p>
       <el-table class="modern-approval-table" :data="displayedApprovalRows" :header-cell-style="{
         backgroundColor: '#f1f5f9',
         color: '#164e63',
         fontWeight: '600'
-      }">
+      }" v-if="relatedApprovalRows.length">
         <el-table-column label="資料類型" width="120">
           <template #default="{ row }">
             <el-tag :type="row.sourceType === 'schedule_confirmation' ? 'primary' : 'info'" class="status-tag">
@@ -644,6 +674,7 @@ const isFinalizing = ref(false)
 const isTableFullscreen = ref(false)
 const isFullscreenToolbarCollapsed = ref(false)
 const scheduleCardRef = ref(null)
+const approvalCardRef = ref(null)
 const fullscreenPopperHostRef = ref(null)
 const scheduleHeaderRef = ref(null)
 const batchToolbarRef = ref(null)
@@ -669,6 +700,7 @@ const approvalCollapsed = ref(true)
 const approvalCollapsedLimit = 10
 const approvalPageSize = 10
 const approvalCurrentPage = ref(1)
+const approvalFetchError = ref('')
 const pageSize = ref(50)
 const currentPage = ref(1)
 const serverPaginationTotal = ref(0)
@@ -1685,6 +1717,12 @@ const leaveApprovalRows = computed(() => {
 })
 
 const relatedApprovalRows = computed(() => [...leaveApprovalRows.value])
+const pendingApprovalCount = computed(() =>
+  relatedApprovalRows.value.filter(row => row.status === 'pending').length
+)
+const disputedApprovalCount = computed(() =>
+  relatedApprovalRows.value.filter(row => row.status === 'disputed').length
+)
 
 const hasMoreApprovals = computed(() => relatedApprovalRows.value.length > approvalCollapsedLimit)
 
@@ -1706,6 +1744,10 @@ watch([relatedApprovalRows, approvalCollapsed], () => {
 
 function onApprovalPageChange(page) {
   approvalCurrentPage.value = page
+}
+
+function jumpToApprovalSection() {
+  approvalCardRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
 function onDetailClosed() {
@@ -3214,6 +3256,7 @@ async function fetchSchedules({ reset = false, fetchAll = false, reason = 'unkno
     if (subId) leaveParams.push(`subDepartment=${subId}`)
     const leaveQuery = `?${leaveParams.join('&')}`
 
+    approvalFetchError.value = ''
     const res2 = await apiFetch(`/api/schedules/leave-approvals${leaveQuery}`)
     if (res2?.ok && typeof res2.json === 'function') {
       const extra = await res2.json()
@@ -3238,7 +3281,7 @@ async function fetchSchedules({ reset = false, fetchAll = false, reason = 'unkno
     } else {
       if (activeScheduleRequest.requestId !== requestId) return
       rawSchedules.value = schedules
-      approvalList.value = []
+      approvalFetchError.value = '簽核資料載入失敗，已保留上一筆資料，請稍後重試。'
       leaveIndex.value = {}
       markLeaveIndexDirty()
       recomputeEmployeeStatuses(targetEmployees)
@@ -4803,6 +4846,34 @@ onUpdated(() => {
       font-weight: 500;
     }
 
+    .approval-summary-inline {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+
+      .approval-summary-inline-item {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: #ecfeff;
+        border: 1px solid #bae6fd;
+      }
+
+      .approval-summary-inline-label {
+        font-size: 0.78rem;
+        color: #0f766e;
+        font-weight: 600;
+      }
+
+      .approval-summary-inline-value {
+        font-size: 1rem;
+        color: #0f172a;
+      }
+    }
+
     .schedule-legend {
       display: flex;
       gap: 12px;
@@ -5280,6 +5351,19 @@ onUpdated(() => {
 }
 
 .approval-card {
+  .approval-empty-hint {
+    margin: 0;
+    padding: 14px 24px;
+    font-size: 0.92rem;
+    color: #475569;
+    border-bottom: 1px solid #e2e8f0;
+    background: #f8fafc;
+  }
+
+  .approval-error-alert {
+    margin: 12px 24px 0;
+  }
+
   .approval-header {
     background: linear-gradient(135deg, #164e63 0%, #0891b2 100%);
     padding: 20px 24px;
@@ -5355,6 +5439,10 @@ onUpdated(() => {
   .schedule-header {
     flex-direction: column;
     align-items: flex-start;
+
+    .approval-summary-inline {
+      width: 100%;
+    }
   }
 
   .modern-schedule-table {

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -183,6 +183,11 @@ describe('Schedule.vue', () => {
       emits: ['update:modelValue'],
       template: '<div class="dialog-stub"><slot></slot></div>'
     }
+    const AlertStub = {
+      name: 'ElAlert',
+      props: ['title', 'type'],
+      template: '<div class="alert-stub" :data-type="type">{{ title }}</div>'
+    }
     const TimelineStub = { name: 'ElTimeline', template: '<div class="timeline-stub"><slot></slot></div>' }
     const TimelineItemStub = {
       name: 'ElTimelineItem',
@@ -209,6 +214,7 @@ describe('Schedule.vue', () => {
       'el-descriptions': DescriptionsStub,
       'el-descriptions-item': DescriptionsItemStub,
       'el-dialog': DialogStub,
+      'el-alert': AlertStub,
       'el-timeline': TimelineStub,
       'el-timeline-item': TimelineItemStub,
       ScheduleDashboard: { name: 'ScheduleDashboard', template: '<div class="dashboard-stub"></div>', props: ['summary'] }
@@ -807,7 +813,8 @@ describe('Schedule.vue', () => {
     expect(rows.some(row => row.applicantName === '外部員工')).toBe(false)
     expect(rows.some(row => row.sourceType === 'schedule_confirmation')).toBe(false)
 
-    expect(wrapper.find('.approval-card').exists()).toBe(false)
+    expect(wrapper.find('.approval-card').exists()).toBe(true)
+    expect(wrapper.find('[data-test="approval-empty-hint"]').exists()).toBe(true)
   })
 
   it('切換頁碼與搜尋員工後，簽核清單會同步更新', async () => {
@@ -911,6 +918,84 @@ describe('Schedule.vue', () => {
     expect(apiFetch).toHaveBeenCalledWith('/api/approvals/ap1')
     expect(wrapper.vm.detail.visible).toBe(true)
     expect(wrapper.vm.detail.doc._id).toBe('ap1')
+  })
+
+  it('簽核資料載入失敗時保留既有資料並顯示 fallback 提示', async () => {
+    setRoleToken('supervisor')
+    localStorage.setItem('employeeId', 'sup1')
+    setupSupervisorApiMock({
+      employees: [{ _id: 'e1', name: '王小明', department: 'd1', subDepartment: 'sd1' }],
+      approvals: [
+        {
+          _id: 'ap1',
+          status: 'pending',
+          form: { _id: 'f1', name: '請假申請', category: 'leave' },
+          applicant_employee: { _id: 'e1', name: '王小明' }
+        }
+      ]
+    })
+
+    const wrapper = mountSchedule()
+    await flush()
+    wrapper.vm.selectedEmployees = new Set(['e1'])
+    wrapper.vm.approvalList = [
+      {
+        _id: 'ap1',
+        status: 'pending',
+        form: { _id: 'f1', name: '請假申請', category: 'leave' },
+        applicant_employee: { _id: 'e1', name: '王小明' }
+      }
+    ]
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.relatedApprovalRows).toHaveLength(1)
+    expect(wrapper.vm.approvalFetchError).toBe('')
+
+    apiFetch.mockImplementation(async (url, options = {}) => {
+      const method = options.method || 'GET'
+      const path = String(url)
+      if (path.startsWith('/api/schedules/leave-approvals') && method === 'GET') {
+        return { ok: false, json: async () => ({ message: 'fail' }) }
+      }
+      if (path.startsWith('/api/schedules/monthly') && method === 'GET') {
+        return { ok: true, json: async () => [] }
+      }
+      if (path.startsWith('/api/shifts') && method === 'GET') {
+        return { ok: true, json: async () => [] }
+      }
+      if (path.startsWith('/api/schedules/summary') && method === 'GET') {
+        return { ok: true, json: async () => [] }
+      }
+      if (path.startsWith('/api/departments') && method === 'GET') {
+        return { ok: true, json: async () => [{ _id: 'd1', name: 'Dept A' }] }
+      }
+      if (path.startsWith('/api/subdepartments') && method === 'GET') {
+        return { ok: true, json: async () => [{ _id: 'sd1', name: 'Sub A', department: { _id: 'd1' } }] }
+      }
+      if (path.startsWith('/api/employees/direct-report-subordinates') && method === 'GET') {
+        return {
+          ok: true,
+          json: async () => [{ _id: 'e1', name: '王小明', department: 'd1', subDepartment: 'sd1' }]
+        }
+      }
+      if (path.startsWith('/api/employees/me/profile') && method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ _id: 'sup1', department: { _id: 'd1' }, subDepartment: { _id: 'sd1' } })
+        }
+      }
+      if (path.startsWith('/api/users/me/settings') && method === 'GET') {
+        return { ok: true, json: async () => ({ scheduleIncludeSelf: false }) }
+      }
+      return { ok: true, json: async () => [] }
+    })
+
+    await wrapper.vm.fetchSchedules({ reset: false })
+    await flush()
+
+    expect(wrapper.vm.approvalList).toHaveLength(1)
+    expect(wrapper.vm.approvalFetchError).toContain('簽核資料載入失敗')
+    expect(wrapper.find('[data-test="approval-error-alert"]').exists()).toBe(true)
   })
 
   it('does not append supervisor param for employee role even when id exists', async () => {
@@ -2260,6 +2345,64 @@ describe('Schedule.vue', () => {
     wrapper.vm.toggleTableFullscreen()
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isTableFullscreen).toBe(false)
+  })
+
+  it('全螢幕模式仍可看到簽核摘要，且可展開簽核詳細列表', async () => {
+    setRoleToken('supervisor')
+    localStorage.setItem('employeeId', 'sup1')
+    setupSupervisorApiMock({
+      employees: [
+        { _id: 'e1', name: '王小明', department: 'd1', subDepartment: 'sd1' },
+        { _id: 'e2', name: '李小華', department: 'd1', subDepartment: 'sd1' }
+      ],
+      approvals: [
+        {
+          _id: 'ap1',
+          status: 'pending',
+          form: { _id: 'f1', name: '請假申請', category: 'leave' },
+          applicant_employee: { _id: 'e1', name: '王小明' }
+        },
+        {
+          _id: 'ap2',
+          status: 'disputed',
+          form: { _id: 'f2', name: '請假申請', category: 'leave' },
+          applicant_employee: { _id: 'e2', name: '李小華' }
+        }
+      ]
+    })
+
+    const wrapper = mountSchedule()
+    await flush()
+    await wrapper.vm.$nextTick()
+    wrapper.vm.selectedEmployees = new Set(['e1', 'e2'])
+    wrapper.vm.approvalList = [
+      {
+        _id: 'ap1',
+        status: 'pending',
+        form: { _id: 'f1', name: '請假申請', category: 'leave' },
+        applicant_employee: { _id: 'e1', name: '王小明' }
+      },
+      {
+        _id: 'ap2',
+        status: 'disputed',
+        form: { _id: 'f2', name: '請假申請', category: 'leave' },
+        applicant_employee: { _id: 'e2', name: '李小華' }
+      }
+    ]
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.toggleTableFullscreen()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.isTableFullscreen).toBe(true)
+    expect(wrapper.find('[data-test="approval-summary-inline"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="approval-summary-pending"]').text()).toBe('1')
+    expect(wrapper.find('[data-test="approval-summary-disputed"]').text()).toBe('1')
+
+    expect(wrapper.vm.approvalCollapsed).toBe(true)
+    wrapper.vm.approvalCollapsed = false
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.displayedApprovalRows.length).toBe(2)
   })
 
   it('全螢幕上方工具列收合時隱藏 batch-toolbar，展開後才顯示', async () => {


### PR DESCRIPTION
### Motivation
- 將簽核摘要（待簽核、異議）提升到排班表頭，確保使用者在全螢幕模式下也能第一時間看見關鍵簽核統計。 
- 保留原有詳細簽核表，但需提供快速定位至簽核區塊的操作以加速檢視流程。 
- 避免在 `approvalList` 載入失敗時靜默清空資料，需有明確 fallback 訊息以免誤判「無簽核」。
- 補齊自動化測試，驗證全螢幕情境下摘要可見且詳細可展開，與載入失敗時的行為。 

### Description
- 在 `client/src/views/front/Schedule.vue` 的表頭新增簽核摘要區塊（顯示 `pendingApprovalCount` / `disputedApprovalCount`）與「前往簽核詳情」按鈕，並新增 `jumpToApprovalSection` 實作以使用 `scrollIntoView` 快速定位。 
- 保留原 `approval` 詳細表格，但改為固定渲染簽核卡片區塊，無資料時顯示空狀態提示（`approval-empty-hint`），並新增 `approvalCardRef` 以供快速定位。 
- 新增 `approvalFetchError` 狀態與警示呈現（`el-alert`），在 `/api/schedules/leave-approvals` 失敗時不再清空 `approvalList`，而是保留既有資料並設定錯誤訊息（避免靜默清空導致誤判）。 
- 補強樣式（表頭摘要膠囊、錯誤提示與行動版佈局），並更新測試支援（在測試中加入 `ElAlert` stub）。 
- 變更檔案：`client/src/views/front/Schedule.vue`、`client/tests/schedule.spec.js`（含測試新增/調整）。 

### Testing
- 執行整份測試檔 `npm --prefix client test -- tests/schedule.spec.js`，初次執行時因專案中其他既存測試項目而出現多項失敗（多個舊測試與環境差異無關本次 feature）。 
- 針對本次變更執行選定測試：使用 `npm --prefix client test -- tests/schedule.spec.js -t "簽核資料載入失敗時保留既有資料並顯示 fallback 提示|全螢幕模式仍可看到簽核摘要，且可展開簽核詳細列表|僅顯示相關人員簽核資料，且隱藏班表確認簽核" --run`，最終相關針對性測試通過（所選測試皆通過）。 
- 執行 `npm run build --prefix client` 並成功打包，確認前端能正常編譯與產出。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5caa37d883298db5c6af2a89a22a)