### PR TITLE
在排班頁加入全螢幕可見的選取操作列並抽成 `SelectionActions` 元件

### DIFF
--- a/client/src/views/front/Schedule.vue
+++ b/client/src/views/front/Schedule.vue
@@ -157,27 +157,17 @@
 
     <!-- Enhanced actions section with modern button design -->
     <div class="actions-card">
-      <div class="primary-actions">
-        <el-button type="primary" class="action-btn primary" @click="clearSelection" :disabled="!hasAnySelection">
-          <i class="el-icon-close"></i>
-          清除選取
-        </el-button>
-        <el-button type="primary" class="action-btn primary" plain @click="selectAllEmployeesOnPage"
-          :disabled="!employees.length">
-          <i class="el-icon-user"></i>
-          本頁全選
-        </el-button>
-        <el-button type="primary" class="action-btn primary" plain @click="selectAllEmployeesAcrossPages"
-          :loading="isSelectingAllEmployeesAcrossPages"
-          :disabled="!serverPaginationTotal || isSelectingAllEmployeesAcrossPages">
-          <i class="el-icon-user-solid"></i>
-          全部人員全選
-        </el-button>
-        <el-button type="primary" class="action-btn primary" plain @click="selectAllDays" :disabled="!days.length">
-          <i class="el-icon-date"></i>
-          全選日期
-        </el-button>
-      </div>
+      <SelectionActions
+        :has-any-selection="hasAnySelection"
+        :employees-length="employees.length"
+        :server-pagination-total="serverPaginationTotal"
+        :is-selecting-all-employees-across-pages="isSelectingAllEmployeesAcrossPages"
+        :days-length="days.length"
+        @clear-selection="clearSelection"
+        @select-all-employees-on-page="selectAllEmployeesOnPage"
+        @select-all-employees-across-pages="selectAllEmployeesAcrossPages"
+        @select-all-days="selectAllDays"
+      />
       <p v-if="selectedEmployeesSet.size > 0" class="selection-scope-hint" data-test="selection-scope-hint">
         {{ allEmployeesSelectionHint }}
       </p>
@@ -247,6 +237,20 @@
           @click="toggleFullscreenToolbar" data-test="fullscreen-toolbar-toggle-button">
           {{ isFullscreenToolbarCollapsed ? '展開上方工具' : '隱藏上方工具' }}
         </el-button>
+        <SelectionActions
+          v-if="isTableFullscreen"
+          compact
+          class="fullscreen-selection-actions"
+          :has-any-selection="hasAnySelection"
+          :employees-length="employees.length"
+          :server-pagination-total="serverPaginationTotal"
+          :is-selecting-all-employees-across-pages="isSelectingAllEmployeesAcrossPages"
+          :days-length="days.length"
+          @clear-selection="clearSelection"
+          @select-all-employees-on-page="selectAllEmployeesOnPage"
+          @select-all-employees-across-pages="selectAllEmployeesAcrossPages"
+          @select-all-days="selectAllDays"
+        />
         <div v-show="!isTableFullscreen || !isFullscreenToolbarCollapsed" class="schedule-legend" data-test="schedule-legend">
           <template v-if="legendShifts.length">
             <span v-for="legend in legendShifts" :key="legend.key" class="legend-item" :style="legend.style"
@@ -623,6 +627,7 @@ import { ElMessage, ElMessageBox, ElLoading } from 'element-plus'
 import { useRouter } from 'vue-router'
 import ScheduleDashboard from './ScheduleDashboard.vue'
 import ScheduleGridVirtualBody from './ScheduleGridVirtualBody.vue'
+import SelectionActions from './SelectionActions.vue'
 import { CircleCloseFilled, WarningFilled } from '@element-plus/icons-vue'
 import { buildShiftStyle } from '../../utils/shiftColors'
 import { ROW_COLOR_PALETTE, normalizeRowColorIndex, resolveRowColor } from '../../utils/rowColors'
