### PR TITLE
修正全螢幕排班工具列下拉層級並將部門/單位改為唯讀顯示

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -289,20 +289,59 @@
         v-show="!isTableFullscreen || !isFullscreenToolbarCollapsed"
         class="batch-toolbar"
       >
-        <el-select v-model="batchShiftId" placeholder="套用班別" class="modern-select batch-select" filterable
-          data-test="batch-shift-select">
+        <el-select
+          v-model="batchShiftId"
+          placeholder="套用班別"
+          class="modern-select batch-select"
+          filterable
+          :teleported="isToolbarDropdownTeleported"
+          :append-to="toolbarPopperAppendTarget"
+          :popper-class="toolbarPopperClassName"
+          data-test="batch-shift-select"
+        >
           <el-option v-for="opt in shifts" :key="opt._id" :label="formatShiftLabel(opt)" :value="opt._id" />
         </el-select>
-        <el-select v-model="batchDepartment" placeholder="套用部門" clearable class="modern-select batch-select"
-          data-test="batch-dept-select">
-          <el-option v-for="dept in departments" :key="dept._id" :label="dept.name" :value="dept._id" />
-        </el-select>
-        <el-select v-model="batchSubDepartment" placeholder="套用單位" clearable class="modern-select batch-select"
-          :disabled="!batchDepartment" data-test="batch-subdept-select">
-          <el-option v-for="sub in batchSubDepartments" :key="sub._id" :label="sub.name" :value="sub._id" />
-        </el-select>
-        <el-select v-model="batchRowColorIndex" placeholder="設定整列顏色" clearable class="modern-select batch-select"
-          data-test="batch-row-color-select">
+        <template v-if="isTableFullscreen">
+          <div class="batch-readonly-field" data-test="batch-dept-readonly">
+            <span class="batch-readonly-field__label">套用部門</span>
+            <span class="batch-readonly-field__value">{{ batchDepartmentDisplayName }}</span>
+          </div>
+          <div class="batch-readonly-field" data-test="batch-subdept-readonly">
+            <span class="batch-readonly-field__label">套用單位</span>
+            <span class="batch-readonly-field__value">{{ batchSubDepartmentDisplayName }}</span>
+          </div>
+        </template>
+        <template v-else>
+          <el-select
+            v-model="batchDepartment"
+            placeholder="套用部門"
+            clearable
+            class="modern-select batch-select"
+            data-test="batch-dept-select"
+          >
+            <el-option v-for="dept in departments" :key="dept._id" :label="dept.name" :value="dept._id" />
+          </el-select>
+          <el-select
+            v-model="batchSubDepartment"
+            placeholder="套用單位"
+            clearable
+            class="modern-select batch-select"
+            :disabled="!batchDepartment"
+            data-test="batch-subdept-select"
+          >
+            <el-option v-for="sub in batchSubDepartments" :key="sub._id" :label="sub.name" :value="sub._id" />
+          </el-select>
+        </template>
+        <el-select
+          v-model="batchRowColorIndex"
+          placeholder="設定整列顏色"
+          clearable
+          class="modern-select batch-select"
+          :teleported="isToolbarDropdownTeleported"
+          :append-to="toolbarPopperAppendTarget"
+          :popper-class="toolbarPopperClassName"
+          data-test="batch-row-color-select"
+        >
           <el-option v-for="opt in rowColorOptions" :key="opt.index" :label="opt.label" :value="opt.index">
             <span class="row-color-option">
               <span class="row-color-dot" :style="{ backgroundColor: opt.bg, borderColor: opt.border }"></span>
@@ -1100,6 +1139,21 @@ const hasAnySelection = computed(() => allSelectedCells.value.size > 0)
 const batchSubDepartments = computed(() =>
   batchDepartment.value ? subDepsFor(batchDepartment.value) : []
 )