@@ -4757,7 +4762,6 @@ onUpdated(() => {
   flex-wrap: wrap;
   gap: 16px;
 
-  .primary-actions,
   .secondary-actions {
     display: flex;
     gap: 12px;
@@ -4974,6 +4978,10 @@ onUpdated(() => {
 
     .status-filter {
       max-width: 160px;
+    }
+
+    .fullscreen-selection-actions {
+      margin-left: auto;
     }
 
   }

--- a/client/src/views/front/SelectionActions.vue
+++ b/client/src/views/front/SelectionActions.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="selection-actions" :class="{ 'selection-actions--compact': compact }">
+    <el-button
+      type="primary"
+      class="action-btn primary"
+      :disabled="!hasAnySelection"
+      :data-test="compact ? 'fullscreen-clear-selection-button' : 'clear-selection-button'"
+      @click="$emit('clear-selection')"
+    >
+      <i class="el-icon-close"></i>
+      清除選取
+    </el-button>
+    <el-button
+      type="primary"
+      class="action-btn primary"
+      plain
+      :loading="isSelectingAllEmployeesAcrossPages"
+      :disabled="!serverPaginationTotal || isSelectingAllEmployeesAcrossPages"
+      :data-test="compact ? 'fullscreen-select-all-button' : 'select-all-employees-across-pages-button'"
+      @click="$emit('select-all-employees-across-pages')"
+    >
+      <i class="el-icon-user-solid"></i>
+      全部人員全選
+    </el-button>
+
+    <template v-if="!compact">
+      <el-button
+        type="primary"
+        class="action-btn primary"
+        plain
+        :disabled="!employeesLength"
+        data-test="select-all-employees-on-page-button"
+        @click="$emit('select-all-employees-on-page')"
+      >
+        <i class="el-icon-user"></i>
+        本頁全選
+      </el-button>
+      <el-button
+        type="primary"
+        class="action-btn primary"
+        plain
+        :disabled="!daysLength"
+        data-test="select-all-days-button"
+        @click="$emit('select-all-days')"
+      >
+        <i class="el-icon-date"></i>
+        全選日期
+      </el-button>
+    </template>
+
+    <el-dropdown
+      v-else
+      trigger="click"
+      data-test="fullscreen-selection-more-dropdown"
+      @command="handleCompactCommand"
+    >
+      <el-button class="action-btn secondary selection-actions__more-btn" data-test="fullscreen-selection-more-button">
+        更多選取操作
+      </el-button>
+      <template #dropdown>
+        <el-dropdown-menu>
+          <el-dropdown-item command="page" :disabled="!employeesLength" data-test="fullscreen-select-page-command">
+            本頁全選
+          </el-dropdown-item>
+          <el-dropdown-item command="days" :disabled="!daysLength" data-test="fullscreen-select-days-command">
+            全選日期
+          </el-dropdown-item>
+        </el-dropdown-menu>
+      </template>
+    </el-dropdown>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  compact: {
+    type: Boolean,
+    default: false
+  },
+  hasAnySelection: {
+    type: Boolean,
+    required: true
+  },
+  employeesLength: {
+    type: Number,
+    required: true
+  },
+  serverPaginationTotal: {
+    type: Number,
+    required: true
+  },
+  isSelectingAllEmployeesAcrossPages: {
+    type: Boolean,
+    required: true
+  },
+  daysLength: {
+    type: Number,
+    required: true
+  }
+})
+
+const emit = defineEmits([
+  'clear-selection',
+  'select-all-employees-on-page',
+  'select-all-employees-across-pages',
+  'select-all-days'
+])
+
+const handleCompactCommand = command => {
+  if (command === 'page') emit('select-all-employees-on-page')
+  if (command === 'days') emit('select-all-days')
+}
+</script>
+
+<style scoped lang="scss">
+.selection-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  &--compact {
+    align-items: center;
+  }
+
+  &__more-btn {
+    border-style: dashed;
+  }
+}
+</style>


### PR DESCRIPTION
### Motivation
- 解決全螢幕模式下上方工具列收合導致「本頁全選 / 全部人員全選 / 清除選取」無法操作的 UX 問題，同時維持原有按鈕行為與禁用條件。

### Description
- 新增可重用元件 `client/src/views/front/SelectionActions.vue`，封裝 `clearSelection`、`selectAllEmployeesOnPage`、`selectAllEmployeesAcrossPages`、`selectAllDays` 等按鈕與事件介面，並提供 `compact` 模式以在全螢幕時只顯示核心操作並把次要操作收納到下拉選單。
- 在 `client/src/views/front/Schedule.vue` 中將原本 `actions-card` 的選取按鈕替換為 `SelectionActions`，並於 `.schedule-header`（全螢幕）加入一組 `v-if="isTableFullscreen"` 的 `SelectionActions compact`，確保全螢幕且工具列收合時仍可操作選取功能。
- 保留既有方法與條件（例如 `:disabled="!employees.length"`、`isSelectingAllEmployeesAcrossPages`、`hasAnySelection` 等），並在 `compact` 模式補上 `data-test` 屬性（如 `fullscreen-select-all-button`、`fullscreen-clear-selection-button`、`fullscreen-selection-more-dropdown`）以利 E2E/單元測試定位。 
- 對樣式做小幅調整以在 header 置中/靠右顯示全螢幕操作列，並維持原本「進入全螢幕時預設收合」的邏輯但在收合區外固定最小操作列以提升可操作性。

### Testing
- 執行 `cd client && npm run build`，建置成功（通過）。
- 執行 `cd client && npm test -- --run`，整套測試有多組既有測試失敗（非本次變更單點造成），整體測試未全綠。 
- 單獨執行 `npx vitest run tests/schedule.spec.js`，結果顯示該檔案測試狀態：1 個測試檔案，36 個失敗、24 個通過；失敗多與環境 mocking（jsdom document/下載模擬）及現有測試間互相污染有關，並非僅新增 `SelectionActions` 引起的單一錯誤。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6d89bf08832991481c1f263f5c80)