+const effectiveBatchDepartment = computed(() =>
+  isTableFullscreen.value ? (batchDepartment.value || selectedDepartment.value || '') : batchDepartment.value
+)
+const effectiveBatchSubDepartment = computed(() => {
+  if (isTableFullscreen.value) {
+    return batchSubDepartment.value || selectedSubDepartment.value || ''
+  }
+  return batchSubDepartment.value
+})
+const batchDepartmentDisplayName = computed(
+  () => departments.value.find(dept => dept._id === effectiveBatchDepartment.value)?.name || '全部部門'
+)
+const batchSubDepartmentDisplayName = computed(
+  () => subDepartments.value.find(sub => sub._id === effectiveBatchSubDepartment.value)?.name || '全部單位'
+)
 const allEmployeesSelectionHint = computed(() =>
   selectedAllEmployeesAcrossPages.value
     ? `已全選 ${selectedEmployeesSet.value.size} 位員工（全部人員），切換分頁仍會維持勾選。`
@@ -1775,6 +1829,16 @@ const fullscreenPopperTarget = computed(() => {
   if (!isTableFullscreen.value) return undefined
   return fullscreenPopperHostRef.value || '.schedule-fullscreen-popper-host'
 })
+const toolbarPopperAppendTarget = computed(() => {
+  if (!isTableFullscreen.value) return undefined
+  return fullscreenPopperTarget.value || '.schedule-fullscreen-popper-host'
+})
+const isToolbarDropdownTeleported = computed(
+  () => !isTableFullscreen.value || !!toolbarPopperAppendTarget.value
+)
+const toolbarPopperClassName = computed(() =>
+  isTableFullscreen.value ? 'schedule-toolbar-popper schedule-toolbar-popper--fullscreen' : 'schedule-toolbar-popper'
+)
 
 const tableMaxHeight = computed(() => {
   if (isTableFullscreen.value) {
@@ -3679,13 +3743,13 @@ async function applyBatch() {
     // 沒資料或本月被視為請假 → 略過
     if (!info || isLeaveCell(empId, day)) return
 
-    const department = batchDepartment.value || info.department || ''
+    const department = effectiveBatchDepartment.value || info.department || ''
     let subDepartment = info.subDepartment || ''
 
-    if (batchDepartment.value) {
-      subDepartment = batchSubDepartment.value || ''
-    } else if (batchSubDepartment.value) {
-      subDepartment = batchSubDepartment.value
+    if (effectiveBatchDepartment.value) {
+      subDepartment = effectiveBatchSubDepartment.value || ''
+    } else if (effectiveBatchSubDepartment.value) {
+      subDepartment = effectiveBatchSubDepartment.value
     }
 
     batchPayload.push({
@@ -4928,6 +4992,30 @@ onUpdated(() => {
     min-width: 180px;
   }
 
+  .batch-readonly-field {
+    min-width: 180px;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid #dbeafe;
+    border-radius: 10px;
+    background: #eff6ff;
+  }
+
+  .batch-readonly-field__label {
+    font-size: 11px;
+    color: #64748b;
+    line-height: 1;
+  }
+
+  .batch-readonly-field__value {
+    font-size: 13px;
+    color: #0f172a;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
   .apply-btn {
     min-width: 120px;
   }
@@ -5059,7 +5147,13 @@ onUpdated(() => {
     pointer-events: auto;
   }
 
+  :deep(.schedule-toolbar-popper--fullscreen) {
+    z-index: 3001 !important;
+    pointer-events: auto;
+  }
+
   :deep(.schedule-fullscreen-popper-host .schedule-cell-editor-popper--fullscreen),
+  :deep(.schedule-fullscreen-popper-host .schedule-toolbar-popper--fullscreen),
   :deep(.schedule-fullscreen-popper-host .el-select-dropdown),
   :deep(.schedule-fullscreen-popper-host .el-popper) {
     pointer-events: auto;

--- a/client/tests/schedule.spec.js
+++ b/client/tests/schedule.spec.js
@@ -1079,7 +1079,6 @@ describe('Schedule.vue', () => {
   })
 
   it('shows loading state while applying batch schedules', async () => {
-    const month = dayjs().format('YYYY-MM')
     setRoleToken('admin')
     apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
     const wrapper = mountSchedule()
@@ -1141,6 +1140,92 @@ describe('Schedule.vue', () => {
     expect(button.element.disabled).toBe(false)
     expect(loadingInstance.close).toHaveBeenCalled()
     expect(ElMessage.success).toHaveBeenCalledWith('批次套用完成')
+  })
+
+  it('uses fullscreen popper strategy for batch shift and row-color selects and shows readonly department fields', async () => {
+    setRoleToken('admin')
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+
+    wrapper.vm.batchDepartment = 'd1'
+    wrapper.vm.batchSubDepartment = 'sd1'
+    wrapper.vm.selectedDepartment = 'd1'
+    wrapper.vm.selectedSubDepartment = 'sd1'
+    wrapper.vm.departments = [{ _id: 'd1', name: '部門A' }]
+    wrapper.vm.subDepartments = [{ _id: 'sd1', name: '單位A', department: 'd1' }]
+    wrapper.vm.isTableFullscreen = true
+    wrapper.vm.isFullscreenToolbarCollapsed = false
+    await wrapper.vm.$nextTick()
+
+    const shiftSelect = wrapper.find('[data-test="batch-shift-select"]')
+    const rowColorSelect = wrapper.find('[data-test="batch-row-color-select"]')
+    expect(shiftSelect.attributes('append-to')).toBeTruthy()
+    expect(shiftSelect.attributes('popper-class')).toContain('schedule-toolbar-popper--fullscreen')
+    expect(rowColorSelect.attributes('append-to')).toBeTruthy()
+    expect(rowColorSelect.attributes('popper-class')).toContain('schedule-toolbar-popper--fullscreen')
+
+    expect(wrapper.find('[data-test="batch-dept-select"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="batch-subdept-select"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="batch-dept-readonly"]').text()).toContain('部門A')
+    expect(wrapper.find('[data-test="batch-subdept-readonly"]').text()).toContain('單位A')
+  })
+
+  it('keeps department and sub-department payload in fullscreen readonly mode when applying batch', async () => {
+    setRoleToken('admin')
+    apiFetch.mockResolvedValue({ ok: true, json: async () => [] })
+    const wrapper = mountSchedule()
+    await flush()
+
+    wrapper.vm.departments = [{ _id: 'd1', name: '部門A' }]
+    wrapper.vm.subDepartments = [{ _id: 'sd1', name: '單位A', department: 'd1' }]
+    wrapper.vm.batchDepartment = 'd1'
+    wrapper.vm.batchSubDepartment = 'sd1'
+    wrapper.vm.selectedDepartment = 'd1'
+    wrapper.vm.selectedSubDepartment = 'sd1'
+    wrapper.vm.batchShiftId = 's1'
+    wrapper.vm.isTableFullscreen = true
+    wrapper.vm.isFullscreenToolbarCollapsed = false
+    wrapper.vm.employees = [
+      { _id: 'e1', departmentId: 'd1', subDepartmentId: 'sd1', department: '', subDepartment: '' }
+    ]
+    wrapper.vm.scheduleMap = {
+      e1: {
+        1: { shiftId: '', department: 'd0', subDepartment: 'sd0' }
+      }
+    }
+    await wrapper.vm.$nextTick()
+    wrapper.vm.toggleCell('e1', 1, true)
+
+    apiFetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => [
+          {
+            _id: 'sch1',
+            employee: 'e1',
+            date: `${wrapper.vm.currentMonth}-01`,
+            shiftId: 's1',
+            department: 'd1',
+            subDepartment: 'sd1'
+          }
+        ]
+      })
+    )
+
+    await wrapper.vm.applyBatch()
+    const request = apiFetch.mock.calls.find(([url]) => url === '/api/schedules/batch')
+    expect(request).toBeTruthy()
+    const body = JSON.parse(request[1].body)
+    expect(body.schedules).toEqual([
+      {
+        employee: 'e1',
+        date: `${wrapper.vm.currentMonth}-01`,
+        shiftId: 's1',
+        department: 'd1',
+        subDepartment: 'sd1'
+      }
+    ])
   })
 
   it('renders leave indicator and prevents editing when leave exists', async () => {


### PR DESCRIPTION
### Motivation
- 避免全螢幕模式下工具列的下拉選單被其他元素遮蓋，並減少誤操作部門/單位的機會同時保留既有預設值邏輯。

### Description
- 為排班頁工具列的 `套用班別` 與 `設定整列顏色` 的 `el-select` 新增 fullscreen popper 策略：加入 `:teleported`、`:append-to` 指向 fullscreen host 與專用 `popper-class` ，並在樣式中提高 z-index 與 pointer-events 設定以確保可互動。
- 全螢幕時隱藏可編輯的 `套用部門` / `套用單位` 下拉，改以小型唯讀欄位顯示（固定值與樣式），非全螢幕維持原有可選行為。
- 新增 `effectiveBatchDepartment` / `effectiveBatchSubDepartment` 計算屬性，在全螢幕情境下以批次值或當前篩選值為優先帶入，確保 UI 為唯讀時仍正確產生送出 payload 的部門/單位資料，並未改變原本資料邏輯或預設規則。
- 修改檔案：`client/src/views/front/Schedule.vue`（UI、computed 與樣式調整）與 `client/tests/schedule.spec.js`（新增兩個對應測試）；commit 訊息為中文：`調整全螢幕排班工具列下拉策略與唯讀顯示`。

### Testing
- 已針對本次改動新增兩個單元測試並執行：`vitest` 針對測試標題 `uses fullscreen popper strategy|keeps department and sub-department payload in fullscreen readonly mode`，兩項測試皆通過（成功）。
- 對整個前端專案執行 `npm --prefix client run build`，生產檔案成功產出（build 成功）。
- 補充說明：完整的 `schedule.spec.js` 原本包含多個與本次 UI 變更無關的既有失敗案例，這些歷史失敗並非此次變更所引入；本 PR 僅針對新增需求撰寫並驗證相關測試案例。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6567ac0483299124a1c7e41ff5f4)